### PR TITLE
Test failure: CRDTActorOwnedTests.test_actorOwned_theLastWrittenOnUpdateCallbackWins

### DIFF
--- a/Sources/DistributedActors/CRDT/CRDTReplicatorShell.swift
+++ b/Sources/DistributedActors/CRDT/CRDTReplicatorShell.swift
@@ -75,18 +75,18 @@ extension CRDT.Replicator {
             }
         }
 
-        private func handleLocalRegisterCommand(_ context: ActorContext<Message>, ownerRef: ActorRef<OwnerMessage>, id: Identity, data: ReplicatedData, replyTo: ActorRef<LocalRegisterResult>) {
+        private func handleLocalRegisterCommand(_ context: ActorContext<Message>, ownerRef: ActorRef<OwnerMessage>, id: Identity, data: ReplicatedData, replyTo: ActorRef<LocalRegisterResult>?) {
             // Register the owner first
             switch self.replicator.registerOwner(dataId: id, owner: ownerRef) {
             case .registered:
                 // Then write the full CRDT so it's ready to be read
                 switch self.replicator.write(id, data, deltaMerge: false) {
                 case .applied:
-                    replyTo.tell(.success)
+                    replyTo?.tell(.success)
                 case .inputAndStoredDataTypeMismatch(let stored):
-                    replyTo.tell(.failed(.inputAndStoredDataTypeMismatch(stored: stored)))
+                    replyTo?.tell(.failed(.inputAndStoredDataTypeMismatch(stored: stored)))
                 case .unsupportedCRDT:
-                    replyTo.tell(.failed(.unsupportedCRDT))
+                    replyTo?.tell(.failed(.unsupportedCRDT))
                 }
             }
 


### PR DESCRIPTION
Motivation:
The aforementioned test fails intermittently. See https://github.com/apple/swift-distributed-actors/issues/14.

Modifications:
There is an existing issue with `.ask`. Use `.tell` instead 1) as a workaround; 2) since we don't need the result anyway.

Also made some minor improvements to code docs.

Result:
No more flaky test hopefully!