### PR TITLE
Fix run_length bug in mailbox #85

### DIFF
--- a/Sources/CDistributedActorsMailbox/c_mailbox.c
+++ b/Sources/CDistributedActorsMailbox/c_mailbox.c
@@ -346,7 +346,7 @@ SActMailboxRunResult cmailbox_run(
                 set_status_suspended(mailbox);
                 print_debug_status(mailbox, "MARKED SUSPENDED");
                 message = NULL;
-            } else if (processed_activations >= run_length) {
+            } else if (message_count(processed_activations) >= run_length) {
                 message = NULL; // break out of the loop
             } else {
                 // dequeue another message, if there are no more messages left, message


### PR DESCRIPTION
### Motivation:

Because of the issue described in #85 we ended up processing fewer messages than possible, which can negatively impact performance.

### Modifications:

Use `message_count(processed_activations)` instead of just `processed_activations` to determine when to yield from processing messages.

### Result:

- Resolves #85 

**Benchmarks Before**

```
Processed 10000000 message in 5.224 seconds 1914262 msgs/s
1,ActorMessageFloodingBenchmarks.10_000_000_messages,1,5225938165,5225938165,5225938165,0,5225938165
```

**Benchmarks After**

```
Processed 10000000 message in 3.940 seconds 2538105 msgs/s
1,ActorMessageFloodingBenchmarks.10_000_000_messages,1,3941722147,3941722147,3941722147,0,3941722147
```