### PR TITLE
+crdt #28 ensure ActorOwned<> CRDT updates from replicator are threadsafe

### DIFF
--- a/Sources/DistributedActors/CRDT/CRDT+GCounter.swift
+++ b/Sources/DistributedActors/CRDT/CRDT+GCounter.swift
@@ -106,7 +106,7 @@ extension CRDT.ActorOwned where DataType == CRDT.GCounter {
         return self.data.value
     }
 
-    public func increment(by amount: Int, writeConsistency consistency: CRDT.OperationConsistency, timeout: TimeAmount) -> Result<DataType> {
+    public func increment(by amount: Int, writeConsistency consistency: CRDT.OperationConsistency, timeout: TimeAmount) -> OperationResult<DataType> {
         // Increment locally then propagate
         self.data.increment(by: amount)
         return self.write(consistency: consistency, timeout: timeout)

--- a/Sources/DistributedActors/CRDT/CRDT+ORSet.swift
+++ b/Sources/DistributedActors/CRDT/CRDT+ORSet.swift
@@ -162,13 +162,13 @@ extension CRDT.ActorOwned where DataType: ORSetOperations {
         return self.data.elements
     }
 
-    public func add(_ element: DataType.Element, writeConsistency consistency: CRDT.OperationConsistency, timeout: TimeAmount) -> Result<DataType> {
+    public func add(_ element: DataType.Element, writeConsistency consistency: CRDT.OperationConsistency, timeout: TimeAmount) -> OperationResult<DataType> {
         // Add element locally then propagate
         self.data.add(element)
         return self.write(consistency: consistency, timeout: timeout)
     }
 
-    public func remove(_ element: DataType.Element, writeConsistency consistency: CRDT.OperationConsistency, timeout: TimeAmount) -> Result<DataType> {
+    public func remove(_ element: DataType.Element, writeConsistency consistency: CRDT.OperationConsistency, timeout: TimeAmount) -> OperationResult<DataType> {
         // Remove element locally then propagate
         self.data.remove(element)
         return self.write(consistency: consistency, timeout: timeout)

--- a/Tests/DistributedActorsTests/CRDT/CRDTActorOwnedTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTActorOwnedTests+XCTest.swift
@@ -27,6 +27,7 @@ extension CRDTActorOwnedTests {
             ("test_actorOwned_GCounter_increment_shouldResetDelta_shouldNotifyOthers", test_actorOwned_GCounter_increment_shouldResetDelta_shouldNotifyOthers),
             ("test_actorOwned_GCounter_deleteFromCluster_shouldChangeStatus", test_actorOwned_GCounter_deleteFromCluster_shouldChangeStatus),
             ("test_actorOwned_ORSet_add_remove_shouldResetDelta_shouldNotifyOthers", test_actorOwned_ORSet_add_remove_shouldResetDelta_shouldNotifyOthers),
+            ("test_actorOwned_ORSet_add_many_times", test_actorOwned_ORSet_add_many_times),
         ]
     }
 }


### PR DESCRIPTION
### Motivation:

- writes to self.data in ActorOwned were not thread safe (we knew, just postponed working on it until now)
### Modifications:

- writes need to be executed via the owner context; so we use the 

### Result:

- Resolves #76