### PR TITLE
Fix throughput calculation in ActorPingPongBenchmark #99

### DIFF
--- a/Sources/DistributedActorsBenchmarks/ActorPingPongBenchmarks.swift
+++ b/Sources/DistributedActorsBenchmarks/ActorPingPongBenchmarks.swift
@@ -124,7 +124,7 @@ private func supervisorBehavior() -> Behavior<PingPongCommand> {
         switch message {
         case .startPingPong(let numMessagesPerActorPair, let numActors, let throughput, _, let replyTo):
             let numPairs = numActors / 2
-            let totalNumMessages = numPairs * numMessagesPerActorPair / 2
+            let totalNumMessages = numPairs * numMessagesPerActorPair
 
             let latch = CountDownLatch(from: numActors)
 


### PR DESCRIPTION
### Motivation:

Getting the correct throughput numbers 😉

### Result:

- Resolves #99

**Benchmark before**

```
Spawning 2 actors too: 0 ms
1000000 messages by 2 actors took: 1041 ms (total: 960000 msg/s)

Spawning 6 actors too: 0 ms
3000000 messages by 6 actors took: 1641 ms (total: 1828000 msg/

Spawning 12 actors too: 0 ms
6000000 messages by 12 actors took: 1810 ms (total: 3314000 msg/

Spawning 24 actors too: 0 ms
12000000 messages by 24 actors took: 3173 ms (total: 3781000 msg/s)
```

**Benchmark after**

```
Spawning 2 actors too: 0 ms
2000000 messages by 2 actors took: 1000 ms (total: 2000000 msg/s)

Spawning 6 actors too: 0 ms
6000000 messages by 6 actors took: 1652 ms (total: 3631000 msg/s)

Spawning 12 actors too: 0 ms
12000000 messages by 12 actors took: 1777 ms (total: 6752000 msg/s)

Spawning 24 actors too: 0 ms
24000000 messages by 24 actors took: 3057 ms (total: 7850000 msg/s)
```