### PR TITLE
Slight cleanup, removes some warnings

### DIFF
--- a/Samples/SampleLetItCrash/main.swift
+++ b/Samples/SampleLetItCrash/main.swift
@@ -23,7 +23,11 @@ import CDistributedActorsMailbox
 let system = ActorSystem("LetItCrashSystem")
 
 func consumeAny<T>(_ value: T) {
-    consumeAny(value)
+    if 2 * 12 / 2 == 12 { // to avoid compiler issued warning about infinite recursion
+        consumeAny(value)
+     } else {
+        return ()
+    }
 }
 
 func returnTrue() -> Bool {
@@ -72,7 +76,11 @@ func crashObjCException() {
 
 func crashStackOverflow() {
     func recurse(accumulator: Int) -> Int {
-        return 1 + recurse(accumulator: accumulator + 1)
+        if 2 * 12 / 2 == 12 { // to avoid compiler issued warning about infinite recursion
+            return 1 + recurse(accumulator: accumulator + 1)
+        } else {
+            return 1
+        }
     }
 
     consumeAny(recurse(accumulator: 0))
@@ -92,7 +100,7 @@ func crashOOM() {
 }
 
 func crashRangeFromUpperBoundWhichLessThanLowerBound() {
-    let values = ["one", "two"].suffix(from: 3)
+    let _ = ["one", "two"].suffix(from: 3)
 }
 
 struct FooExclusivityViolation {

--- a/Sources/DistributedActors/CRDT/Protobuf/CRDTEnvelope+Serialization.swift
+++ b/Sources/DistributedActors/CRDT/Protobuf/CRDTEnvelope+Serialization.swift
@@ -58,7 +58,6 @@ extension CRDTEnvelope: ProtobufRepresentable {
         var proto = ProtoCRDTEnvelope()
         switch self._boxed {
         case .crdt(let data):
-            fatalError()
             let (serializerId, _bytes) = try context.system.serialization.serialize(message: data.underlying, metaType: data.metaType)
             var bytes = _bytes
             proto.boxed = .anyCvrdt
@@ -67,7 +66,7 @@ extension CRDTEnvelope: ProtobufRepresentable {
             return proto
 
         case .delta(let delta):
-            var (serializerId, _bytes) = try context.system.serialization.serialize(message: delta.underlying, metaType: delta.metaType)
+            let (serializerId, _bytes) = try context.system.serialization.serialize(message: delta.underlying, metaType: delta.metaType)
             var bytes = _bytes
             proto.boxed = .anyDeltaCrdt
             proto.serializerID = serializerId

--- a/Sources/DistributedActors/CRDT/Protobuf/CRDTReplication+Serialization.swift
+++ b/Sources/DistributedActors/CRDT/Protobuf/CRDTReplication+Serialization.swift
@@ -39,13 +39,13 @@ extension CRDT.Replicator.Message: InternalProtobufRepresentable {
             write.envelope = try CRDTEnvelope(serializerId: serializerId, crdtOrDelta).toProto(context: context)
             proto.write = write
 
-        case .writeDelta(let id, let delta, let replyTo):
+        case .writeDelta:
             fatalError("to be implemented")
 
-        case .read(let id, let replyTo):
+        case .read:
             fatalError("to be implemented")
 
-        case .delete(let id, let replyTo):
+        case .delete:
             fatalError("to be implemented")
         }
 

--- a/Sources/DistributedActors/Clocks/Protobuf/VersionVector+Serialization.swift
+++ b/Sources/DistributedActors/Clocks/Protobuf/VersionVector+Serialization.swift
@@ -21,9 +21,7 @@ extension VersionVector: InternalProtobufRepresentable {
     func toProto(context: ActorSerializationContext) throws -> ProtoVersionVector {
         var proto = ProtoVersionVector()
 
-        var replicaVersions: [ProtoReplicaVersion] = []
-        replicaVersions.reserveCapacity(self.state.count)
-        for (replicaId, version) in self.state {
+        let replicaVersions: [ProtoReplicaVersion] = self.state.map { replicaId, version in
             var p = ProtoReplicaVersion()
             p.version = UInt32(version)
 
@@ -34,7 +32,7 @@ extension VersionVector: InternalProtobufRepresentable {
             }
             p.replicaID = id
 
-            replicaVersions.append(p)
+            return p
         }
         proto.state = replicaVersions
         return proto

--- a/Tests/DistributedActorsDocumentationTests/ActorDocExamples.swift
+++ b/Tests/DistributedActorsDocumentationTests/ActorDocExamples.swift
@@ -249,11 +249,11 @@ class ActorDocExamples: XCTestCase {
 
             return .same // (a)
             // or
-            return .stop // (b)
+            // return .stop // (b)
             // or
-            throw TestError("Whoops!") // (c)
+            // throw TestError("Whoops!") // (c)
             // or
-            fatalError("Whoops!") // (d)
+            // fatalError("Whoops!") // (d)
         }
         // end::defer_simple[]
 
@@ -282,6 +282,7 @@ class ActorDocExamples: XCTestCase {
 
         let result = try response.nioFuture.wait() // <3>
         // end::ask_outside[]
+        _ = result
     }
 
     func example_ask_inside() throws {

--- a/Tests/DistributedActorsDocumentationTests/ClusteringDocExamples.swift
+++ b/Tests/DistributedActorsDocumentationTests/ClusteringDocExamples.swift
@@ -23,7 +23,7 @@ class ClusteringDocExamples: XCTestCase {
         let system = ActorSystem("TestSystem") { settings in
             // ...
             settings.cluster.tls = TLSConfiguration.forServer( // <1>
-                certificateChain: [.file("/path/to/certificate.pem")], // <2>
+                certificateChain: try! NIOSSLCertificate.fromPEMFile("/path/to/certificate.pem").map { NIOSSLCertificateSource.certificate($0) }, // <2>
                 privateKey: .file("/path/to/private-key.pem"), // <3>
                 certificateVerification: .fullVerification, // <4>
                 trustRoots: .file("/path/to/certificateChain.pem")

--- a/Tests/DistributedActorsDocumentationTests/DeathWatchDocExamples.swift
+++ b/Tests/DistributedActorsDocumentationTests/DeathWatchDocExamples.swift
@@ -63,7 +63,7 @@ class DeathWatchDocExamples {
         // tag::handling_termination_deathwatch[]
         let concedeTimer: TimerKey = "concede-timer"
 
-        Behavior<GameMatch.Command>.receive { context, command in
+        _ = Behavior<GameMatch.Command>.receive { context, command in
             switch command {
             case .playerConnected(let player):
                 context.timers.cancel(for: concedeTimer)

--- a/Tests/DistributedActorsDocumentationTests/ProcessIsolatedDocExamples.swift
+++ b/Tests/DistributedActorsDocumentationTests/ProcessIsolatedDocExamples.swift
@@ -49,7 +49,7 @@ class ProcessIsolatedDocExamples {
             )
 
             // spawn the an actor on the master node <6>
-            try isolated.system.spawn("bruce", of: WorkRequest.self, .receiveMessage { _ in
+            _ = try isolated.system.spawn("bruce", of: WorkRequest.self, .receiveMessage { _ in
                 // do something with the `work`
                 .same
             })
@@ -57,8 +57,8 @@ class ProcessIsolatedDocExamples {
         // end of executes only on .master process ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
         // executes only on .servant process ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        try isolated.run(on: .servant) { // <7>
-            try isolated.system.spawn("alfred", of: Requests.self, .ignore)
+        _ = try isolated.run(on: .servant) { // <7>
+            _ = try isolated.system.spawn("alfred", of: Requests.self, .ignore)
         }
         // end of: executes only on .servant process ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Tests/DistributedActorsTestKitTests/ActorTestProbeTests+XCTest.swift
+++ b/Tests/DistributedActorsTestKitTests/ActorTestProbeTests+XCTest.swift
@@ -23,8 +23,6 @@ import XCTest
 extension ActorTestProbeTests {
     static var allTests: [(String, (ActorTestProbeTests) -> () throws -> Void)] {
         return [
-            ("test_expectMessage_shouldFailWhenNoMessageSentWithinTimeout", test_expectMessage_shouldFailWhenNoMessageSentWithinTimeout),
-            ("test_expectMessage_shouldFailWhenWrongMessageReceived", test_expectMessage_shouldFailWhenWrongMessageReceived),
             ("test_maybeExpectMessage_shouldReturnTheReceivedMessage", test_maybeExpectMessage_shouldReturnTheReceivedMessage),
             ("test_maybeExpectMessage_shouldReturnNilIfTimeoutExceeded", test_maybeExpectMessage_shouldReturnNilIfTimeoutExceeded),
             ("test_expectNoMessage", test_expectNoMessage),

--- a/Tests/DistributedActorsTestKitTests/ActorTestProbeTests.swift
+++ b/Tests/DistributedActorsTestKitTests/ActorTestProbeTests.swift
@@ -29,32 +29,6 @@ class ActorTestProbeTests: XCTestCase {
         self.system.shutdown()
     }
 
-    func test_expectMessage_shouldFailWhenNoMessageSentWithinTimeout() throws {
-        #if !SACT_TESTS_CRASH
-        pnote("Skipping test \(#function), can't test assert(); To see it crash run with `-D SACT_TESTS_CRASH`")
-        return ()
-        #endif
-        _ = "Skipping test \(#function), can't test the 'test assertions' being emitted; To see it crash run with `-D SACT_TESTS_CRASH`"
-
-        let probe = self.testKit.spawnTestProbe("p1", expecting: String.self)
-
-        try probe.expectMessage("awaiting-forever")
-    }
-
-    func test_expectMessage_shouldFailWhenWrongMessageReceived() throws {
-        #if !SACT_TESTS_CRASH
-        pnote("Skipping test \(#function), can't test the 'test assertions' being emitted; To see it crash run with `-D SACT_TESTS_CRASH`")
-        return ()
-        #endif
-        _ = "Skipping test \(#function), can't test the 'test assertions' being emitted; To see it crash run with `-D SACT_TESTS_CRASH`"
-
-        let probe = self.testKit.spawnTestProbe("p2", expecting: String.self)
-
-        probe.tell("one")
-
-        try probe.expectMessage("two")
-    }
-
     func test_maybeExpectMessage_shouldReturnTheReceivedMessage() throws {
         let probe = self.testKit.spawnTestProbe("p2", expecting: String.self)
 

--- a/Tests/DistributedActorsTests/ActorNamingTests.swift
+++ b/Tests/DistributedActorsTests/ActorNamingTests.swift
@@ -21,7 +21,7 @@ final class ActorNamingTests: XCTestCase {
         var context = ActorNamingContext()
         let naming = ActorNaming.unique("hello")
 
-        for i in 0 ... 3 {
+        for _ in 0 ... 3 {
             let name = naming.makeName(&context)
             name.shouldEqual("hello")
         }

--- a/Tests/DistributedActorsTests/ActorSystem+Testing.swift
+++ b/Tests/DistributedActorsTests/ActorSystem+Testing.swift
@@ -25,7 +25,7 @@ extension ActorSystem {
     func _resolve<Message>(ref: ActorRef<Message>, onSystem remoteSystem: ActorSystem) -> ActorRef<Message> {
         assertBacktrace(ref.address.isLocal, "Expecting passed in `ref` to not have an address defined (yet), as this is what we are going to do in this function.")
 
-        var remoteAddress = ActorAddress(node: remoteSystem.settings.cluster.uniqueBindNode, path: ref.path, incarnation: ref.address.incarnation)
+        let remoteAddress = ActorAddress(node: remoteSystem.settings.cluster.uniqueBindNode, path: ref.path, incarnation: ref.address.incarnation)
 
         let resolveContext = ResolveContext<Message>(address: remoteAddress, system: self)
         return self._resolve(context: resolveContext)

--- a/Tests/DistributedActorsTests/CRDT/Protobuf/CRDT+SerializationTests.swift
+++ b/Tests/DistributedActorsTests/CRDT/Protobuf/CRDT+SerializationTests.swift
@@ -22,7 +22,7 @@ final class CRDTSerializationTests: XCTestCase {
 
     override func setUp() {
         self.system = ActorSystem(String(describing: type(of: self))) { settings in
-            settings.serialization.registerInternalProtobufRepresentable(for: CRDT.ORSet<String>.self, underId: 1001)
+            settings.serialization.registerProtobufRepresentable(for: CRDT.ORSet<String>.self, underId: 1001)
         }
         self.testKit = ActorTestKit(self.system)
     }

--- a/Tests/DistributedActorsTests/MembershipTests.swift
+++ b/Tests/DistributedActorsTests/MembershipTests.swift
@@ -101,7 +101,7 @@ final class MembershipTests: XCTestCase {
         res1!.reachability.shouldEqual(.unreachable)
 
         membership.mark(member.node, reachability: .unreachable).shouldEqual(nil) // no change
-        let res2 = membership.mark(member.node, reachability: .unreachable)
+        _ = membership.mark(member.node, reachability: .unreachable)
     }
 
     // ==== ------------------------------------------------------------------------------------------------------------

--- a/Tests/DistributedActorsTests/SerializationTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/SerializationTests+XCTest.swift
@@ -34,7 +34,6 @@ extension SerializationTests {
             ("test_serialize_shouldNotSerializeNotRegisteredType", test_serialize_shouldNotSerializeNotRegisteredType),
             ("test_serialize_receivesSystemMessages_inMessage", test_serialize_receivesSystemMessages_inMessage),
             ("test_verifySerializable_shouldPass_forPreconfiguredSerializableMessages_string", test_verifySerializable_shouldPass_forPreconfiguredSerializableMessages_string),
-            ("test_verifySerializable_shouldFault_forNotSerializableMessage", test_verifySerializable_shouldFault_forNotSerializableMessage),
         ]
     }
 }

--- a/Tests/DistributedActorsTests/SerializationTests.swift
+++ b/Tests/DistributedActorsTests/SerializationTests.swift
@@ -76,7 +76,7 @@ class SerializationTests: XCTestCase {
             let address = try ActorPath(root: "user").appending("hello").makeLocalAddress(incarnation: .random())
 
             let encoder = JSONEncoder()
-            let encoded = try encoder.encode(address)
+            _ = try encoder.encode(address)
         }
 
         "\(err)".shouldStartWith(prefix: """
@@ -285,32 +285,6 @@ class SerializationTests: XCTestCase {
             s2.shutdown()
             throw error
         }
-        s2.shutdown()
-    }
-
-    func test_verifySerializable_shouldFault_forNotSerializableMessage() throws {
-        pnote("Fault handling is not implemented, so we cannot test for the fault ocurring when no serializer defined.")
-        return
-
-        /// if we had fault handling, this test should work:
-        let s2 = ActorSystem("SerializeMessages") { settings in
-            settings.serialization.allMessages = true
-        }
-
-        let testKit2 = ActorTestKit(s2)
-        let p = testKit2.spawnTestProbe(expecting: NotSerializable.self)
-
-        let recipient: ActorRef<NotSerializable> = try s2.spawn("recipient", .ignore)
-
-        let senderOfNotSerializableMessage: ActorRef<String> = try s2.spawn("expected-to-fault-due-to-serialization-check", .receiveMessage { _ in
-            recipient.tell(NotSerializable("\(#file):\(#line)"))
-            return .same
-        })
-
-        p.watch(senderOfNotSerializableMessage)
-        senderOfNotSerializableMessage.tell("send it now!")
-
-        try p.expectTerminated(senderOfNotSerializableMessage)
         s2.shutdown()
     }
 }

--- a/Tests/DistributedActorsTests/SupervisionTests.swift
+++ b/Tests/DistributedActorsTests/SupervisionTests.swift
@@ -641,7 +641,6 @@ class SupervisionTests: XCTestCase {
         let pm = self.testKit.spawnTestProbe("pm", expecting: ActorRef<String>.self)
         let pab = self.testKit.spawnTestProbe("pab", expecting: ActorRef<String>.self)
         let pb = self.testKit.spawnTestProbe("pb", expecting: ActorRef<String>.self)
-        let pp = self.testKit.spawnTestProbe("pp", expecting: String.self)
 
         _ = try self.system.spawn("top", of: String.self, .setup { c in
             pt.tell(c.myself)


### PR DESCRIPTION
### Motivation:

- forgot one followup from loop -> map from crdt serialization review
- trying to get to be able to compile as -warnings-as-errors

### Result:

- less warnings