### PR TITLE
Slight adjustments in sorting of ActorAddress

### DIFF
--- a/Sources/DistributedActors/ActorAddress.swift
+++ b/Sources/DistributedActors/ActorAddress.swift
@@ -40,8 +40,8 @@
 /// The address consists of the following parts:
 ///
 /// ```
-/// |              node                | path              | incarnation |
-/// ( protocol | (name) | host | port ) ( [segments] name ) (   uint32   )
+/// |              node                 | path              | incarnation |
+///  ( protocol | (name) | host | port ) ( [segments] name ) (   uint32  )
 /// ```
 ///
 /// For example: `sact://human-readable-name@127.0.0.1:7337/user/wallet/id-121242`.
@@ -169,23 +169,19 @@ extension ActorAddress: PathRelationships {
 /// Offers arbitrary ordering for predictable ordered printing of things keyed by addresses.
 extension ActorAddress: Comparable {
     public static func < (lhs: ActorAddress, rhs: ActorAddress) -> Bool {
-        return lhs.node < lhs.node ||
-            (lhs.node == rhs.node && lhs.path < rhs.path) ||
-            (lhs.node == rhs.node && lhs.path == rhs.path && lhs.incarnation < rhs.incarnation)
-    }
-}
-
-extension Optional: Comparable where Wrapped == UniqueNode {
-    public static func < (lhs: UniqueNode?, rhs: UniqueNode?) -> Bool {
-        switch (lhs, rhs) {
-        case (.some, .none):
-            return false
+        switch (lhs.node, rhs.node) {
         case (.none, .some):
             return true
-        case (.some(let l), .some(let r)):
-            return l < r
-        case (.none, .none):
+        case (.some, .none):
             return false
+        case (.none, .none):
+            // both are local addresses
+            return (lhs.path < rhs.path) || (lhs.path == rhs.path && lhs.incarnation < rhs.incarnation)
+        case (.some(let lhsNode), .some(let rhsNode)) where lhsNode == rhsNode:
+            // both are on the same node
+            return (lhs.path < rhs.path) || (lhs.path == rhs.path && lhs.incarnation < rhs.incarnation)
+        case (.some(let lhsNode), .some(let rhsNode)):
+            return lhsNode < rhsNode
         }
     }
 }

--- a/Tests/DistributedActorsTests/ActorAddressTests.swift
+++ b/Tests/DistributedActorsTests/ActorAddressTests.swift
@@ -138,15 +138,31 @@ final class ActorAddressTests: XCTestCase {
     }
 
     func test_sortingOf_ActorAddresses() throws {
-        var addresses: [ActorAddress] = []
-        let a: ActorAddress = try ActorPath._user.appending("a").makeLocalAddress(incarnation: .random())
+        let node100 = UniqueNode(systemName: "X", host: "localhost", port: 22, nid: NodeID(100))
+        let node200 = UniqueNode(systemName: "X", host: "localhost", port: 22, nid: NodeID(200))
+        let node200p1 = UniqueNode(systemName: "X", host: "localhost", port: 1, nid: NodeID(200))
+
+        let pathA: ActorPath = try ActorPath._user.appending("a")
+        let a10: ActorAddress = ActorAddress(node: node100, path: pathA, incarnation: ActorIncarnation(10))
+        let a11: ActorAddress = ActorAddress(node: node100, path: pathA, incarnation: ActorIncarnation(11))
+        let a20: ActorAddress = ActorAddress(node: node100, path: pathA, incarnation: ActorIncarnation(20))
+        [a20, a10, a11].sorted().shouldEqual([a10, a11, a20]) // on equal nodes and paths, incarnations matter
+
+        let pathB: ActorPath = try ActorPath._user.appending("b")
+        let b10: ActorAddress = ActorAddress(node: node100, path: pathB, incarnation: .random())
+        let b20: ActorAddress = ActorAddress(node: node200, path: pathB, incarnation: .random())
+        [b20, b10].sorted().shouldEqual([b10, b20])
+
+        let pathC: ActorPath = try ActorPath._user.appending("b")
+        let cp22: ActorAddress = ActorAddress(node: node200, path: pathC, incarnation: .perpetual)
+        let cp1i0: ActorAddress = ActorAddress(node: node200p1, path: pathC, incarnation: .perpetual)
+        let cp1i1000: ActorAddress = ActorAddress(node: node200p1, path: pathC, incarnation: ActorIncarnation(1000))
+        [cp1i1000, cp1i0, cp22].sorted().shouldEqual([cp1i0, cp1i1000, cp22])
+
+        let a: ActorAddress = try ActorAddress(node: node100, path: ActorPath._user.appending("a"), incarnation: ActorIncarnation(10))
         let b: ActorAddress = try ActorPath._user.appending("b").makeLocalAddress(incarnation: .random())
         let c: ActorAddress = try ActorPath._user.appending("c").makeLocalAddress(incarnation: .random())
-        addresses.append(c)
-        addresses.append(b)
-        addresses.append(a)
-
-        // sorting should not be impacted by the random incarnation numbers
-        addresses.sorted().shouldEqual([a, b, c])
+        // sorting should not be impacted by the random incarnation numbers, as node or path segments already decide order
+        [b, a, c].sorted().shouldEqual([b, c, a]) // local refs sorted first
     }
 }


### PR DESCRIPTION
Follow up to #103 

### Motivation:

- Sorting to be more "visually" predictable,
- sort "local" actors predictably always earlier than others
- when sorting, group actors by the nodes on which they live


### Before:

```
/Users/ktoso/code/actors/Tests/DistributedActorsTests/ActorAddressTests.swift:153: error: -[DistributedActorsTests.ActorAddressTests test_sortingOf_ActorAddresses] : XCTAssertEqual failed: ("[sact://X@localhost:12/user/b#735520709, sact://X@localhost:12/user/b#2334848421]") is not equal to ("[sact://X@localhost:12/user/b#2334848421, sact://X@localhost:12/user/b#735520709]") -
        [b20, b10].sorted().shouldEqual([b10, b20])
                            ^~~~~~~~~~~~
error: [[sact://X@localhost:12/user/b#735520709, sact://X@localhost:12/user/b#2334848421]] does not equal expected: [[sact://X@localhost:12/user/b#2334848421, sact://X@localhost:12/user/b#735520709]]

/Users/ktoso/code/actors/Tests/DistributedActorsTests/ActorAddressTests.swift:159: error: -[DistributedActorsTests.ActorAddressTests test_sortingOf_ActorAddresses] : XCTAssertEqual failed: ("[/user/b#1137342129, sact://X@localhost:12/user/a#10, /user/c#2278582529]") is not equal to ("[/user/b#1137342129, /user/c#2278582529, sact://X@localhost:12/user/a#10]") -
        [b, a, c].sorted().shouldEqual([b, c, a]) // local refs sorted first
                           ^~~~~~~~~~~~
error: [[/user/b#1137342129, sact://X@localhost:12/user/a#10, /user/c#2278582529]] does not equal expected: [[/user/b#1137342129, /user/c#2278582529, sact://X@localhost:12/user/a#10]]
```

### After:

ordering passing as in the tests added here.
