### PR TITLE
Make ActorShell.deferred let instead of var

### DIFF
--- a/Sources/DistributedActors/ActorShell.swift
+++ b/Sources/DistributedActors/ActorShell.swift
@@ -91,7 +91,7 @@ internal final class ActorShell<Message>: ActorContext<Message>, AbstractActor {
     // MARK: Defer
 
     @usableFromInline
-    internal var deferred = DefersContainer()
+    internal let deferred = DefersContainer()
 
     public override func `defer`(until: DeferUntilWhen,
                                  file: String = #file, line: UInt = #line,


### PR DESCRIPTION
### Motivation:

Is not being mutated, so shouldn't be a `var`
