### PR TITLE
Exclude protobuf generated sources from swiftformat #84

### DIFF
--- a/Sources/DistributedActors/CRDT/Protobuf/CRDT.pb.swift
+++ b/Sources/DistributedActors/CRDT/Protobuf/CRDT.pb.swift
@@ -28,728 +28,718 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that your are building against the same version of the API
 // that was used to generate this file.
-private struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-    struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
-    typealias Version = _2
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 public struct ProtoCRDTIdentity {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    public var id: String = String()
+  public var id: String = String()
 
-    public var unknownFields = SwiftProtobuf.UnknownStorage()
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public init() {}
+  public init() {}
 }
 
 public struct ProtoCRDTVersionContext {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    public var versionVector: ProtoVersionVector {
-        get { return self._storage._versionVector ?? ProtoVersionVector() }
-        set { _uniqueStorage()._versionVector = newValue }
-    }
+  public var versionVector: ProtoVersionVector {
+    get {return _storage._versionVector ?? ProtoVersionVector()}
+    set {_uniqueStorage()._versionVector = newValue}
+  }
+  /// Returns true if `versionVector` has been explicitly set.
+  public var hasVersionVector: Bool {return _storage._versionVector != nil}
+  /// Clears the value of `versionVector`. Subsequent reads from it will return its default value.
+  public mutating func clearVersionVector() {_uniqueStorage()._versionVector = nil}
 
-    /// Returns true if `versionVector` has been explicitly set.
-    public var hasVersionVector: Bool { return self._storage._versionVector != nil }
-    /// Clears the value of `versionVector`. Subsequent reads from it will return its default value.
-    public mutating func clearVersionVector() { _uniqueStorage()._versionVector = nil }
+  public var gaps: [ProtoVersionDot] {
+    get {return _storage._gaps}
+    set {_uniqueStorage()._gaps = newValue}
+  }
 
-    public var gaps: [ProtoVersionDot] {
-        get { return self._storage._gaps }
-        set { _uniqueStorage()._gaps = newValue }
-    }
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public var unknownFields = SwiftProtobuf.UnknownStorage()
+  public init() {}
 
-    public init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 public struct ProtoCRDTVersionedContainer {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    public var replicaID: ProtoVersionReplicaId {
-        get { return self._storage._replicaID ?? ProtoVersionReplicaId() }
-        set { _uniqueStorage()._replicaID = newValue }
-    }
+  public var replicaID: ProtoVersionReplicaId {
+    get {return _storage._replicaID ?? ProtoVersionReplicaId()}
+    set {_uniqueStorage()._replicaID = newValue}
+  }
+  /// Returns true if `replicaID` has been explicitly set.
+  public var hasReplicaID: Bool {return _storage._replicaID != nil}
+  /// Clears the value of `replicaID`. Subsequent reads from it will return its default value.
+  public mutating func clearReplicaID() {_uniqueStorage()._replicaID = nil}
 
-    /// Returns true if `replicaID` has been explicitly set.
-    public var hasReplicaID: Bool { return self._storage._replicaID != nil }
-    /// Clears the value of `replicaID`. Subsequent reads from it will return its default value.
-    public mutating func clearReplicaID() { _uniqueStorage()._replicaID = nil }
+  public var versionContext: ProtoCRDTVersionContext {
+    get {return _storage._versionContext ?? ProtoCRDTVersionContext()}
+    set {_uniqueStorage()._versionContext = newValue}
+  }
+  /// Returns true if `versionContext` has been explicitly set.
+  public var hasVersionContext: Bool {return _storage._versionContext != nil}
+  /// Clears the value of `versionContext`. Subsequent reads from it will return its default value.
+  public mutating func clearVersionContext() {_uniqueStorage()._versionContext = nil}
 
-    public var versionContext: ProtoCRDTVersionContext {
-        get { return self._storage._versionContext ?? ProtoCRDTVersionContext() }
-        set { _uniqueStorage()._versionContext = newValue }
-    }
+  public var elementByBirthDot: [ProtoVersionDottedElementEnvelope] {
+    get {return _storage._elementByBirthDot}
+    set {_uniqueStorage()._elementByBirthDot = newValue}
+  }
 
-    /// Returns true if `versionContext` has been explicitly set.
-    public var hasVersionContext: Bool { return self._storage._versionContext != nil }
-    /// Clears the value of `versionContext`. Subsequent reads from it will return its default value.
-    public mutating func clearVersionContext() { _uniqueStorage()._versionContext = nil }
+  public var delta: ProtoCRDTVersionedContainerDelta {
+    get {return _storage._delta ?? ProtoCRDTVersionedContainerDelta()}
+    set {_uniqueStorage()._delta = newValue}
+  }
+  /// Returns true if `delta` has been explicitly set.
+  public var hasDelta: Bool {return _storage._delta != nil}
+  /// Clears the value of `delta`. Subsequent reads from it will return its default value.
+  public mutating func clearDelta() {_uniqueStorage()._delta = nil}
 
-    public var elementByBirthDot: [ProtoVersionDottedElementEnvelope] {
-        get { return self._storage._elementByBirthDot }
-        set { _uniqueStorage()._elementByBirthDot = newValue }
-    }
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public var delta: ProtoCRDTVersionedContainerDelta {
-        get { return self._storage._delta ?? ProtoCRDTVersionedContainerDelta() }
-        set { _uniqueStorage()._delta = newValue }
-    }
+  public init() {}
 
-    /// Returns true if `delta` has been explicitly set.
-    public var hasDelta: Bool { return self._storage._delta != nil }
-    /// Clears the value of `delta`. Subsequent reads from it will return its default value.
-    public mutating func clearDelta() { _uniqueStorage()._delta = nil }
-
-    public var unknownFields = SwiftProtobuf.UnknownStorage()
-
-    public init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 public struct ProtoCRDTVersionedContainerDelta {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    public var versionContext: ProtoCRDTVersionContext {
-        get { return self._storage._versionContext ?? ProtoCRDTVersionContext() }
-        set { _uniqueStorage()._versionContext = newValue }
-    }
+  public var versionContext: ProtoCRDTVersionContext {
+    get {return _storage._versionContext ?? ProtoCRDTVersionContext()}
+    set {_uniqueStorage()._versionContext = newValue}
+  }
+  /// Returns true if `versionContext` has been explicitly set.
+  public var hasVersionContext: Bool {return _storage._versionContext != nil}
+  /// Clears the value of `versionContext`. Subsequent reads from it will return its default value.
+  public mutating func clearVersionContext() {_uniqueStorage()._versionContext = nil}
 
-    /// Returns true if `versionContext` has been explicitly set.
-    public var hasVersionContext: Bool { return self._storage._versionContext != nil }
-    /// Clears the value of `versionContext`. Subsequent reads from it will return its default value.
-    public mutating func clearVersionContext() { _uniqueStorage()._versionContext = nil }
+  public var elementByBirthDot: [ProtoVersionDottedElementEnvelope] {
+    get {return _storage._elementByBirthDot}
+    set {_uniqueStorage()._elementByBirthDot = newValue}
+  }
 
-    public var elementByBirthDot: [ProtoVersionDottedElementEnvelope] {
-        get { return self._storage._elementByBirthDot }
-        set { _uniqueStorage()._elementByBirthDot = newValue }
-    }
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public var unknownFields = SwiftProtobuf.UnknownStorage()
+  public init() {}
 
-    public init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 public struct ProtoCRDTGCounter {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var replicaID: ProtoVersionReplicaId {
+    get {return _storage._replicaID ?? ProtoVersionReplicaId()}
+    set {_uniqueStorage()._replicaID = newValue}
+  }
+  /// Returns true if `replicaID` has been explicitly set.
+  public var hasReplicaID: Bool {return _storage._replicaID != nil}
+  /// Clears the value of `replicaID`. Subsequent reads from it will return its default value.
+  public mutating func clearReplicaID() {_uniqueStorage()._replicaID = nil}
+
+  /// Not a map since we cannot use `replicaId` as key
+  public var state: [ProtoCRDTGCounter.ReplicaState] {
+    get {return _storage._state}
+    set {_uniqueStorage()._state = newValue}
+  }
+
+  public var delta: ProtoCRDTGCounter.Delta {
+    get {return _storage._delta ?? ProtoCRDTGCounter.Delta()}
+    set {_uniqueStorage()._delta = newValue}
+  }
+  /// Returns true if `delta` has been explicitly set.
+  public var hasDelta: Bool {return _storage._delta != nil}
+  /// Clears the value of `delta`. Subsequent reads from it will return its default value.
+  public mutating func clearDelta() {_uniqueStorage()._delta = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public struct ReplicaState {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
 
     public var replicaID: ProtoVersionReplicaId {
-        get { return self._storage._replicaID ?? ProtoVersionReplicaId() }
-        set { _uniqueStorage()._replicaID = newValue }
+      get {return _storage._replicaID ?? ProtoVersionReplicaId()}
+      set {_uniqueStorage()._replicaID = newValue}
     }
-
     /// Returns true if `replicaID` has been explicitly set.
-    public var hasReplicaID: Bool { return self._storage._replicaID != nil }
+    public var hasReplicaID: Bool {return _storage._replicaID != nil}
     /// Clears the value of `replicaID`. Subsequent reads from it will return its default value.
-    public mutating func clearReplicaID() { _uniqueStorage()._replicaID = nil }
+    public mutating func clearReplicaID() {_uniqueStorage()._replicaID = nil}
 
-    /// Not a map since we cannot use `replicaId` as key
-    public var state: [ProtoCRDTGCounter.ReplicaState] {
-        get { return self._storage._state }
-        set { _uniqueStorage()._state = newValue }
+    public var count: UInt64 {
+      get {return _storage._count}
+      set {_uniqueStorage()._count = newValue}
     }
-
-    public var delta: ProtoCRDTGCounter.Delta {
-        get { return self._storage._delta ?? ProtoCRDTGCounter.Delta() }
-        set { _uniqueStorage()._delta = newValue }
-    }
-
-    /// Returns true if `delta` has been explicitly set.
-    public var hasDelta: Bool { return self._storage._delta != nil }
-    /// Clears the value of `delta`. Subsequent reads from it will return its default value.
-    public mutating func clearDelta() { _uniqueStorage()._delta = nil }
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
-
-    public struct ReplicaState {
-        // SwiftProtobuf.Message conformance is added in an extension below. See the
-        // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-        // methods supported on all messages.
-
-        public var replicaID: ProtoVersionReplicaId {
-            get { return self._storage._replicaID ?? ProtoVersionReplicaId() }
-            set { _uniqueStorage()._replicaID = newValue }
-        }
-
-        /// Returns true if `replicaID` has been explicitly set.
-        public var hasReplicaID: Bool { return self._storage._replicaID != nil }
-        /// Clears the value of `replicaID`. Subsequent reads from it will return its default value.
-        public mutating func clearReplicaID() { _uniqueStorage()._replicaID = nil }
-
-        public var count: UInt64 {
-            get { return self._storage._count }
-            set { _uniqueStorage()._count = newValue }
-        }
-
-        public var unknownFields = SwiftProtobuf.UnknownStorage()
-
-        public init() {}
-
-        fileprivate var _storage = _StorageClass.defaultInstance
-    }
-
-    public struct Delta {
-        // SwiftProtobuf.Message conformance is added in an extension below. See the
-        // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-        // methods supported on all messages.
-
-        public var state: [ProtoCRDTGCounter.ReplicaState] = []
-
-        public var unknownFields = SwiftProtobuf.UnknownStorage()
-
-        public init() {}
-    }
 
     public init() {}
 
     fileprivate var _storage = _StorageClass.defaultInstance
+  }
+
+  public struct Delta {
+    // SwiftProtobuf.Message conformance is added in an extension below. See the
+    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+    // methods supported on all messages.
+
+    public var state: [ProtoCRDTGCounter.ReplicaState] = []
+
+    public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+    public init() {}
+  }
+
+  public init() {}
+
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 public struct ProtoCRDTORSet {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    public var replicaID: ProtoVersionReplicaId {
-        get { return self._storage._replicaID ?? ProtoVersionReplicaId() }
-        set { _uniqueStorage()._replicaID = newValue }
-    }
+  public var replicaID: ProtoVersionReplicaId {
+    get {return _storage._replicaID ?? ProtoVersionReplicaId()}
+    set {_uniqueStorage()._replicaID = newValue}
+  }
+  /// Returns true if `replicaID` has been explicitly set.
+  public var hasReplicaID: Bool {return _storage._replicaID != nil}
+  /// Clears the value of `replicaID`. Subsequent reads from it will return its default value.
+  public mutating func clearReplicaID() {_uniqueStorage()._replicaID = nil}
 
-    /// Returns true if `replicaID` has been explicitly set.
-    public var hasReplicaID: Bool { return self._storage._replicaID != nil }
-    /// Clears the value of `replicaID`. Subsequent reads from it will return its default value.
-    public mutating func clearReplicaID() { _uniqueStorage()._replicaID = nil }
+  /// Includes delta
+  public var state: ProtoCRDTVersionedContainer {
+    get {return _storage._state ?? ProtoCRDTVersionedContainer()}
+    set {_uniqueStorage()._state = newValue}
+  }
+  /// Returns true if `state` has been explicitly set.
+  public var hasState: Bool {return _storage._state != nil}
+  /// Clears the value of `state`. Subsequent reads from it will return its default value.
+  public mutating func clearState() {_uniqueStorage()._state = nil}
 
-    /// Includes delta
-    public var state: ProtoCRDTVersionedContainer {
-        get { return self._storage._state ?? ProtoCRDTVersionedContainer() }
-        set { _uniqueStorage()._state = newValue }
-    }
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    /// Returns true if `state` has been explicitly set.
-    public var hasState: Bool { return self._storage._state != nil }
-    /// Clears the value of `state`. Subsequent reads from it will return its default value.
-    public mutating func clearState() { _uniqueStorage()._state = nil }
+  public init() {}
 
-    public var unknownFields = SwiftProtobuf.UnknownStorage()
-
-    public init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 extension ProtoCRDTIdentity: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    public static let protoMessageName: String = "CRDTIdentity"
-    public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "id"),
-    ]
+  public static let protoMessageName: String = "CRDTIdentity"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "id"),
+  ]
 
-    public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        while let fieldNumber = try decoder.nextFieldNumber() {
-            switch fieldNumber {
-            case 1: try decoder.decodeSingularStringField(value: &self.id)
-            default: break
-            }
-        }
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self.id)
+      default: break
+      }
     }
+  }
 
-    public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        if !self.id.isEmpty {
-            try visitor.visitSingularStringField(value: self.id, fieldNumber: 1)
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.id.isEmpty {
+      try visitor.visitSingularStringField(value: self.id, fieldNumber: 1)
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    public static func == (lhs: ProtoCRDTIdentity, rhs: ProtoCRDTIdentity) -> Bool {
-        if lhs.id != rhs.id { return false }
-        if lhs.unknownFields != rhs.unknownFields { return false }
-        return true
-    }
+  public static func ==(lhs: ProtoCRDTIdentity, rhs: ProtoCRDTIdentity) -> Bool {
+    if lhs.id != rhs.id {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoCRDTVersionContext: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    public static let protoMessageName: String = "CRDTVersionContext"
-    public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "versionVector"),
-        2: .same(proto: "gaps"),
-    ]
+  public static let protoMessageName: String = "CRDTVersionContext"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "versionVector"),
+    2: .same(proto: "gaps"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _versionVector: ProtoVersionVector?
-        var _gaps: [ProtoVersionDot] = []
+  fileprivate class _StorageClass {
+    var _versionVector: ProtoVersionVector? = nil
+    var _gaps: [ProtoVersionDot] = []
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._versionVector = source._versionVector
-            self._gaps = source._gaps
-        }
+    init(copying source: _StorageClass) {
+      _versionVector = source._versionVector
+      _gaps = source._gaps
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularMessageField(value: &_storage._versionVector)
-                case 2: try decoder.decodeRepeatedMessageField(value: &_storage._gaps)
-                default: break
-                }
-            }
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularMessageField(value: &_storage._versionVector)
+        case 2: try decoder.decodeRepeatedMessageField(value: &_storage._gaps)
+        default: break
         }
+      }
     }
+  }
 
-    public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if let v = _storage._versionVector {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            }
-            if !_storage._gaps.isEmpty {
-                try visitor.visitRepeatedMessageField(value: _storage._gaps, fieldNumber: 2)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._versionVector {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+      if !_storage._gaps.isEmpty {
+        try visitor.visitRepeatedMessageField(value: _storage._gaps, fieldNumber: 2)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    public static func == (lhs: ProtoCRDTVersionContext, rhs: ProtoCRDTVersionContext) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._versionVector != rhs_storage._versionVector { return false }
-                if _storage._gaps != rhs_storage._gaps { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  public static func ==(lhs: ProtoCRDTVersionContext, rhs: ProtoCRDTVersionContext) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._versionVector != rhs_storage._versionVector {return false}
+        if _storage._gaps != rhs_storage._gaps {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoCRDTVersionedContainer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    public static let protoMessageName: String = "CRDTVersionedContainer"
-    public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "replicaId"),
-        2: .same(proto: "versionContext"),
-        3: .same(proto: "elementByBirthDot"),
-        4: .same(proto: "delta"),
-    ]
+  public static let protoMessageName: String = "CRDTVersionedContainer"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "replicaId"),
+    2: .same(proto: "versionContext"),
+    3: .same(proto: "elementByBirthDot"),
+    4: .same(proto: "delta"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _replicaID: ProtoVersionReplicaId?
-        var _versionContext: ProtoCRDTVersionContext?
-        var _elementByBirthDot: [ProtoVersionDottedElementEnvelope] = []
-        var _delta: ProtoCRDTVersionedContainerDelta?
+  fileprivate class _StorageClass {
+    var _replicaID: ProtoVersionReplicaId? = nil
+    var _versionContext: ProtoCRDTVersionContext? = nil
+    var _elementByBirthDot: [ProtoVersionDottedElementEnvelope] = []
+    var _delta: ProtoCRDTVersionedContainerDelta? = nil
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._replicaID = source._replicaID
-            self._versionContext = source._versionContext
-            self._elementByBirthDot = source._elementByBirthDot
-            self._delta = source._delta
-        }
+    init(copying source: _StorageClass) {
+      _replicaID = source._replicaID
+      _versionContext = source._versionContext
+      _elementByBirthDot = source._elementByBirthDot
+      _delta = source._delta
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularMessageField(value: &_storage._replicaID)
-                case 2: try decoder.decodeSingularMessageField(value: &_storage._versionContext)
-                case 3: try decoder.decodeRepeatedMessageField(value: &_storage._elementByBirthDot)
-                case 4: try decoder.decodeSingularMessageField(value: &_storage._delta)
-                default: break
-                }
-            }
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularMessageField(value: &_storage._replicaID)
+        case 2: try decoder.decodeSingularMessageField(value: &_storage._versionContext)
+        case 3: try decoder.decodeRepeatedMessageField(value: &_storage._elementByBirthDot)
+        case 4: try decoder.decodeSingularMessageField(value: &_storage._delta)
+        default: break
         }
+      }
     }
+  }
 
-    public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if let v = _storage._replicaID {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            }
-            if let v = _storage._versionContext {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-            }
-            if !_storage._elementByBirthDot.isEmpty {
-                try visitor.visitRepeatedMessageField(value: _storage._elementByBirthDot, fieldNumber: 3)
-            }
-            if let v = _storage._delta {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._replicaID {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+      if let v = _storage._versionContext {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      }
+      if !_storage._elementByBirthDot.isEmpty {
+        try visitor.visitRepeatedMessageField(value: _storage._elementByBirthDot, fieldNumber: 3)
+      }
+      if let v = _storage._delta {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    public static func == (lhs: ProtoCRDTVersionedContainer, rhs: ProtoCRDTVersionedContainer) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._replicaID != rhs_storage._replicaID { return false }
-                if _storage._versionContext != rhs_storage._versionContext { return false }
-                if _storage._elementByBirthDot != rhs_storage._elementByBirthDot { return false }
-                if _storage._delta != rhs_storage._delta { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  public static func ==(lhs: ProtoCRDTVersionedContainer, rhs: ProtoCRDTVersionedContainer) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._replicaID != rhs_storage._replicaID {return false}
+        if _storage._versionContext != rhs_storage._versionContext {return false}
+        if _storage._elementByBirthDot != rhs_storage._elementByBirthDot {return false}
+        if _storage._delta != rhs_storage._delta {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoCRDTVersionedContainerDelta: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    public static let protoMessageName: String = "CRDTVersionedContainerDelta"
-    public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "versionContext"),
-        2: .same(proto: "elementByBirthDot"),
-    ]
+  public static let protoMessageName: String = "CRDTVersionedContainerDelta"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "versionContext"),
+    2: .same(proto: "elementByBirthDot"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _versionContext: ProtoCRDTVersionContext?
-        var _elementByBirthDot: [ProtoVersionDottedElementEnvelope] = []
+  fileprivate class _StorageClass {
+    var _versionContext: ProtoCRDTVersionContext? = nil
+    var _elementByBirthDot: [ProtoVersionDottedElementEnvelope] = []
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._versionContext = source._versionContext
-            self._elementByBirthDot = source._elementByBirthDot
-        }
+    init(copying source: _StorageClass) {
+      _versionContext = source._versionContext
+      _elementByBirthDot = source._elementByBirthDot
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularMessageField(value: &_storage._versionContext)
-                case 2: try decoder.decodeRepeatedMessageField(value: &_storage._elementByBirthDot)
-                default: break
-                }
-            }
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularMessageField(value: &_storage._versionContext)
+        case 2: try decoder.decodeRepeatedMessageField(value: &_storage._elementByBirthDot)
+        default: break
         }
+      }
     }
+  }
 
-    public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if let v = _storage._versionContext {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            }
-            if !_storage._elementByBirthDot.isEmpty {
-                try visitor.visitRepeatedMessageField(value: _storage._elementByBirthDot, fieldNumber: 2)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._versionContext {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+      if !_storage._elementByBirthDot.isEmpty {
+        try visitor.visitRepeatedMessageField(value: _storage._elementByBirthDot, fieldNumber: 2)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    public static func == (lhs: ProtoCRDTVersionedContainerDelta, rhs: ProtoCRDTVersionedContainerDelta) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._versionContext != rhs_storage._versionContext { return false }
-                if _storage._elementByBirthDot != rhs_storage._elementByBirthDot { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  public static func ==(lhs: ProtoCRDTVersionedContainerDelta, rhs: ProtoCRDTVersionedContainerDelta) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._versionContext != rhs_storage._versionContext {return false}
+        if _storage._elementByBirthDot != rhs_storage._elementByBirthDot {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoCRDTGCounter: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    public static let protoMessageName: String = "CRDTGCounter"
-    public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "replicaId"),
-        2: .same(proto: "state"),
-        3: .same(proto: "delta"),
-    ]
+  public static let protoMessageName: String = "CRDTGCounter"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "replicaId"),
+    2: .same(proto: "state"),
+    3: .same(proto: "delta"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _replicaID: ProtoVersionReplicaId?
-        var _state: [ProtoCRDTGCounter.ReplicaState] = []
-        var _delta: ProtoCRDTGCounter.Delta?
+  fileprivate class _StorageClass {
+    var _replicaID: ProtoVersionReplicaId? = nil
+    var _state: [ProtoCRDTGCounter.ReplicaState] = []
+    var _delta: ProtoCRDTGCounter.Delta? = nil
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._replicaID = source._replicaID
-            self._state = source._state
-            self._delta = source._delta
-        }
+    init(copying source: _StorageClass) {
+      _replicaID = source._replicaID
+      _state = source._state
+      _delta = source._delta
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularMessageField(value: &_storage._replicaID)
-                case 2: try decoder.decodeRepeatedMessageField(value: &_storage._state)
-                case 3: try decoder.decodeSingularMessageField(value: &_storage._delta)
-                default: break
-                }
-            }
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularMessageField(value: &_storage._replicaID)
+        case 2: try decoder.decodeRepeatedMessageField(value: &_storage._state)
+        case 3: try decoder.decodeSingularMessageField(value: &_storage._delta)
+        default: break
         }
+      }
     }
+  }
 
-    public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if let v = _storage._replicaID {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            }
-            if !_storage._state.isEmpty {
-                try visitor.visitRepeatedMessageField(value: _storage._state, fieldNumber: 2)
-            }
-            if let v = _storage._delta {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._replicaID {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+      if !_storage._state.isEmpty {
+        try visitor.visitRepeatedMessageField(value: _storage._state, fieldNumber: 2)
+      }
+      if let v = _storage._delta {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    public static func == (lhs: ProtoCRDTGCounter, rhs: ProtoCRDTGCounter) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._replicaID != rhs_storage._replicaID { return false }
-                if _storage._state != rhs_storage._state { return false }
-                if _storage._delta != rhs_storage._delta { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  public static func ==(lhs: ProtoCRDTGCounter, rhs: ProtoCRDTGCounter) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._replicaID != rhs_storage._replicaID {return false}
+        if _storage._state != rhs_storage._state {return false}
+        if _storage._delta != rhs_storage._delta {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoCRDTGCounter.ReplicaState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    public static let protoMessageName: String = ProtoCRDTGCounter.protoMessageName + ".ReplicaState"
-    public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "replicaId"),
-        2: .same(proto: "count"),
-    ]
+  public static let protoMessageName: String = ProtoCRDTGCounter.protoMessageName + ".ReplicaState"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "replicaId"),
+    2: .same(proto: "count"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _replicaID: ProtoVersionReplicaId?
-        var _count: UInt64 = 0
+  fileprivate class _StorageClass {
+    var _replicaID: ProtoVersionReplicaId? = nil
+    var _count: UInt64 = 0
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._replicaID = source._replicaID
-            self._count = source._count
-        }
+    init(copying source: _StorageClass) {
+      _replicaID = source._replicaID
+      _count = source._count
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularMessageField(value: &_storage._replicaID)
-                case 2: try decoder.decodeSingularUInt64Field(value: &_storage._count)
-                default: break
-                }
-            }
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularMessageField(value: &_storage._replicaID)
+        case 2: try decoder.decodeSingularUInt64Field(value: &_storage._count)
+        default: break
         }
+      }
     }
+  }
 
-    public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if let v = _storage._replicaID {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            }
-            if _storage._count != 0 {
-                try visitor.visitSingularUInt64Field(value: _storage._count, fieldNumber: 2)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._replicaID {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+      if _storage._count != 0 {
+        try visitor.visitSingularUInt64Field(value: _storage._count, fieldNumber: 2)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    public static func == (lhs: ProtoCRDTGCounter.ReplicaState, rhs: ProtoCRDTGCounter.ReplicaState) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._replicaID != rhs_storage._replicaID { return false }
-                if _storage._count != rhs_storage._count { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  public static func ==(lhs: ProtoCRDTGCounter.ReplicaState, rhs: ProtoCRDTGCounter.ReplicaState) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._replicaID != rhs_storage._replicaID {return false}
+        if _storage._count != rhs_storage._count {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoCRDTGCounter.Delta: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    public static let protoMessageName: String = ProtoCRDTGCounter.protoMessageName + ".Delta"
-    public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "state"),
-    ]
+  public static let protoMessageName: String = ProtoCRDTGCounter.protoMessageName + ".Delta"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "state"),
+  ]
 
-    public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        while let fieldNumber = try decoder.nextFieldNumber() {
-            switch fieldNumber {
-            case 1: try decoder.decodeRepeatedMessageField(value: &self.state)
-            default: break
-            }
-        }
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeRepeatedMessageField(value: &self.state)
+      default: break
+      }
     }
+  }
 
-    public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        if !self.state.isEmpty {
-            try visitor.visitRepeatedMessageField(value: self.state, fieldNumber: 1)
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.state.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.state, fieldNumber: 1)
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    public static func == (lhs: ProtoCRDTGCounter.Delta, rhs: ProtoCRDTGCounter.Delta) -> Bool {
-        if lhs.state != rhs.state { return false }
-        if lhs.unknownFields != rhs.unknownFields { return false }
-        return true
-    }
+  public static func ==(lhs: ProtoCRDTGCounter.Delta, rhs: ProtoCRDTGCounter.Delta) -> Bool {
+    if lhs.state != rhs.state {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoCRDTORSet: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    public static let protoMessageName: String = "CRDTORSet"
-    public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "replicaId"),
-        2: .same(proto: "state"),
-    ]
+  public static let protoMessageName: String = "CRDTORSet"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "replicaId"),
+    2: .same(proto: "state"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _replicaID: ProtoVersionReplicaId?
-        var _state: ProtoCRDTVersionedContainer?
+  fileprivate class _StorageClass {
+    var _replicaID: ProtoVersionReplicaId? = nil
+    var _state: ProtoCRDTVersionedContainer? = nil
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._replicaID = source._replicaID
-            self._state = source._state
-        }
+    init(copying source: _StorageClass) {
+      _replicaID = source._replicaID
+      _state = source._state
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularMessageField(value: &_storage._replicaID)
-                case 2: try decoder.decodeSingularMessageField(value: &_storage._state)
-                default: break
-                }
-            }
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularMessageField(value: &_storage._replicaID)
+        case 2: try decoder.decodeSingularMessageField(value: &_storage._state)
+        default: break
         }
+      }
     }
+  }
 
-    public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if let v = _storage._replicaID {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            }
-            if let v = _storage._state {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._replicaID {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+      if let v = _storage._state {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    public static func == (lhs: ProtoCRDTORSet, rhs: ProtoCRDTORSet) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._replicaID != rhs_storage._replicaID { return false }
-                if _storage._state != rhs_storage._state { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  public static func ==(lhs: ProtoCRDTORSet, rhs: ProtoCRDTORSet) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._replicaID != rhs_storage._replicaID {return false}
+        if _storage._state != rhs_storage._state {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }

--- a/Sources/DistributedActors/CRDT/Protobuf/CRDTReplication.pb.swift
+++ b/Sources/DistributedActors/CRDT/Protobuf/CRDTReplication.pb.swift
@@ -28,584 +28,583 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that your are building against the same version of the API
 // that was used to generate this file.
-private struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-    struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
-    typealias Version = _2
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct ProtoCRDTEnvelope {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var boxed: ProtoCRDTEnvelope.Boxed = .anyCvrdt
+  var boxed: ProtoCRDTEnvelope.Boxed = .anyCvrdt
 
-    var serializerID: UInt32 = 0
+  var serializerID: UInt32 = 0
 
-    var payload: Data = SwiftProtobuf.Internal.emptyData
+  var payload: Data = SwiftProtobuf.Internal.emptyData
 
-    var unknownFields = SwiftProtobuf.UnknownStorage()
+  var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    enum Boxed: SwiftProtobuf.Enum {
-        typealias RawValue = Int
+  enum Boxed: SwiftProtobuf.Enum {
+    typealias RawValue = Int
 
-        //// Box as `AnyCvRDT` when deserializing
-        case anyCvrdt // = 0
+    //// Box as `AnyCvRDT` when deserializing
+    case anyCvrdt // = 0
 
-        //// Box as `AnyDeltaCRDT` when deserializing
-        case anyDeltaCrdt // = 1
-        case UNRECOGNIZED(Int)
+    //// Box as `AnyDeltaCRDT` when deserializing
+    case anyDeltaCrdt // = 1
+    case UNRECOGNIZED(Int)
 
-        init() {
-            self = .anyCvrdt
-        }
-
-        init?(rawValue: Int) {
-            switch rawValue {
-            case 0: self = .anyCvrdt
-            case 1: self = .anyDeltaCrdt
-            default: self = .UNRECOGNIZED(rawValue)
-            }
-        }
-
-        var rawValue: Int {
-            switch self {
-            case .anyCvrdt: return 0
-            case .anyDeltaCrdt: return 1
-            case .UNRECOGNIZED(let i): return i
-            }
-        }
+    init() {
+      self = .anyCvrdt
     }
 
-    init() {}
+    init?(rawValue: Int) {
+      switch rawValue {
+      case 0: self = .anyCvrdt
+      case 1: self = .anyDeltaCrdt
+      default: self = .UNRECOGNIZED(rawValue)
+      }
+    }
+
+    var rawValue: Int {
+      switch self {
+      case .anyCvrdt: return 0
+      case .anyDeltaCrdt: return 1
+      case .UNRECOGNIZED(let i): return i
+      }
+    }
+
+  }
+
+  init() {}
 }
 
 #if swift(>=4.2)
 
 extension ProtoCRDTEnvelope.Boxed: CaseIterable {
-    // The compiler won't synthesize support with the UNRECOGNIZED case.
-    static var allCases: [ProtoCRDTEnvelope.Boxed] = [
-        .anyCvrdt,
-        .anyDeltaCrdt,
-    ]
+  // The compiler won't synthesize support with the UNRECOGNIZED case.
+  static var allCases: [ProtoCRDTEnvelope.Boxed] = [
+    .anyCvrdt,
+    .anyDeltaCrdt,
+  ]
 }
 
-#endif // swift(>=4.2)
+#endif  // swift(>=4.2)
 
 struct ProtoCRDTReplicatorMessage {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var value: OneOf_Value? {
-        get { return self._storage._value }
-        set { _uniqueStorage()._value = newValue }
+  var value: OneOf_Value? {
+    get {return _storage._value}
+    set {_uniqueStorage()._value = newValue}
+  }
+
+  var write: ProtoCRDTWrite {
+    get {
+      if case .write(let v)? = _storage._value {return v}
+      return ProtoCRDTWrite()
     }
+    set {_uniqueStorage()._value = .write(newValue)}
+  }
 
-    var write: ProtoCRDTWrite {
-        get {
-            if case .write(let v)? = self._storage._value { return v }
-            return ProtoCRDTWrite()
-        }
-        set { _uniqueStorage()._value = .write(newValue) }
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  enum OneOf_Value: Equatable {
+    case write(ProtoCRDTWrite)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtoCRDTReplicatorMessage.OneOf_Value, rhs: ProtoCRDTReplicatorMessage.OneOf_Value) -> Bool {
+      switch (lhs, rhs) {
+      case (.write(let l), .write(let r)): return l == r
+      }
     }
+  #endif
+  }
 
-    var unknownFields = SwiftProtobuf.UnknownStorage()
+  init() {}
 
-    enum OneOf_Value: Equatable {
-        case write(ProtoCRDTWrite)
-
-        #if !swift(>=4.1)
-        static func == (lhs: ProtoCRDTReplicatorMessage.OneOf_Value, rhs: ProtoCRDTReplicatorMessage.OneOf_Value) -> Bool {
-            switch (lhs, rhs) {
-            case (.write(let l), .write(let r)): return l == r
-            }
-        }
-        #endif
-    }
-
-    init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 struct ProtoCRDTWrite {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var identity: ProtoCRDTIdentity {
-        get { return self._storage._identity ?? ProtoCRDTIdentity() }
-        set { _uniqueStorage()._identity = newValue }
-    }
+  var identity: ProtoCRDTIdentity {
+    get {return _storage._identity ?? ProtoCRDTIdentity()}
+    set {_uniqueStorage()._identity = newValue}
+  }
+  /// Returns true if `identity` has been explicitly set.
+  var hasIdentity: Bool {return _storage._identity != nil}
+  /// Clears the value of `identity`. Subsequent reads from it will return its default value.
+  mutating func clearIdentity() {_uniqueStorage()._identity = nil}
 
-    /// Returns true if `identity` has been explicitly set.
-    var hasIdentity: Bool { return _storage._identity != nil }
-    /// Clears the value of `identity`. Subsequent reads from it will return its default value.
-    mutating func clearIdentity() { _uniqueStorage()._identity = nil }
+  var envelope: ProtoCRDTEnvelope {
+    get {return _storage._envelope ?? ProtoCRDTEnvelope()}
+    set {_uniqueStorage()._envelope = newValue}
+  }
+  /// Returns true if `envelope` has been explicitly set.
+  var hasEnvelope: Bool {return _storage._envelope != nil}
+  /// Clears the value of `envelope`. Subsequent reads from it will return its default value.
+  mutating func clearEnvelope() {_uniqueStorage()._envelope = nil}
 
-    var envelope: ProtoCRDTEnvelope {
-        get { return self._storage._envelope ?? ProtoCRDTEnvelope() }
-        set { _uniqueStorage()._envelope = newValue }
-    }
+  var replyTo: ProtoActorAddress {
+    get {return _storage._replyTo ?? ProtoActorAddress()}
+    set {_uniqueStorage()._replyTo = newValue}
+  }
+  /// Returns true if `replyTo` has been explicitly set.
+  var hasReplyTo: Bool {return _storage._replyTo != nil}
+  /// Clears the value of `replyTo`. Subsequent reads from it will return its default value.
+  mutating func clearReplyTo() {_uniqueStorage()._replyTo = nil}
 
-    /// Returns true if `envelope` has been explicitly set.
-    var hasEnvelope: Bool { return _storage._envelope != nil }
-    /// Clears the value of `envelope`. Subsequent reads from it will return its default value.
-    mutating func clearEnvelope() { _uniqueStorage()._envelope = nil }
+  var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    var replyTo: ProtoActorAddress {
-        get { return self._storage._replyTo ?? ProtoActorAddress() }
-        set { _uniqueStorage()._replyTo = newValue }
-    }
+  init() {}
 
-    /// Returns true if `replyTo` has been explicitly set.
-    var hasReplyTo: Bool { return _storage._replyTo != nil }
-    /// Clears the value of `replyTo`. Subsequent reads from it will return its default value.
-    mutating func clearReplyTo() { _uniqueStorage()._replyTo = nil }
-
-    var unknownFields = SwiftProtobuf.UnknownStorage()
-
-    init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 struct ProtoCRDTWriteResult {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var type: ProtoCRDTWriteResult.TypeEnum {
-        get { return self._storage._type }
-        set { _uniqueStorage()._type = newValue }
+  var type: ProtoCRDTWriteResult.TypeEnum {
+    get {return _storage._type}
+    set {_uniqueStorage()._type = newValue}
+  }
+
+  var error: ProtoCRDTWriteError {
+    get {return _storage._error ?? ProtoCRDTWriteError()}
+    set {_uniqueStorage()._error = newValue}
+  }
+  /// Returns true if `error` has been explicitly set.
+  var hasError: Bool {return _storage._error != nil}
+  /// Clears the value of `error`. Subsequent reads from it will return its default value.
+  mutating func clearError() {_uniqueStorage()._error = nil}
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  enum TypeEnum: SwiftProtobuf.Enum {
+    typealias RawValue = Int
+    case success // = 0
+    case failed // = 1
+    case UNRECOGNIZED(Int)
+
+    init() {
+      self = .success
     }
 
-    var error: ProtoCRDTWriteError {
-        get { return self._storage._error ?? ProtoCRDTWriteError() }
-        set { _uniqueStorage()._error = newValue }
+    init?(rawValue: Int) {
+      switch rawValue {
+      case 0: self = .success
+      case 1: self = .failed
+      default: self = .UNRECOGNIZED(rawValue)
+      }
     }
 
-    /// Returns true if `error` has been explicitly set.
-    var hasError: Bool { return _storage._error != nil }
-    /// Clears the value of `error`. Subsequent reads from it will return its default value.
-    mutating func clearError() { _uniqueStorage()._error = nil }
-
-    var unknownFields = SwiftProtobuf.UnknownStorage()
-
-    enum TypeEnum: SwiftProtobuf.Enum {
-        typealias RawValue = Int
-        case success // = 0
-        case failed // = 1
-        case UNRECOGNIZED(Int)
-
-        init() {
-            self = .success
-        }
-
-        init?(rawValue: Int) {
-            switch rawValue {
-            case 0: self = .success
-            case 1: self = .failed
-            default: self = .UNRECOGNIZED(rawValue)
-            }
-        }
-
-        var rawValue: Int {
-            switch self {
-            case .success: return 0
-            case .failed: return 1
-            case .UNRECOGNIZED(let i): return i
-            }
-        }
+    var rawValue: Int {
+      switch self {
+      case .success: return 0
+      case .failed: return 1
+      case .UNRECOGNIZED(let i): return i
+      }
     }
 
-    init() {}
+  }
 
-    fileprivate var _storage = _StorageClass.defaultInstance
+  init() {}
+
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 #if swift(>=4.2)
 
 extension ProtoCRDTWriteResult.TypeEnum: CaseIterable {
-    // The compiler won't synthesize support with the UNRECOGNIZED case.
-    static var allCases: [ProtoCRDTWriteResult.TypeEnum] = [
-        .success,
-        .failed,
-    ]
+  // The compiler won't synthesize support with the UNRECOGNIZED case.
+  static var allCases: [ProtoCRDTWriteResult.TypeEnum] = [
+    .success,
+    .failed,
+  ]
 }
 
-#endif // swift(>=4.2)
+#endif  // swift(>=4.2)
 
 struct ProtoCRDTWriteError {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var type: ProtoCRDTWriteError.TypeEnum = .missingCrdtForDelta
+  var type: ProtoCRDTWriteError.TypeEnum = .missingCrdtForDelta
 
-    var unknownFields = SwiftProtobuf.UnknownStorage()
+  var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    enum TypeEnum: SwiftProtobuf.Enum {
-        typealias RawValue = Int
-        case missingCrdtForDelta // = 0
-        case incorrectDeltaType // = 1
-        case cannotWriteDeltaForNonDeltaCrdt // = 2
-        case inputAndStoredDataTypeMismatch // = 3
-        case unsupportedCrdt // = 4
-        case UNRECOGNIZED(Int)
+  enum TypeEnum: SwiftProtobuf.Enum {
+    typealias RawValue = Int
+    case missingCrdtForDelta // = 0
+    case incorrectDeltaType // = 1
+    case cannotWriteDeltaForNonDeltaCrdt // = 2
+    case inputAndStoredDataTypeMismatch // = 3
+    case unsupportedCrdt // = 4
+    case UNRECOGNIZED(Int)
 
-        init() {
-            self = .missingCrdtForDelta
-        }
-
-        init?(rawValue: Int) {
-            switch rawValue {
-            case 0: self = .missingCrdtForDelta
-            case 1: self = .incorrectDeltaType
-            case 2: self = .cannotWriteDeltaForNonDeltaCrdt
-            case 3: self = .inputAndStoredDataTypeMismatch
-            case 4: self = .unsupportedCrdt
-            default: self = .UNRECOGNIZED(rawValue)
-            }
-        }
-
-        var rawValue: Int {
-            switch self {
-            case .missingCrdtForDelta: return 0
-            case .incorrectDeltaType: return 1
-            case .cannotWriteDeltaForNonDeltaCrdt: return 2
-            case .inputAndStoredDataTypeMismatch: return 3
-            case .unsupportedCrdt: return 4
-            case .UNRECOGNIZED(let i): return i
-            }
-        }
+    init() {
+      self = .missingCrdtForDelta
     }
 
-    init() {}
+    init?(rawValue: Int) {
+      switch rawValue {
+      case 0: self = .missingCrdtForDelta
+      case 1: self = .incorrectDeltaType
+      case 2: self = .cannotWriteDeltaForNonDeltaCrdt
+      case 3: self = .inputAndStoredDataTypeMismatch
+      case 4: self = .unsupportedCrdt
+      default: self = .UNRECOGNIZED(rawValue)
+      }
+    }
+
+    var rawValue: Int {
+      switch self {
+      case .missingCrdtForDelta: return 0
+      case .incorrectDeltaType: return 1
+      case .cannotWriteDeltaForNonDeltaCrdt: return 2
+      case .inputAndStoredDataTypeMismatch: return 3
+      case .unsupportedCrdt: return 4
+      case .UNRECOGNIZED(let i): return i
+      }
+    }
+
+  }
+
+  init() {}
 }
 
 #if swift(>=4.2)
 
 extension ProtoCRDTWriteError.TypeEnum: CaseIterable {
-    // The compiler won't synthesize support with the UNRECOGNIZED case.
-    static var allCases: [ProtoCRDTWriteError.TypeEnum] = [
-        .missingCrdtForDelta,
-        .incorrectDeltaType,
-        .cannotWriteDeltaForNonDeltaCrdt,
-        .inputAndStoredDataTypeMismatch,
-        .unsupportedCrdt,
-    ]
+  // The compiler won't synthesize support with the UNRECOGNIZED case.
+  static var allCases: [ProtoCRDTWriteError.TypeEnum] = [
+    .missingCrdtForDelta,
+    .incorrectDeltaType,
+    .cannotWriteDeltaForNonDeltaCrdt,
+    .inputAndStoredDataTypeMismatch,
+    .unsupportedCrdt,
+  ]
 }
 
-#endif // swift(>=4.2)
+#endif  // swift(>=4.2)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 extension ProtoCRDTEnvelope: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "CRDTEnvelope"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "boxed"),
-        2: .same(proto: "serializerId"),
-        3: .same(proto: "payload"),
-    ]
+  static let protoMessageName: String = "CRDTEnvelope"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "boxed"),
+    2: .same(proto: "serializerId"),
+    3: .same(proto: "payload"),
+  ]
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        while let fieldNumber = try decoder.nextFieldNumber() {
-            switch fieldNumber {
-            case 1: try decoder.decodeSingularEnumField(value: &self.boxed)
-            case 2: try decoder.decodeSingularUInt32Field(value: &self.serializerID)
-            case 3: try decoder.decodeSingularBytesField(value: &self.payload)
-            default: break
-            }
-        }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularEnumField(value: &self.boxed)
+      case 2: try decoder.decodeSingularUInt32Field(value: &self.serializerID)
+      case 3: try decoder.decodeSingularBytesField(value: &self.payload)
+      default: break
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        if self.boxed != .anyCvrdt {
-            try visitor.visitSingularEnumField(value: self.boxed, fieldNumber: 1)
-        }
-        if self.serializerID != 0 {
-            try visitor.visitSingularUInt32Field(value: self.serializerID, fieldNumber: 2)
-        }
-        if !self.payload.isEmpty {
-            try visitor.visitSingularBytesField(value: self.payload, fieldNumber: 3)
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.boxed != .anyCvrdt {
+      try visitor.visitSingularEnumField(value: self.boxed, fieldNumber: 1)
     }
+    if self.serializerID != 0 {
+      try visitor.visitSingularUInt32Field(value: self.serializerID, fieldNumber: 2)
+    }
+    if !self.payload.isEmpty {
+      try visitor.visitSingularBytesField(value: self.payload, fieldNumber: 3)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoCRDTEnvelope, rhs: ProtoCRDTEnvelope) -> Bool {
-        if lhs.boxed != rhs.boxed { return false }
-        if lhs.serializerID != rhs.serializerID { return false }
-        if lhs.payload != rhs.payload { return false }
-        if lhs.unknownFields != rhs.unknownFields { return false }
-        return true
-    }
+  static func ==(lhs: ProtoCRDTEnvelope, rhs: ProtoCRDTEnvelope) -> Bool {
+    if lhs.boxed != rhs.boxed {return false}
+    if lhs.serializerID != rhs.serializerID {return false}
+    if lhs.payload != rhs.payload {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoCRDTEnvelope.Boxed: SwiftProtobuf._ProtoNameProviding {
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        0: .same(proto: "ANY_CVRDT"),
-        1: .same(proto: "ANY_DELTA_CRDT"),
-    ]
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ANY_CVRDT"),
+    1: .same(proto: "ANY_DELTA_CRDT"),
+  ]
 }
 
 extension ProtoCRDTReplicatorMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "CRDTReplicatorMessage"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "write"),
-    ]
+  static let protoMessageName: String = "CRDTReplicatorMessage"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "write"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _value: ProtoCRDTReplicatorMessage.OneOf_Value?
+  fileprivate class _StorageClass {
+    var _value: ProtoCRDTReplicatorMessage.OneOf_Value?
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._value = source._value
-        }
+    init(copying source: _StorageClass) {
+      _value = source._value
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1:
-                    var v: ProtoCRDTWrite?
-                    if let current = _storage._value {
-                        try decoder.handleConflictingOneOf()
-                        if case .write(let m) = current { v = m }
-                    }
-                    try decoder.decodeSingularMessageField(value: &v)
-                    if let v = v { _storage._value = .write(v) }
-                default: break
-                }
-            }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1:
+          var v: ProtoCRDTWrite?
+          if let current = _storage._value {
+            try decoder.handleConflictingOneOf()
+            if case .write(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {_storage._value = .write(v)}
+        default: break
         }
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if case .write(let v)? = _storage._value {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if case .write(let v)? = _storage._value {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoCRDTReplicatorMessage, rhs: ProtoCRDTReplicatorMessage) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._value != rhs_storage._value { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  static func ==(lhs: ProtoCRDTReplicatorMessage, rhs: ProtoCRDTReplicatorMessage) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._value != rhs_storage._value {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoCRDTWrite: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "CRDTWrite"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "identity"),
-        2: .same(proto: "envelope"),
-        3: .same(proto: "replyTo"),
-    ]
+  static let protoMessageName: String = "CRDTWrite"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "identity"),
+    2: .same(proto: "envelope"),
+    3: .same(proto: "replyTo"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _identity: ProtoCRDTIdentity?
-        var _envelope: ProtoCRDTEnvelope?
-        var _replyTo: ProtoActorAddress?
+  fileprivate class _StorageClass {
+    var _identity: ProtoCRDTIdentity? = nil
+    var _envelope: ProtoCRDTEnvelope? = nil
+    var _replyTo: ProtoActorAddress? = nil
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._identity = source._identity
-            self._envelope = source._envelope
-            self._replyTo = source._replyTo
-        }
+    init(copying source: _StorageClass) {
+      _identity = source._identity
+      _envelope = source._envelope
+      _replyTo = source._replyTo
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularMessageField(value: &_storage._identity)
-                case 2: try decoder.decodeSingularMessageField(value: &_storage._envelope)
-                case 3: try decoder.decodeSingularMessageField(value: &_storage._replyTo)
-                default: break
-                }
-            }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularMessageField(value: &_storage._identity)
+        case 2: try decoder.decodeSingularMessageField(value: &_storage._envelope)
+        case 3: try decoder.decodeSingularMessageField(value: &_storage._replyTo)
+        default: break
         }
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if let v = _storage._identity {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            }
-            if let v = _storage._envelope {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-            }
-            if let v = _storage._replyTo {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._identity {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+      if let v = _storage._envelope {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      }
+      if let v = _storage._replyTo {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoCRDTWrite, rhs: ProtoCRDTWrite) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._identity != rhs_storage._identity { return false }
-                if _storage._envelope != rhs_storage._envelope { return false }
-                if _storage._replyTo != rhs_storage._replyTo { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  static func ==(lhs: ProtoCRDTWrite, rhs: ProtoCRDTWrite) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._identity != rhs_storage._identity {return false}
+        if _storage._envelope != rhs_storage._envelope {return false}
+        if _storage._replyTo != rhs_storage._replyTo {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoCRDTWriteResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "CRDTWriteResult"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "type"),
-        2: .same(proto: "error"),
-    ]
+  static let protoMessageName: String = "CRDTWriteResult"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "type"),
+    2: .same(proto: "error"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _type: ProtoCRDTWriteResult.TypeEnum = .success
-        var _error: ProtoCRDTWriteError?
+  fileprivate class _StorageClass {
+    var _type: ProtoCRDTWriteResult.TypeEnum = .success
+    var _error: ProtoCRDTWriteError? = nil
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._type = source._type
-            self._error = source._error
-        }
+    init(copying source: _StorageClass) {
+      _type = source._type
+      _error = source._error
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularEnumField(value: &_storage._type)
-                case 2: try decoder.decodeSingularMessageField(value: &_storage._error)
-                default: break
-                }
-            }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularEnumField(value: &_storage._type)
+        case 2: try decoder.decodeSingularMessageField(value: &_storage._error)
+        default: break
         }
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if _storage._type != .success {
-                try visitor.visitSingularEnumField(value: _storage._type, fieldNumber: 1)
-            }
-            if let v = _storage._error {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if _storage._type != .success {
+        try visitor.visitSingularEnumField(value: _storage._type, fieldNumber: 1)
+      }
+      if let v = _storage._error {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoCRDTWriteResult, rhs: ProtoCRDTWriteResult) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._type != rhs_storage._type { return false }
-                if _storage._error != rhs_storage._error { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  static func ==(lhs: ProtoCRDTWriteResult, rhs: ProtoCRDTWriteResult) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._type != rhs_storage._type {return false}
+        if _storage._error != rhs_storage._error {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoCRDTWriteResult.TypeEnum: SwiftProtobuf._ProtoNameProviding {
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        0: .same(proto: "SUCCESS"),
-        1: .same(proto: "FAILED"),
-    ]
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "SUCCESS"),
+    1: .same(proto: "FAILED"),
+  ]
 }
 
 extension ProtoCRDTWriteError: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "CRDTWriteError"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "type"),
-    ]
+  static let protoMessageName: String = "CRDTWriteError"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "type"),
+  ]
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        while let fieldNumber = try decoder.nextFieldNumber() {
-            switch fieldNumber {
-            case 1: try decoder.decodeSingularEnumField(value: &self.type)
-            default: break
-            }
-        }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularEnumField(value: &self.type)
+      default: break
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        if self.type != .missingCrdtForDelta {
-            try visitor.visitSingularEnumField(value: self.type, fieldNumber: 1)
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.type != .missingCrdtForDelta {
+      try visitor.visitSingularEnumField(value: self.type, fieldNumber: 1)
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoCRDTWriteError, rhs: ProtoCRDTWriteError) -> Bool {
-        if lhs.type != rhs.type { return false }
-        if lhs.unknownFields != rhs.unknownFields { return false }
-        return true
-    }
+  static func ==(lhs: ProtoCRDTWriteError, rhs: ProtoCRDTWriteError) -> Bool {
+    if lhs.type != rhs.type {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoCRDTWriteError.TypeEnum: SwiftProtobuf._ProtoNameProviding {
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        0: .same(proto: "MISSING_CRDT_FOR_DELTA"),
-        1: .same(proto: "INCORRECT_DELTA_TYPE"),
-        2: .same(proto: "CANNOT_WRITE_DELTA_FOR_NON_DELTA_CRDT"),
-        3: .same(proto: "INPUT_AND_STORED_DATA_TYPE_MISMATCH"),
-        4: .same(proto: "UNSUPPORTED_CRDT"),
-    ]
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "MISSING_CRDT_FOR_DELTA"),
+    1: .same(proto: "INCORRECT_DELTA_TYPE"),
+    2: .same(proto: "CANNOT_WRITE_DELTA_FOR_NON_DELTA_CRDT"),
+    3: .same(proto: "INPUT_AND_STORED_DATA_TYPE_MISMATCH"),
+    4: .same(proto: "UNSUPPORTED_CRDT"),
+  ]
 }

--- a/Sources/DistributedActors/Clocks/Protobuf/VersionVector.pb.swift
+++ b/Sources/DistributedActors/Clocks/Protobuf/VersionVector.pb.swift
@@ -28,459 +28,456 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that your are building against the same version of the API
 // that was used to generate this file.
-private struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-    struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
-    typealias Version = _2
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 public struct ProtoVersionReplicaId {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    public var value: OneOf_Value? {
-        get { return self._storage._value }
-        set { _uniqueStorage()._value = newValue }
+  public var value: OneOf_Value? {
+    get {return _storage._value}
+    set {_uniqueStorage()._value = newValue}
+  }
+
+  public var actorAddress: ProtoActorAddress {
+    get {
+      if case .actorAddress(let v)? = _storage._value {return v}
+      return ProtoActorAddress()
     }
+    set {_uniqueStorage()._value = .actorAddress(newValue)}
+  }
 
-    public var actorAddress: ProtoActorAddress {
-        get {
-            if case .actorAddress(let v)? = self._storage._value { return v }
-            return ProtoActorAddress()
-        }
-        set { _uniqueStorage()._value = .actorAddress(newValue) }
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public enum OneOf_Value: Equatable {
+    case actorAddress(ProtoActorAddress)
+
+  #if !swift(>=4.1)
+    public static func ==(lhs: ProtoVersionReplicaId.OneOf_Value, rhs: ProtoVersionReplicaId.OneOf_Value) -> Bool {
+      switch (lhs, rhs) {
+      case (.actorAddress(let l), .actorAddress(let r)): return l == r
+      }
     }
+  #endif
+  }
 
-    public var unknownFields = SwiftProtobuf.UnknownStorage()
+  public init() {}
 
-    public enum OneOf_Value: Equatable {
-        case actorAddress(ProtoActorAddress)
-
-        #if !swift(>=4.1)
-        public static func == (lhs: ProtoVersionReplicaId.OneOf_Value, rhs: ProtoVersionReplicaId.OneOf_Value) -> Bool {
-            switch (lhs, rhs) {
-            case (.actorAddress(let l), .actorAddress(let r)): return l == r
-            }
-        }
-        #endif
-    }
-
-    public init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 public struct ProtoReplicaVersion {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    public var replicaID: ProtoVersionReplicaId {
-        get { return self._storage._replicaID ?? ProtoVersionReplicaId() }
-        set { _uniqueStorage()._replicaID = newValue }
-    }
+  public var replicaID: ProtoVersionReplicaId {
+    get {return _storage._replicaID ?? ProtoVersionReplicaId()}
+    set {_uniqueStorage()._replicaID = newValue}
+  }
+  /// Returns true if `replicaID` has been explicitly set.
+  public var hasReplicaID: Bool {return _storage._replicaID != nil}
+  /// Clears the value of `replicaID`. Subsequent reads from it will return its default value.
+  public mutating func clearReplicaID() {_uniqueStorage()._replicaID = nil}
 
-    /// Returns true if `replicaID` has been explicitly set.
-    public var hasReplicaID: Bool { return self._storage._replicaID != nil }
-    /// Clears the value of `replicaID`. Subsequent reads from it will return its default value.
-    public mutating func clearReplicaID() { _uniqueStorage()._replicaID = nil }
+  public var version: UInt64 {
+    get {return _storage._version}
+    set {_uniqueStorage()._version = newValue}
+  }
 
-    public var version: UInt64 {
-        get { return self._storage._version }
-        set { _uniqueStorage()._version = newValue }
-    }
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public var unknownFields = SwiftProtobuf.UnknownStorage()
+  public init() {}
 
-    public init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 public struct ProtoVersionVector {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    /// Not a map since we cannot use `replicaId` as key
-    public var state: [ProtoReplicaVersion] = []
+  /// Not a map since we cannot use `replicaId` as key
+  public var state: [ProtoReplicaVersion] = []
 
-    public var unknownFields = SwiftProtobuf.UnknownStorage()
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public init() {}
+  public init() {}
 }
 
 public struct ProtoVersionDot {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    public var replicaID: ProtoVersionReplicaId {
-        get { return self._storage._replicaID ?? ProtoVersionReplicaId() }
-        set { _uniqueStorage()._replicaID = newValue }
-    }
+  public var replicaID: ProtoVersionReplicaId {
+    get {return _storage._replicaID ?? ProtoVersionReplicaId()}
+    set {_uniqueStorage()._replicaID = newValue}
+  }
+  /// Returns true if `replicaID` has been explicitly set.
+  public var hasReplicaID: Bool {return _storage._replicaID != nil}
+  /// Clears the value of `replicaID`. Subsequent reads from it will return its default value.
+  public mutating func clearReplicaID() {_uniqueStorage()._replicaID = nil}
 
-    /// Returns true if `replicaID` has been explicitly set.
-    public var hasReplicaID: Bool { return self._storage._replicaID != nil }
-    /// Clears the value of `replicaID`. Subsequent reads from it will return its default value.
-    public mutating func clearReplicaID() { _uniqueStorage()._replicaID = nil }
+  public var version: UInt64 {
+    get {return _storage._version}
+    set {_uniqueStorage()._version = newValue}
+  }
 
-    public var version: UInt64 {
-        get { return self._storage._version }
-        set { _uniqueStorage()._version = newValue }
-    }
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public var unknownFields = SwiftProtobuf.UnknownStorage()
+  public init() {}
 
-    public init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 /// A dot and its arbitrary, serialized element
 public struct ProtoVersionDottedElementEnvelope {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    public var dot: ProtoVersionDot {
-        get { return self._storage._dot ?? ProtoVersionDot() }
-        set { _uniqueStorage()._dot = newValue }
-    }
+  public var dot: ProtoVersionDot {
+    get {return _storage._dot ?? ProtoVersionDot()}
+    set {_uniqueStorage()._dot = newValue}
+  }
+  /// Returns true if `dot` has been explicitly set.
+  public var hasDot: Bool {return _storage._dot != nil}
+  /// Clears the value of `dot`. Subsequent reads from it will return its default value.
+  public mutating func clearDot() {_uniqueStorage()._dot = nil}
 
-    /// Returns true if `dot` has been explicitly set.
-    public var hasDot: Bool { return self._storage._dot != nil }
-    /// Clears the value of `dot`. Subsequent reads from it will return its default value.
-    public mutating func clearDot() { _uniqueStorage()._dot = nil }
+  /// ~~ element ~~
+  public var serializerID: UInt32 {
+    get {return _storage._serializerID}
+    set {_uniqueStorage()._serializerID = newValue}
+  }
 
-    /// ~~ element ~~
-    public var serializerID: UInt32 {
-        get { return self._storage._serializerID }
-        set { _uniqueStorage()._serializerID = newValue }
-    }
+  public var payload: Data {
+    get {return _storage._payload}
+    set {_uniqueStorage()._payload = newValue}
+  }
 
-    public var payload: Data {
-        get { return self._storage._payload }
-        set { _uniqueStorage()._payload = newValue }
-    }
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public var unknownFields = SwiftProtobuf.UnknownStorage()
+  public init() {}
 
-    public init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 extension ProtoVersionReplicaId: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    public static let protoMessageName: String = "VersionReplicaId"
-    public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "actorAddress"),
-    ]
+  public static let protoMessageName: String = "VersionReplicaId"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "actorAddress"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _value: ProtoVersionReplicaId.OneOf_Value?
+  fileprivate class _StorageClass {
+    var _value: ProtoVersionReplicaId.OneOf_Value?
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._value = source._value
-        }
+    init(copying source: _StorageClass) {
+      _value = source._value
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1:
-                    var v: ProtoActorAddress?
-                    if let current = _storage._value {
-                        try decoder.handleConflictingOneOf()
-                        if case .actorAddress(let m) = current { v = m }
-                    }
-                    try decoder.decodeSingularMessageField(value: &v)
-                    if let v = v { _storage._value = .actorAddress(v) }
-                default: break
-                }
-            }
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1:
+          var v: ProtoActorAddress?
+          if let current = _storage._value {
+            try decoder.handleConflictingOneOf()
+            if case .actorAddress(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {_storage._value = .actorAddress(v)}
+        default: break
         }
+      }
     }
+  }
 
-    public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if case .actorAddress(let v)? = _storage._value {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if case .actorAddress(let v)? = _storage._value {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    public static func == (lhs: ProtoVersionReplicaId, rhs: ProtoVersionReplicaId) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._value != rhs_storage._value { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  public static func ==(lhs: ProtoVersionReplicaId, rhs: ProtoVersionReplicaId) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._value != rhs_storage._value {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoReplicaVersion: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    public static let protoMessageName: String = "ReplicaVersion"
-    public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "replicaId"),
-        2: .same(proto: "version"),
-    ]
+  public static let protoMessageName: String = "ReplicaVersion"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "replicaId"),
+    2: .same(proto: "version"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _replicaID: ProtoVersionReplicaId?
-        var _version: UInt64 = 0
+  fileprivate class _StorageClass {
+    var _replicaID: ProtoVersionReplicaId? = nil
+    var _version: UInt64 = 0
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._replicaID = source._replicaID
-            self._version = source._version
-        }
+    init(copying source: _StorageClass) {
+      _replicaID = source._replicaID
+      _version = source._version
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularMessageField(value: &_storage._replicaID)
-                case 2: try decoder.decodeSingularUInt64Field(value: &_storage._version)
-                default: break
-                }
-            }
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularMessageField(value: &_storage._replicaID)
+        case 2: try decoder.decodeSingularUInt64Field(value: &_storage._version)
+        default: break
         }
+      }
     }
+  }
 
-    public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if let v = _storage._replicaID {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            }
-            if _storage._version != 0 {
-                try visitor.visitSingularUInt64Field(value: _storage._version, fieldNumber: 2)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._replicaID {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+      if _storage._version != 0 {
+        try visitor.visitSingularUInt64Field(value: _storage._version, fieldNumber: 2)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    public static func == (lhs: ProtoReplicaVersion, rhs: ProtoReplicaVersion) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._replicaID != rhs_storage._replicaID { return false }
-                if _storage._version != rhs_storage._version { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  public static func ==(lhs: ProtoReplicaVersion, rhs: ProtoReplicaVersion) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._replicaID != rhs_storage._replicaID {return false}
+        if _storage._version != rhs_storage._version {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoVersionVector: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    public static let protoMessageName: String = "VersionVector"
-    public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "state"),
-    ]
+  public static let protoMessageName: String = "VersionVector"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "state"),
+  ]
 
-    public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        while let fieldNumber = try decoder.nextFieldNumber() {
-            switch fieldNumber {
-            case 1: try decoder.decodeRepeatedMessageField(value: &self.state)
-            default: break
-            }
-        }
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeRepeatedMessageField(value: &self.state)
+      default: break
+      }
     }
+  }
 
-    public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        if !self.state.isEmpty {
-            try visitor.visitRepeatedMessageField(value: self.state, fieldNumber: 1)
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.state.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.state, fieldNumber: 1)
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    public static func == (lhs: ProtoVersionVector, rhs: ProtoVersionVector) -> Bool {
-        if lhs.state != rhs.state { return false }
-        if lhs.unknownFields != rhs.unknownFields { return false }
-        return true
-    }
+  public static func ==(lhs: ProtoVersionVector, rhs: ProtoVersionVector) -> Bool {
+    if lhs.state != rhs.state {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoVersionDot: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    public static let protoMessageName: String = "VersionDot"
-    public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "replicaId"),
-        2: .same(proto: "version"),
-    ]
+  public static let protoMessageName: String = "VersionDot"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "replicaId"),
+    2: .same(proto: "version"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _replicaID: ProtoVersionReplicaId?
-        var _version: UInt64 = 0
+  fileprivate class _StorageClass {
+    var _replicaID: ProtoVersionReplicaId? = nil
+    var _version: UInt64 = 0
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._replicaID = source._replicaID
-            self._version = source._version
-        }
+    init(copying source: _StorageClass) {
+      _replicaID = source._replicaID
+      _version = source._version
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularMessageField(value: &_storage._replicaID)
-                case 2: try decoder.decodeSingularUInt64Field(value: &_storage._version)
-                default: break
-                }
-            }
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularMessageField(value: &_storage._replicaID)
+        case 2: try decoder.decodeSingularUInt64Field(value: &_storage._version)
+        default: break
         }
+      }
     }
+  }
 
-    public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if let v = _storage._replicaID {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            }
-            if _storage._version != 0 {
-                try visitor.visitSingularUInt64Field(value: _storage._version, fieldNumber: 2)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._replicaID {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+      if _storage._version != 0 {
+        try visitor.visitSingularUInt64Field(value: _storage._version, fieldNumber: 2)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    public static func == (lhs: ProtoVersionDot, rhs: ProtoVersionDot) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._replicaID != rhs_storage._replicaID { return false }
-                if _storage._version != rhs_storage._version { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  public static func ==(lhs: ProtoVersionDot, rhs: ProtoVersionDot) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._replicaID != rhs_storage._replicaID {return false}
+        if _storage._version != rhs_storage._version {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoVersionDottedElementEnvelope: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    public static let protoMessageName: String = "VersionDottedElementEnvelope"
-    public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "dot"),
-        2: .same(proto: "serializerId"),
-        3: .same(proto: "payload"),
-    ]
+  public static let protoMessageName: String = "VersionDottedElementEnvelope"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "dot"),
+    2: .same(proto: "serializerId"),
+    3: .same(proto: "payload"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _dot: ProtoVersionDot?
-        var _serializerID: UInt32 = 0
-        var _payload: Data = SwiftProtobuf.Internal.emptyData
+  fileprivate class _StorageClass {
+    var _dot: ProtoVersionDot? = nil
+    var _serializerID: UInt32 = 0
+    var _payload: Data = SwiftProtobuf.Internal.emptyData
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._dot = source._dot
-            self._serializerID = source._serializerID
-            self._payload = source._payload
-        }
+    init(copying source: _StorageClass) {
+      _dot = source._dot
+      _serializerID = source._serializerID
+      _payload = source._payload
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularMessageField(value: &_storage._dot)
-                case 2: try decoder.decodeSingularUInt32Field(value: &_storage._serializerID)
-                case 3: try decoder.decodeSingularBytesField(value: &_storage._payload)
-                default: break
-                }
-            }
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularMessageField(value: &_storage._dot)
+        case 2: try decoder.decodeSingularUInt32Field(value: &_storage._serializerID)
+        case 3: try decoder.decodeSingularBytesField(value: &_storage._payload)
+        default: break
         }
+      }
     }
+  }
 
-    public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if let v = _storage._dot {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            }
-            if _storage._serializerID != 0 {
-                try visitor.visitSingularUInt32Field(value: _storage._serializerID, fieldNumber: 2)
-            }
-            if !_storage._payload.isEmpty {
-                try visitor.visitSingularBytesField(value: _storage._payload, fieldNumber: 3)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._dot {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+      if _storage._serializerID != 0 {
+        try visitor.visitSingularUInt32Field(value: _storage._serializerID, fieldNumber: 2)
+      }
+      if !_storage._payload.isEmpty {
+        try visitor.visitSingularBytesField(value: _storage._payload, fieldNumber: 3)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    public static func == (lhs: ProtoVersionDottedElementEnvelope, rhs: ProtoVersionDottedElementEnvelope) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._dot != rhs_storage._dot { return false }
-                if _storage._serializerID != rhs_storage._serializerID { return false }
-                if _storage._payload != rhs_storage._payload { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  public static func ==(lhs: ProtoVersionDottedElementEnvelope, rhs: ProtoVersionDottedElementEnvelope) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._dot != rhs_storage._dot {return false}
+        if _storage._serializerID != rhs_storage._serializerID {return false}
+        if _storage._payload != rhs_storage._payload {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }

--- a/Sources/DistributedActors/Cluster/SWIM/Protobuf/SWIM.pb.swift
+++ b/Sources/DistributedActors/Cluster/SWIM/Protobuf/SWIM.pb.swift
@@ -28,755 +28,745 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that your are building against the same version of the API
 // that was used to generate this file.
-private struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-    struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
-    typealias Version = _2
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct ProtoSWIMMessage {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var request: OneOf_Request? {
-        get { return self._storage._request }
-        set { _uniqueStorage()._request = newValue }
+  var request: OneOf_Request? {
+    get {return _storage._request}
+    set {_uniqueStorage()._request = newValue}
+  }
+
+  var ping: ProtoSWIMPing {
+    get {
+      if case .ping(let v)? = _storage._request {return v}
+      return ProtoSWIMPing()
     }
+    set {_uniqueStorage()._request = .ping(newValue)}
+  }
 
-    var ping: ProtoSWIMPing {
-        get {
-            if case .ping(let v)? = self._storage._request { return v }
-            return ProtoSWIMPing()
-        }
-        set { _uniqueStorage()._request = .ping(newValue) }
+  var pingRequest: ProtoSWIMPingRequest {
+    get {
+      if case .pingRequest(let v)? = _storage._request {return v}
+      return ProtoSWIMPingRequest()
     }
+    set {_uniqueStorage()._request = .pingRequest(newValue)}
+  }
 
-    var pingRequest: ProtoSWIMPingRequest {
-        get {
-            if case .pingRequest(let v)? = self._storage._request { return v }
-            return ProtoSWIMPingRequest()
-        }
-        set { _uniqueStorage()._request = .pingRequest(newValue) }
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  enum OneOf_Request: Equatable {
+    case ping(ProtoSWIMPing)
+    case pingRequest(ProtoSWIMPingRequest)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtoSWIMMessage.OneOf_Request, rhs: ProtoSWIMMessage.OneOf_Request) -> Bool {
+      switch (lhs, rhs) {
+      case (.ping(let l), .ping(let r)): return l == r
+      case (.pingRequest(let l), .pingRequest(let r)): return l == r
+      default: return false
+      }
     }
+  #endif
+  }
 
-    var unknownFields = SwiftProtobuf.UnknownStorage()
+  init() {}
 
-    enum OneOf_Request: Equatable {
-        case ping(ProtoSWIMPing)
-        case pingRequest(ProtoSWIMPingRequest)
-
-        #if !swift(>=4.1)
-        static func == (lhs: ProtoSWIMMessage.OneOf_Request, rhs: ProtoSWIMMessage.OneOf_Request) -> Bool {
-            switch (lhs, rhs) {
-            case (.ping(let l), .ping(let r)): return l == r
-            case (.pingRequest(let l), .pingRequest(let r)): return l == r
-            default: return false
-            }
-        }
-        #endif
-    }
-
-    init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 struct ProtoSWIMPing {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var lastKnownStatus: ProtoSWIMStatus {
-        get { return self._storage._lastKnownStatus ?? ProtoSWIMStatus() }
-        set { _uniqueStorage()._lastKnownStatus = newValue }
-    }
+  var lastKnownStatus: ProtoSWIMStatus {
+    get {return _storage._lastKnownStatus ?? ProtoSWIMStatus()}
+    set {_uniqueStorage()._lastKnownStatus = newValue}
+  }
+  /// Returns true if `lastKnownStatus` has been explicitly set.
+  var hasLastKnownStatus: Bool {return _storage._lastKnownStatus != nil}
+  /// Clears the value of `lastKnownStatus`. Subsequent reads from it will return its default value.
+  mutating func clearLastKnownStatus() {_uniqueStorage()._lastKnownStatus = nil}
 
-    /// Returns true if `lastKnownStatus` has been explicitly set.
-    var hasLastKnownStatus: Bool { return _storage._lastKnownStatus != nil }
-    /// Clears the value of `lastKnownStatus`. Subsequent reads from it will return its default value.
-    mutating func clearLastKnownStatus() { _uniqueStorage()._lastKnownStatus = nil }
+  var replyTo: ProtoActorAddress {
+    get {return _storage._replyTo ?? ProtoActorAddress()}
+    set {_uniqueStorage()._replyTo = newValue}
+  }
+  /// Returns true if `replyTo` has been explicitly set.
+  var hasReplyTo: Bool {return _storage._replyTo != nil}
+  /// Clears the value of `replyTo`. Subsequent reads from it will return its default value.
+  mutating func clearReplyTo() {_uniqueStorage()._replyTo = nil}
 
-    var replyTo: ProtoActorAddress {
-        get { return self._storage._replyTo ?? ProtoActorAddress() }
-        set { _uniqueStorage()._replyTo = newValue }
-    }
+  var payload: ProtoSWIMPayload {
+    get {return _storage._payload ?? ProtoSWIMPayload()}
+    set {_uniqueStorage()._payload = newValue}
+  }
+  /// Returns true if `payload` has been explicitly set.
+  var hasPayload: Bool {return _storage._payload != nil}
+  /// Clears the value of `payload`. Subsequent reads from it will return its default value.
+  mutating func clearPayload() {_uniqueStorage()._payload = nil}
 
-    /// Returns true if `replyTo` has been explicitly set.
-    var hasReplyTo: Bool { return _storage._replyTo != nil }
-    /// Clears the value of `replyTo`. Subsequent reads from it will return its default value.
-    mutating func clearReplyTo() { _uniqueStorage()._replyTo = nil }
+  var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    var payload: ProtoSWIMPayload {
-        get { return self._storage._payload ?? ProtoSWIMPayload() }
-        set { _uniqueStorage()._payload = newValue }
-    }
+  init() {}
 
-    /// Returns true if `payload` has been explicitly set.
-    var hasPayload: Bool { return _storage._payload != nil }
-    /// Clears the value of `payload`. Subsequent reads from it will return its default value.
-    mutating func clearPayload() { _uniqueStorage()._payload = nil }
-
-    var unknownFields = SwiftProtobuf.UnknownStorage()
-
-    init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 struct ProtoSWIMPingRequest {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var target: ProtoActorAddress {
-        get { return self._storage._target ?? ProtoActorAddress() }
-        set { _uniqueStorage()._target = newValue }
-    }
+  var target: ProtoActorAddress {
+    get {return _storage._target ?? ProtoActorAddress()}
+    set {_uniqueStorage()._target = newValue}
+  }
+  /// Returns true if `target` has been explicitly set.
+  var hasTarget: Bool {return _storage._target != nil}
+  /// Clears the value of `target`. Subsequent reads from it will return its default value.
+  mutating func clearTarget() {_uniqueStorage()._target = nil}
 
-    /// Returns true if `target` has been explicitly set.
-    var hasTarget: Bool { return _storage._target != nil }
-    /// Clears the value of `target`. Subsequent reads from it will return its default value.
-    mutating func clearTarget() { _uniqueStorage()._target = nil }
+  var lastKnownStatus: ProtoSWIMStatus {
+    get {return _storage._lastKnownStatus ?? ProtoSWIMStatus()}
+    set {_uniqueStorage()._lastKnownStatus = newValue}
+  }
+  /// Returns true if `lastKnownStatus` has been explicitly set.
+  var hasLastKnownStatus: Bool {return _storage._lastKnownStatus != nil}
+  /// Clears the value of `lastKnownStatus`. Subsequent reads from it will return its default value.
+  mutating func clearLastKnownStatus() {_uniqueStorage()._lastKnownStatus = nil}
 
-    var lastKnownStatus: ProtoSWIMStatus {
-        get { return self._storage._lastKnownStatus ?? ProtoSWIMStatus() }
-        set { _uniqueStorage()._lastKnownStatus = newValue }
-    }
+  var replyTo: ProtoActorAddress {
+    get {return _storage._replyTo ?? ProtoActorAddress()}
+    set {_uniqueStorage()._replyTo = newValue}
+  }
+  /// Returns true if `replyTo` has been explicitly set.
+  var hasReplyTo: Bool {return _storage._replyTo != nil}
+  /// Clears the value of `replyTo`. Subsequent reads from it will return its default value.
+  mutating func clearReplyTo() {_uniqueStorage()._replyTo = nil}
 
-    /// Returns true if `lastKnownStatus` has been explicitly set.
-    var hasLastKnownStatus: Bool { return _storage._lastKnownStatus != nil }
-    /// Clears the value of `lastKnownStatus`. Subsequent reads from it will return its default value.
-    mutating func clearLastKnownStatus() { _uniqueStorage()._lastKnownStatus = nil }
+  var payload: ProtoSWIMPayload {
+    get {return _storage._payload ?? ProtoSWIMPayload()}
+    set {_uniqueStorage()._payload = newValue}
+  }
+  /// Returns true if `payload` has been explicitly set.
+  var hasPayload: Bool {return _storage._payload != nil}
+  /// Clears the value of `payload`. Subsequent reads from it will return its default value.
+  mutating func clearPayload() {_uniqueStorage()._payload = nil}
 
-    var replyTo: ProtoActorAddress {
-        get { return self._storage._replyTo ?? ProtoActorAddress() }
-        set { _uniqueStorage()._replyTo = newValue }
-    }
+  var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    /// Returns true if `replyTo` has been explicitly set.
-    var hasReplyTo: Bool { return _storage._replyTo != nil }
-    /// Clears the value of `replyTo`. Subsequent reads from it will return its default value.
-    mutating func clearReplyTo() { _uniqueStorage()._replyTo = nil }
+  init() {}
 
-    var payload: ProtoSWIMPayload {
-        get { return self._storage._payload ?? ProtoSWIMPayload() }
-        set { _uniqueStorage()._payload = newValue }
-    }
-
-    /// Returns true if `payload` has been explicitly set.
-    var hasPayload: Bool { return _storage._payload != nil }
-    /// Clears the value of `payload`. Subsequent reads from it will return its default value.
-    mutating func clearPayload() { _uniqueStorage()._payload = nil }
-
-    var unknownFields = SwiftProtobuf.UnknownStorage()
-
-    init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 struct ProtoSWIMAck {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var pinged: ProtoActorAddress {
-        get { return self._storage._pinged ?? ProtoActorAddress() }
-        set { _uniqueStorage()._pinged = newValue }
-    }
+  var pinged: ProtoActorAddress {
+    get {return _storage._pinged ?? ProtoActorAddress()}
+    set {_uniqueStorage()._pinged = newValue}
+  }
+  /// Returns true if `pinged` has been explicitly set.
+  var hasPinged: Bool {return _storage._pinged != nil}
+  /// Clears the value of `pinged`. Subsequent reads from it will return its default value.
+  mutating func clearPinged() {_uniqueStorage()._pinged = nil}
 
-    /// Returns true if `pinged` has been explicitly set.
-    var hasPinged: Bool { return _storage._pinged != nil }
-    /// Clears the value of `pinged`. Subsequent reads from it will return its default value.
-    mutating func clearPinged() { _uniqueStorage()._pinged = nil }
+  var incarnation: UInt64 {
+    get {return _storage._incarnation}
+    set {_uniqueStorage()._incarnation = newValue}
+  }
 
-    var incarnation: UInt64 {
-        get { return self._storage._incarnation }
-        set { _uniqueStorage()._incarnation = newValue }
-    }
+  var payload: ProtoSWIMPayload {
+    get {return _storage._payload ?? ProtoSWIMPayload()}
+    set {_uniqueStorage()._payload = newValue}
+  }
+  /// Returns true if `payload` has been explicitly set.
+  var hasPayload: Bool {return _storage._payload != nil}
+  /// Clears the value of `payload`. Subsequent reads from it will return its default value.
+  mutating func clearPayload() {_uniqueStorage()._payload = nil}
 
-    var payload: ProtoSWIMPayload {
-        get { return self._storage._payload ?? ProtoSWIMPayload() }
-        set { _uniqueStorage()._payload = newValue }
-    }
+  var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    /// Returns true if `payload` has been explicitly set.
-    var hasPayload: Bool { return _storage._payload != nil }
-    /// Clears the value of `payload`. Subsequent reads from it will return its default value.
-    mutating func clearPayload() { _uniqueStorage()._payload = nil }
+  init() {}
 
-    var unknownFields = SwiftProtobuf.UnknownStorage()
-
-    init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 struct ProtoSWIMStatus {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var type: ProtoSWIMStatus.TypeEnum = .alive
+  var type: ProtoSWIMStatus.TypeEnum = .alive
 
-    var incarnation: UInt64 = 0
+  var incarnation: UInt64 = 0
 
-    var unknownFields = SwiftProtobuf.UnknownStorage()
+  var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    enum TypeEnum: SwiftProtobuf.Enum {
-        typealias RawValue = Int
-        case alive // = 0
-        case suspect // = 1
-        case unreachable // = 2
-        case dead // = 3
-        case UNRECOGNIZED(Int)
+  enum TypeEnum: SwiftProtobuf.Enum {
+    typealias RawValue = Int
+    case alive // = 0
+    case suspect // = 1
+    case unreachable // = 2
+    case dead // = 3
+    case UNRECOGNIZED(Int)
 
-        init() {
-            self = .alive
-        }
-
-        init?(rawValue: Int) {
-            switch rawValue {
-            case 0: self = .alive
-            case 1: self = .suspect
-            case 2: self = .unreachable
-            case 3: self = .dead
-            default: self = .UNRECOGNIZED(rawValue)
-            }
-        }
-
-        var rawValue: Int {
-            switch self {
-            case .alive: return 0
-            case .suspect: return 1
-            case .unreachable: return 2
-            case .dead: return 3
-            case .UNRECOGNIZED(let i): return i
-            }
-        }
+    init() {
+      self = .alive
     }
 
-    init() {}
+    init?(rawValue: Int) {
+      switch rawValue {
+      case 0: self = .alive
+      case 1: self = .suspect
+      case 2: self = .unreachable
+      case 3: self = .dead
+      default: self = .UNRECOGNIZED(rawValue)
+      }
+    }
+
+    var rawValue: Int {
+      switch self {
+      case .alive: return 0
+      case .suspect: return 1
+      case .unreachable: return 2
+      case .dead: return 3
+      case .UNRECOGNIZED(let i): return i
+      }
+    }
+
+  }
+
+  init() {}
 }
 
 #if swift(>=4.2)
 
 extension ProtoSWIMStatus.TypeEnum: CaseIterable {
-    // The compiler won't synthesize support with the UNRECOGNIZED case.
-    static var allCases: [ProtoSWIMStatus.TypeEnum] = [
-        .alive,
-        .suspect,
-        .unreachable,
-        .dead,
-    ]
+  // The compiler won't synthesize support with the UNRECOGNIZED case.
+  static var allCases: [ProtoSWIMStatus.TypeEnum] = [
+    .alive,
+    .suspect,
+    .unreachable,
+    .dead,
+  ]
 }
 
-#endif // swift(>=4.2)
+#endif  // swift(>=4.2)
 
 struct ProtoSWIMMember {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var address: ProtoActorAddress {
-        get { return self._storage._address ?? ProtoActorAddress() }
-        set { _uniqueStorage()._address = newValue }
-    }
+  var address: ProtoActorAddress {
+    get {return _storage._address ?? ProtoActorAddress()}
+    set {_uniqueStorage()._address = newValue}
+  }
+  /// Returns true if `address` has been explicitly set.
+  var hasAddress: Bool {return _storage._address != nil}
+  /// Clears the value of `address`. Subsequent reads from it will return its default value.
+  mutating func clearAddress() {_uniqueStorage()._address = nil}
 
-    /// Returns true if `address` has been explicitly set.
-    var hasAddress: Bool { return _storage._address != nil }
-    /// Clears the value of `address`. Subsequent reads from it will return its default value.
-    mutating func clearAddress() { _uniqueStorage()._address = nil }
+  var status: ProtoSWIMStatus {
+    get {return _storage._status ?? ProtoSWIMStatus()}
+    set {_uniqueStorage()._status = newValue}
+  }
+  /// Returns true if `status` has been explicitly set.
+  var hasStatus: Bool {return _storage._status != nil}
+  /// Clears the value of `status`. Subsequent reads from it will return its default value.
+  mutating func clearStatus() {_uniqueStorage()._status = nil}
 
-    var status: ProtoSWIMStatus {
-        get { return self._storage._status ?? ProtoSWIMStatus() }
-        set { _uniqueStorage()._status = newValue }
-    }
+  var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    /// Returns true if `status` has been explicitly set.
-    var hasStatus: Bool { return _storage._status != nil }
-    /// Clears the value of `status`. Subsequent reads from it will return its default value.
-    mutating func clearStatus() { _uniqueStorage()._status = nil }
+  init() {}
 
-    var unknownFields = SwiftProtobuf.UnknownStorage()
-
-    init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 struct ProtoSWIMPayload {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var member: [ProtoSWIMMember] = []
+  var member: [ProtoSWIMMember] = []
 
-    var unknownFields = SwiftProtobuf.UnknownStorage()
+  var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    init() {}
+  init() {}
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 extension ProtoSWIMMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "SWIMMessage"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "ping"),
-        2: .same(proto: "pingRequest"),
-    ]
+  static let protoMessageName: String = "SWIMMessage"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "ping"),
+    2: .same(proto: "pingRequest"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _request: ProtoSWIMMessage.OneOf_Request?
+  fileprivate class _StorageClass {
+    var _request: ProtoSWIMMessage.OneOf_Request?
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._request = source._request
-        }
+    init(copying source: _StorageClass) {
+      _request = source._request
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1:
-                    var v: ProtoSWIMPing?
-                    if let current = _storage._request {
-                        try decoder.handleConflictingOneOf()
-                        if case .ping(let m) = current { v = m }
-                    }
-                    try decoder.decodeSingularMessageField(value: &v)
-                    if let v = v { _storage._request = .ping(v) }
-                case 2:
-                    var v: ProtoSWIMPingRequest?
-                    if let current = _storage._request {
-                        try decoder.handleConflictingOneOf()
-                        if case .pingRequest(let m) = current { v = m }
-                    }
-                    try decoder.decodeSingularMessageField(value: &v)
-                    if let v = v { _storage._request = .pingRequest(v) }
-                default: break
-                }
-            }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1:
+          var v: ProtoSWIMPing?
+          if let current = _storage._request {
+            try decoder.handleConflictingOneOf()
+            if case .ping(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {_storage._request = .ping(v)}
+        case 2:
+          var v: ProtoSWIMPingRequest?
+          if let current = _storage._request {
+            try decoder.handleConflictingOneOf()
+            if case .pingRequest(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {_storage._request = .pingRequest(v)}
+        default: break
         }
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            switch _storage._request {
-            case .ping(let v)?:
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            case .pingRequest(let v)?:
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-            case nil: break
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      switch _storage._request {
+      case .ping(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      case .pingRequest(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      case nil: break
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoSWIMMessage, rhs: ProtoSWIMMessage) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._request != rhs_storage._request { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  static func ==(lhs: ProtoSWIMMessage, rhs: ProtoSWIMMessage) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._request != rhs_storage._request {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoSWIMPing: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "SWIMPing"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "lastKnownStatus"),
-        2: .same(proto: "replyTo"),
-        3: .same(proto: "payload"),
-    ]
+  static let protoMessageName: String = "SWIMPing"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "lastKnownStatus"),
+    2: .same(proto: "replyTo"),
+    3: .same(proto: "payload"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _lastKnownStatus: ProtoSWIMStatus?
-        var _replyTo: ProtoActorAddress?
-        var _payload: ProtoSWIMPayload?
+  fileprivate class _StorageClass {
+    var _lastKnownStatus: ProtoSWIMStatus? = nil
+    var _replyTo: ProtoActorAddress? = nil
+    var _payload: ProtoSWIMPayload? = nil
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._lastKnownStatus = source._lastKnownStatus
-            self._replyTo = source._replyTo
-            self._payload = source._payload
-        }
+    init(copying source: _StorageClass) {
+      _lastKnownStatus = source._lastKnownStatus
+      _replyTo = source._replyTo
+      _payload = source._payload
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularMessageField(value: &_storage._lastKnownStatus)
-                case 2: try decoder.decodeSingularMessageField(value: &_storage._replyTo)
-                case 3: try decoder.decodeSingularMessageField(value: &_storage._payload)
-                default: break
-                }
-            }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularMessageField(value: &_storage._lastKnownStatus)
+        case 2: try decoder.decodeSingularMessageField(value: &_storage._replyTo)
+        case 3: try decoder.decodeSingularMessageField(value: &_storage._payload)
+        default: break
         }
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if let v = _storage._lastKnownStatus {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            }
-            if let v = _storage._replyTo {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-            }
-            if let v = _storage._payload {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._lastKnownStatus {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+      if let v = _storage._replyTo {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      }
+      if let v = _storage._payload {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoSWIMPing, rhs: ProtoSWIMPing) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._lastKnownStatus != rhs_storage._lastKnownStatus { return false }
-                if _storage._replyTo != rhs_storage._replyTo { return false }
-                if _storage._payload != rhs_storage._payload { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  static func ==(lhs: ProtoSWIMPing, rhs: ProtoSWIMPing) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._lastKnownStatus != rhs_storage._lastKnownStatus {return false}
+        if _storage._replyTo != rhs_storage._replyTo {return false}
+        if _storage._payload != rhs_storage._payload {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoSWIMPingRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "SWIMPingRequest"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "target"),
-        2: .same(proto: "lastKnownStatus"),
-        3: .same(proto: "replyTo"),
-        4: .same(proto: "payload"),
-    ]
+  static let protoMessageName: String = "SWIMPingRequest"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "target"),
+    2: .same(proto: "lastKnownStatus"),
+    3: .same(proto: "replyTo"),
+    4: .same(proto: "payload"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _target: ProtoActorAddress?
-        var _lastKnownStatus: ProtoSWIMStatus?
-        var _replyTo: ProtoActorAddress?
-        var _payload: ProtoSWIMPayload?
+  fileprivate class _StorageClass {
+    var _target: ProtoActorAddress? = nil
+    var _lastKnownStatus: ProtoSWIMStatus? = nil
+    var _replyTo: ProtoActorAddress? = nil
+    var _payload: ProtoSWIMPayload? = nil
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._target = source._target
-            self._lastKnownStatus = source._lastKnownStatus
-            self._replyTo = source._replyTo
-            self._payload = source._payload
-        }
+    init(copying source: _StorageClass) {
+      _target = source._target
+      _lastKnownStatus = source._lastKnownStatus
+      _replyTo = source._replyTo
+      _payload = source._payload
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularMessageField(value: &_storage._target)
-                case 2: try decoder.decodeSingularMessageField(value: &_storage._lastKnownStatus)
-                case 3: try decoder.decodeSingularMessageField(value: &_storage._replyTo)
-                case 4: try decoder.decodeSingularMessageField(value: &_storage._payload)
-                default: break
-                }
-            }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularMessageField(value: &_storage._target)
+        case 2: try decoder.decodeSingularMessageField(value: &_storage._lastKnownStatus)
+        case 3: try decoder.decodeSingularMessageField(value: &_storage._replyTo)
+        case 4: try decoder.decodeSingularMessageField(value: &_storage._payload)
+        default: break
         }
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if let v = _storage._target {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            }
-            if let v = _storage._lastKnownStatus {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-            }
-            if let v = _storage._replyTo {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-            }
-            if let v = _storage._payload {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._target {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+      if let v = _storage._lastKnownStatus {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      }
+      if let v = _storage._replyTo {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      }
+      if let v = _storage._payload {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoSWIMPingRequest, rhs: ProtoSWIMPingRequest) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._target != rhs_storage._target { return false }
-                if _storage._lastKnownStatus != rhs_storage._lastKnownStatus { return false }
-                if _storage._replyTo != rhs_storage._replyTo { return false }
-                if _storage._payload != rhs_storage._payload { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  static func ==(lhs: ProtoSWIMPingRequest, rhs: ProtoSWIMPingRequest) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._target != rhs_storage._target {return false}
+        if _storage._lastKnownStatus != rhs_storage._lastKnownStatus {return false}
+        if _storage._replyTo != rhs_storage._replyTo {return false}
+        if _storage._payload != rhs_storage._payload {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoSWIMAck: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "SWIMAck"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "pinged"),
-        2: .same(proto: "incarnation"),
-        3: .same(proto: "payload"),
-    ]
+  static let protoMessageName: String = "SWIMAck"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "pinged"),
+    2: .same(proto: "incarnation"),
+    3: .same(proto: "payload"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _pinged: ProtoActorAddress?
-        var _incarnation: UInt64 = 0
-        var _payload: ProtoSWIMPayload?
+  fileprivate class _StorageClass {
+    var _pinged: ProtoActorAddress? = nil
+    var _incarnation: UInt64 = 0
+    var _payload: ProtoSWIMPayload? = nil
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._pinged = source._pinged
-            self._incarnation = source._incarnation
-            self._payload = source._payload
-        }
+    init(copying source: _StorageClass) {
+      _pinged = source._pinged
+      _incarnation = source._incarnation
+      _payload = source._payload
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularMessageField(value: &_storage._pinged)
-                case 2: try decoder.decodeSingularUInt64Field(value: &_storage._incarnation)
-                case 3: try decoder.decodeSingularMessageField(value: &_storage._payload)
-                default: break
-                }
-            }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularMessageField(value: &_storage._pinged)
+        case 2: try decoder.decodeSingularUInt64Field(value: &_storage._incarnation)
+        case 3: try decoder.decodeSingularMessageField(value: &_storage._payload)
+        default: break
         }
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if let v = _storage._pinged {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            }
-            if _storage._incarnation != 0 {
-                try visitor.visitSingularUInt64Field(value: _storage._incarnation, fieldNumber: 2)
-            }
-            if let v = _storage._payload {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._pinged {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+      if _storage._incarnation != 0 {
+        try visitor.visitSingularUInt64Field(value: _storage._incarnation, fieldNumber: 2)
+      }
+      if let v = _storage._payload {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoSWIMAck, rhs: ProtoSWIMAck) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._pinged != rhs_storage._pinged { return false }
-                if _storage._incarnation != rhs_storage._incarnation { return false }
-                if _storage._payload != rhs_storage._payload { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  static func ==(lhs: ProtoSWIMAck, rhs: ProtoSWIMAck) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._pinged != rhs_storage._pinged {return false}
+        if _storage._incarnation != rhs_storage._incarnation {return false}
+        if _storage._payload != rhs_storage._payload {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoSWIMStatus: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "SWIMStatus"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "type"),
-        2: .same(proto: "incarnation"),
-    ]
+  static let protoMessageName: String = "SWIMStatus"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "type"),
+    2: .same(proto: "incarnation"),
+  ]
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        while let fieldNumber = try decoder.nextFieldNumber() {
-            switch fieldNumber {
-            case 1: try decoder.decodeSingularEnumField(value: &self.type)
-            case 2: try decoder.decodeSingularUInt64Field(value: &self.incarnation)
-            default: break
-            }
-        }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularEnumField(value: &self.type)
+      case 2: try decoder.decodeSingularUInt64Field(value: &self.incarnation)
+      default: break
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        if self.type != .alive {
-            try visitor.visitSingularEnumField(value: self.type, fieldNumber: 1)
-        }
-        if self.incarnation != 0 {
-            try visitor.visitSingularUInt64Field(value: self.incarnation, fieldNumber: 2)
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.type != .alive {
+      try visitor.visitSingularEnumField(value: self.type, fieldNumber: 1)
     }
+    if self.incarnation != 0 {
+      try visitor.visitSingularUInt64Field(value: self.incarnation, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoSWIMStatus, rhs: ProtoSWIMStatus) -> Bool {
-        if lhs.type != rhs.type { return false }
-        if lhs.incarnation != rhs.incarnation { return false }
-        if lhs.unknownFields != rhs.unknownFields { return false }
-        return true
-    }
+  static func ==(lhs: ProtoSWIMStatus, rhs: ProtoSWIMStatus) -> Bool {
+    if lhs.type != rhs.type {return false}
+    if lhs.incarnation != rhs.incarnation {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoSWIMStatus.TypeEnum: SwiftProtobuf._ProtoNameProviding {
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        0: .same(proto: "ALIVE"),
-        1: .same(proto: "SUSPECT"),
-        2: .same(proto: "UNREACHABLE"),
-        3: .same(proto: "DEAD"),
-    ]
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ALIVE"),
+    1: .same(proto: "SUSPECT"),
+    2: .same(proto: "UNREACHABLE"),
+    3: .same(proto: "DEAD"),
+  ]
 }
 
 extension ProtoSWIMMember: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "SWIMMember"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "address"),
-        2: .same(proto: "status"),
-    ]
+  static let protoMessageName: String = "SWIMMember"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "address"),
+    2: .same(proto: "status"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _address: ProtoActorAddress?
-        var _status: ProtoSWIMStatus?
+  fileprivate class _StorageClass {
+    var _address: ProtoActorAddress? = nil
+    var _status: ProtoSWIMStatus? = nil
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._address = source._address
-            self._status = source._status
-        }
+    init(copying source: _StorageClass) {
+      _address = source._address
+      _status = source._status
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularMessageField(value: &_storage._address)
-                case 2: try decoder.decodeSingularMessageField(value: &_storage._status)
-                default: break
-                }
-            }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularMessageField(value: &_storage._address)
+        case 2: try decoder.decodeSingularMessageField(value: &_storage._status)
+        default: break
         }
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if let v = _storage._address {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            }
-            if let v = _storage._status {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._address {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+      if let v = _storage._status {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoSWIMMember, rhs: ProtoSWIMMember) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._address != rhs_storage._address { return false }
-                if _storage._status != rhs_storage._status { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  static func ==(lhs: ProtoSWIMMember, rhs: ProtoSWIMMember) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._address != rhs_storage._address {return false}
+        if _storage._status != rhs_storage._status {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoSWIMPayload: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "SWIMPayload"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "member"),
-    ]
+  static let protoMessageName: String = "SWIMPayload"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "member"),
+  ]
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        while let fieldNumber = try decoder.nextFieldNumber() {
-            switch fieldNumber {
-            case 1: try decoder.decodeRepeatedMessageField(value: &self.member)
-            default: break
-            }
-        }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeRepeatedMessageField(value: &self.member)
+      default: break
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        if !self.member.isEmpty {
-            try visitor.visitRepeatedMessageField(value: self.member, fieldNumber: 1)
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.member.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.member, fieldNumber: 1)
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoSWIMPayload, rhs: ProtoSWIMPayload) -> Bool {
-        if lhs.member != rhs.member { return false }
-        if lhs.unknownFields != rhs.unknownFields { return false }
-        return true
-    }
+  static func ==(lhs: ProtoSWIMPayload, rhs: ProtoSWIMPayload) -> Bool {
+    if lhs.member != rhs.member {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }

--- a/Sources/DistributedActors/Protobuf/ActorAddress.pb.swift
+++ b/Sources/DistributedActors/Protobuf/ActorAddress.pb.swift
@@ -28,326 +28,323 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that your are building against the same version of the API
 // that was used to generate this file.
-private struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-    struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
-    typealias Version = _2
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 public struct ProtoActorAddress {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    // TODO: oneof { senderNode | recipientNode | node }
-    public var node: ProtoUniqueNode {
-        get { return self._storage._node ?? ProtoUniqueNode() }
-        set { _uniqueStorage()._node = newValue }
-    }
+  /// TODO oneof { senderNode | recipientNode | node }
+  public var node: ProtoUniqueNode {
+    get {return _storage._node ?? ProtoUniqueNode()}
+    set {_uniqueStorage()._node = newValue}
+  }
+  /// Returns true if `node` has been explicitly set.
+  public var hasNode: Bool {return _storage._node != nil}
+  /// Clears the value of `node`. Subsequent reads from it will return its default value.
+  public mutating func clearNode() {_uniqueStorage()._node = nil}
 
-    /// Returns true if `node` has been explicitly set.
-    public var hasNode: Bool { return self._storage._node != nil }
-    /// Clears the value of `node`. Subsequent reads from it will return its default value.
-    public mutating func clearNode() { _uniqueStorage()._node = nil }
+  public var path: ProtoActorPath {
+    get {return _storage._path ?? ProtoActorPath()}
+    set {_uniqueStorage()._path = newValue}
+  }
+  /// Returns true if `path` has been explicitly set.
+  public var hasPath: Bool {return _storage._path != nil}
+  /// Clears the value of `path`. Subsequent reads from it will return its default value.
+  public mutating func clearPath() {_uniqueStorage()._path = nil}
 
-    public var path: ProtoActorPath {
-        get { return self._storage._path ?? ProtoActorPath() }
-        set { _uniqueStorage()._path = newValue }
-    }
+  public var incarnation: UInt32 {
+    get {return _storage._incarnation}
+    set {_uniqueStorage()._incarnation = newValue}
+  }
 
-    /// Returns true if `path` has been explicitly set.
-    public var hasPath: Bool { return self._storage._path != nil }
-    /// Clears the value of `path`. Subsequent reads from it will return its default value.
-    public mutating func clearPath() { _uniqueStorage()._path = nil }
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public var incarnation: UInt32 {
-        get { return self._storage._incarnation }
-        set { _uniqueStorage()._incarnation = newValue }
-    }
+  public init() {}
 
-    public var unknownFields = SwiftProtobuf.UnknownStorage()
-
-    public init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 public struct ProtoActorPath {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    public var segments: [String] = []
+  public var segments: [String] = []
 
-    public var unknownFields = SwiftProtobuf.UnknownStorage()
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public init() {}
+  public init() {}
 }
 
 public struct ProtoUniqueNode {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    public var node: ProtoNode {
-        get { return self._storage._node ?? ProtoNode() }
-        set { _uniqueStorage()._node = newValue }
-    }
+  public var node: ProtoNode {
+    get {return _storage._node ?? ProtoNode()}
+    set {_uniqueStorage()._node = newValue}
+  }
+  /// Returns true if `node` has been explicitly set.
+  public var hasNode: Bool {return _storage._node != nil}
+  /// Clears the value of `node`. Subsequent reads from it will return its default value.
+  public mutating func clearNode() {_uniqueStorage()._node = nil}
 
-    /// Returns true if `node` has been explicitly set.
-    public var hasNode: Bool { return self._storage._node != nil }
-    /// Clears the value of `node`. Subsequent reads from it will return its default value.
-    public mutating func clearNode() { _uniqueStorage()._node = nil }
+  public var nid: UInt32 {
+    get {return _storage._nid}
+    set {_uniqueStorage()._nid = newValue}
+  }
 
-    public var nid: UInt32 {
-        get { return self._storage._nid }
-        set { _uniqueStorage()._nid = newValue }
-    }
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public var unknownFields = SwiftProtobuf.UnknownStorage()
+  public init() {}
 
-    public init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 public struct ProtoNode {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    public var `protocol`: String = String()
+  public var `protocol`: String = String()
 
-    public var system: String = String()
+  public var system: String = String()
 
-    public var hostname: String = String()
+  public var hostname: String = String()
 
-    public var port: UInt32 = 0
+  public var port: UInt32 = 0
 
-    public var unknownFields = SwiftProtobuf.UnknownStorage()
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public init() {}
+  public init() {}
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 extension ProtoActorAddress: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    public static let protoMessageName: String = "ActorAddress"
-    public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "node"),
-        2: .same(proto: "path"),
-        3: .same(proto: "incarnation"),
-    ]
+  public static let protoMessageName: String = "ActorAddress"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "node"),
+    2: .same(proto: "path"),
+    3: .same(proto: "incarnation"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _node: ProtoUniqueNode?
-        var _path: ProtoActorPath?
-        var _incarnation: UInt32 = 0
+  fileprivate class _StorageClass {
+    var _node: ProtoUniqueNode? = nil
+    var _path: ProtoActorPath? = nil
+    var _incarnation: UInt32 = 0
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._node = source._node
-            self._path = source._path
-            self._incarnation = source._incarnation
-        }
+    init(copying source: _StorageClass) {
+      _node = source._node
+      _path = source._path
+      _incarnation = source._incarnation
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularMessageField(value: &_storage._node)
-                case 2: try decoder.decodeSingularMessageField(value: &_storage._path)
-                case 3: try decoder.decodeSingularUInt32Field(value: &_storage._incarnation)
-                default: break
-                }
-            }
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularMessageField(value: &_storage._node)
+        case 2: try decoder.decodeSingularMessageField(value: &_storage._path)
+        case 3: try decoder.decodeSingularUInt32Field(value: &_storage._incarnation)
+        default: break
         }
+      }
     }
+  }
 
-    public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if let v = _storage._node {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            }
-            if let v = _storage._path {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-            }
-            if _storage._incarnation != 0 {
-                try visitor.visitSingularUInt32Field(value: _storage._incarnation, fieldNumber: 3)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._node {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+      if let v = _storage._path {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      }
+      if _storage._incarnation != 0 {
+        try visitor.visitSingularUInt32Field(value: _storage._incarnation, fieldNumber: 3)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    public static func == (lhs: ProtoActorAddress, rhs: ProtoActorAddress) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._node != rhs_storage._node { return false }
-                if _storage._path != rhs_storage._path { return false }
-                if _storage._incarnation != rhs_storage._incarnation { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  public static func ==(lhs: ProtoActorAddress, rhs: ProtoActorAddress) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._node != rhs_storage._node {return false}
+        if _storage._path != rhs_storage._path {return false}
+        if _storage._incarnation != rhs_storage._incarnation {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoActorPath: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    public static let protoMessageName: String = "ActorPath"
-    public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "segments"),
-    ]
+  public static let protoMessageName: String = "ActorPath"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "segments"),
+  ]
 
-    public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        while let fieldNumber = try decoder.nextFieldNumber() {
-            switch fieldNumber {
-            case 1: try decoder.decodeRepeatedStringField(value: &self.segments)
-            default: break
-            }
-        }
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeRepeatedStringField(value: &self.segments)
+      default: break
+      }
     }
+  }
 
-    public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        if !self.segments.isEmpty {
-            try visitor.visitRepeatedStringField(value: self.segments, fieldNumber: 1)
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.segments.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.segments, fieldNumber: 1)
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    public static func == (lhs: ProtoActorPath, rhs: ProtoActorPath) -> Bool {
-        if lhs.segments != rhs.segments { return false }
-        if lhs.unknownFields != rhs.unknownFields { return false }
-        return true
-    }
+  public static func ==(lhs: ProtoActorPath, rhs: ProtoActorPath) -> Bool {
+    if lhs.segments != rhs.segments {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoUniqueNode: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    public static let protoMessageName: String = "UniqueNode"
-    public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "node"),
-        2: .same(proto: "nid"),
-    ]
+  public static let protoMessageName: String = "UniqueNode"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "node"),
+    2: .same(proto: "nid"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _node: ProtoNode?
-        var _nid: UInt32 = 0
+  fileprivate class _StorageClass {
+    var _node: ProtoNode? = nil
+    var _nid: UInt32 = 0
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._node = source._node
-            self._nid = source._nid
-        }
+    init(copying source: _StorageClass) {
+      _node = source._node
+      _nid = source._nid
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularMessageField(value: &_storage._node)
-                case 2: try decoder.decodeSingularUInt32Field(value: &_storage._nid)
-                default: break
-                }
-            }
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularMessageField(value: &_storage._node)
+        case 2: try decoder.decodeSingularUInt32Field(value: &_storage._nid)
+        default: break
         }
+      }
     }
+  }
 
-    public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if let v = _storage._node {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            }
-            if _storage._nid != 0 {
-                try visitor.visitSingularUInt32Field(value: _storage._nid, fieldNumber: 2)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._node {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+      if _storage._nid != 0 {
+        try visitor.visitSingularUInt32Field(value: _storage._nid, fieldNumber: 2)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    public static func == (lhs: ProtoUniqueNode, rhs: ProtoUniqueNode) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._node != rhs_storage._node { return false }
-                if _storage._nid != rhs_storage._nid { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  public static func ==(lhs: ProtoUniqueNode, rhs: ProtoUniqueNode) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._node != rhs_storage._node {return false}
+        if _storage._nid != rhs_storage._nid {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoNode: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    public static let protoMessageName: String = "Node"
-    public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "protocol"),
-        2: .same(proto: "system"),
-        3: .same(proto: "hostname"),
-        4: .same(proto: "port"),
-    ]
+  public static let protoMessageName: String = "Node"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "protocol"),
+    2: .same(proto: "system"),
+    3: .same(proto: "hostname"),
+    4: .same(proto: "port"),
+  ]
 
-    public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        while let fieldNumber = try decoder.nextFieldNumber() {
-            switch fieldNumber {
-            case 1: try decoder.decodeSingularStringField(value: &self.protocol)
-            case 2: try decoder.decodeSingularStringField(value: &self.system)
-            case 3: try decoder.decodeSingularStringField(value: &self.hostname)
-            case 4: try decoder.decodeSingularUInt32Field(value: &self.port)
-            default: break
-            }
-        }
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self.`protocol`)
+      case 2: try decoder.decodeSingularStringField(value: &self.system)
+      case 3: try decoder.decodeSingularStringField(value: &self.hostname)
+      case 4: try decoder.decodeSingularUInt32Field(value: &self.port)
+      default: break
+      }
     }
+  }
 
-    public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        if !self.protocol.isEmpty {
-            try visitor.visitSingularStringField(value: self.protocol, fieldNumber: 1)
-        }
-        if !self.system.isEmpty {
-            try visitor.visitSingularStringField(value: self.system, fieldNumber: 2)
-        }
-        if !self.hostname.isEmpty {
-            try visitor.visitSingularStringField(value: self.hostname, fieldNumber: 3)
-        }
-        if self.port != 0 {
-            try visitor.visitSingularUInt32Field(value: self.port, fieldNumber: 4)
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.`protocol`.isEmpty {
+      try visitor.visitSingularStringField(value: self.`protocol`, fieldNumber: 1)
     }
+    if !self.system.isEmpty {
+      try visitor.visitSingularStringField(value: self.system, fieldNumber: 2)
+    }
+    if !self.hostname.isEmpty {
+      try visitor.visitSingularStringField(value: self.hostname, fieldNumber: 3)
+    }
+    if self.port != 0 {
+      try visitor.visitSingularUInt32Field(value: self.port, fieldNumber: 4)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    public static func == (lhs: ProtoNode, rhs: ProtoNode) -> Bool {
-        if lhs.protocol != rhs.protocol { return false }
-        if lhs.system != rhs.system { return false }
-        if lhs.hostname != rhs.hostname { return false }
-        if lhs.port != rhs.port { return false }
-        if lhs.unknownFields != rhs.unknownFields { return false }
-        return true
-    }
+  public static func ==(lhs: ProtoNode, rhs: ProtoNode) -> Bool {
+    if lhs.`protocol` != rhs.`protocol` {return false}
+    if lhs.system != rhs.system {return false}
+    if lhs.hostname != rhs.hostname {return false}
+    if lhs.port != rhs.port {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }

--- a/Sources/DistributedActors/Protobuf/SystemMessages.pb.swift
+++ b/Sources/DistributedActors/Protobuf/SystemMessages.pb.swift
@@ -28,649 +28,643 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that your are building against the same version of the API
 // that was used to generate this file.
-private struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-    struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
-    typealias Version = _2
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct ProtoSystemMessage {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var payload: OneOf_Payload? {
-        get { return self._storage._payload }
-        set { _uniqueStorage()._payload = newValue }
+  var payload: OneOf_Payload? {
+    get {return _storage._payload}
+    set {_uniqueStorage()._payload = newValue}
+  }
+
+  var watch: ProtoSystemMessage_Watch {
+    get {
+      if case .watch(let v)? = _storage._payload {return v}
+      return ProtoSystemMessage_Watch()
     }
+    set {_uniqueStorage()._payload = .watch(newValue)}
+  }
 
-    var watch: ProtoSystemMessage_Watch {
-        get {
-            if case .watch(let v)? = self._storage._payload { return v }
-            return ProtoSystemMessage_Watch()
-        }
-        set { _uniqueStorage()._payload = .watch(newValue) }
+  var unwatch: ProtoSystemMessage_Unwatch {
+    get {
+      if case .unwatch(let v)? = _storage._payload {return v}
+      return ProtoSystemMessage_Unwatch()
     }
+    set {_uniqueStorage()._payload = .unwatch(newValue)}
+  }
 
-    var unwatch: ProtoSystemMessage_Unwatch {
-        get {
-            if case .unwatch(let v)? = self._storage._payload { return v }
-            return ProtoSystemMessage_Unwatch()
-        }
-        set { _uniqueStorage()._payload = .unwatch(newValue) }
+  var terminated: ProtoSystemMessage_Terminated {
+    get {
+      if case .terminated(let v)? = _storage._payload {return v}
+      return ProtoSystemMessage_Terminated()
     }
+    set {_uniqueStorage()._payload = .terminated(newValue)}
+  }
 
-    var terminated: ProtoSystemMessage_Terminated {
-        get {
-            if case .terminated(let v)? = self._storage._payload { return v }
-            return ProtoSystemMessage_Terminated()
-        }
-        set { _uniqueStorage()._payload = .terminated(newValue) }
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  enum OneOf_Payload: Equatable {
+    case watch(ProtoSystemMessage_Watch)
+    case unwatch(ProtoSystemMessage_Unwatch)
+    case terminated(ProtoSystemMessage_Terminated)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtoSystemMessage.OneOf_Payload, rhs: ProtoSystemMessage.OneOf_Payload) -> Bool {
+      switch (lhs, rhs) {
+      case (.watch(let l), .watch(let r)): return l == r
+      case (.unwatch(let l), .unwatch(let r)): return l == r
+      case (.terminated(let l), .terminated(let r)): return l == r
+      default: return false
+      }
     }
+  #endif
+  }
 
-    var unknownFields = SwiftProtobuf.UnknownStorage()
+  init() {}
 
-    enum OneOf_Payload: Equatable {
-        case watch(ProtoSystemMessage_Watch)
-        case unwatch(ProtoSystemMessage_Unwatch)
-        case terminated(ProtoSystemMessage_Terminated)
-
-        #if !swift(>=4.1)
-        static func == (lhs: ProtoSystemMessage.OneOf_Payload, rhs: ProtoSystemMessage.OneOf_Payload) -> Bool {
-            switch (lhs, rhs) {
-            case (.watch(let l), .watch(let r)): return l == r
-            case (.unwatch(let l), .unwatch(let r)): return l == r
-            case (.terminated(let l), .terminated(let r)): return l == r
-            default: return false
-            }
-        }
-        #endif
-    }
-
-    init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 struct ProtoSystemMessage_Watch {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var watchee: ProtoActorAddress {
-        get { return self._storage._watchee ?? ProtoActorAddress() }
-        set { _uniqueStorage()._watchee = newValue }
-    }
+  var watchee: ProtoActorAddress {
+    get {return _storage._watchee ?? ProtoActorAddress()}
+    set {_uniqueStorage()._watchee = newValue}
+  }
+  /// Returns true if `watchee` has been explicitly set.
+  var hasWatchee: Bool {return _storage._watchee != nil}
+  /// Clears the value of `watchee`. Subsequent reads from it will return its default value.
+  mutating func clearWatchee() {_uniqueStorage()._watchee = nil}
 
-    /// Returns true if `watchee` has been explicitly set.
-    var hasWatchee: Bool { return _storage._watchee != nil }
-    /// Clears the value of `watchee`. Subsequent reads from it will return its default value.
-    mutating func clearWatchee() { _uniqueStorage()._watchee = nil }
+  var watcher: ProtoActorAddress {
+    get {return _storage._watcher ?? ProtoActorAddress()}
+    set {_uniqueStorage()._watcher = newValue}
+  }
+  /// Returns true if `watcher` has been explicitly set.
+  var hasWatcher: Bool {return _storage._watcher != nil}
+  /// Clears the value of `watcher`. Subsequent reads from it will return its default value.
+  mutating func clearWatcher() {_uniqueStorage()._watcher = nil}
 
-    var watcher: ProtoActorAddress {
-        get { return self._storage._watcher ?? ProtoActorAddress() }
-        set { _uniqueStorage()._watcher = newValue }
-    }
+  var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    /// Returns true if `watcher` has been explicitly set.
-    var hasWatcher: Bool { return _storage._watcher != nil }
-    /// Clears the value of `watcher`. Subsequent reads from it will return its default value.
-    mutating func clearWatcher() { _uniqueStorage()._watcher = nil }
+  init() {}
 
-    var unknownFields = SwiftProtobuf.UnknownStorage()
-
-    init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 struct ProtoSystemMessage_Unwatch {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var watchee: ProtoActorAddress {
-        get { return self._storage._watchee ?? ProtoActorAddress() }
-        set { _uniqueStorage()._watchee = newValue }
-    }
+  var watchee: ProtoActorAddress {
+    get {return _storage._watchee ?? ProtoActorAddress()}
+    set {_uniqueStorage()._watchee = newValue}
+  }
+  /// Returns true if `watchee` has been explicitly set.
+  var hasWatchee: Bool {return _storage._watchee != nil}
+  /// Clears the value of `watchee`. Subsequent reads from it will return its default value.
+  mutating func clearWatchee() {_uniqueStorage()._watchee = nil}
 
-    /// Returns true if `watchee` has been explicitly set.
-    var hasWatchee: Bool { return _storage._watchee != nil }
-    /// Clears the value of `watchee`. Subsequent reads from it will return its default value.
-    mutating func clearWatchee() { _uniqueStorage()._watchee = nil }
+  var watcher: ProtoActorAddress {
+    get {return _storage._watcher ?? ProtoActorAddress()}
+    set {_uniqueStorage()._watcher = newValue}
+  }
+  /// Returns true if `watcher` has been explicitly set.
+  var hasWatcher: Bool {return _storage._watcher != nil}
+  /// Clears the value of `watcher`. Subsequent reads from it will return its default value.
+  mutating func clearWatcher() {_uniqueStorage()._watcher = nil}
 
-    var watcher: ProtoActorAddress {
-        get { return self._storage._watcher ?? ProtoActorAddress() }
-        set { _uniqueStorage()._watcher = newValue }
-    }
+  var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    /// Returns true if `watcher` has been explicitly set.
-    var hasWatcher: Bool { return _storage._watcher != nil }
-    /// Clears the value of `watcher`. Subsequent reads from it will return its default value.
-    mutating func clearWatcher() { _uniqueStorage()._watcher = nil }
+  init() {}
 
-    var unknownFields = SwiftProtobuf.UnknownStorage()
-
-    init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 struct ProtoSystemMessage_Terminated {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var ref: ProtoActorAddress {
-        get { return self._storage._ref ?? ProtoActorAddress() }
-        set { _uniqueStorage()._ref = newValue }
-    }
+  var ref: ProtoActorAddress {
+    get {return _storage._ref ?? ProtoActorAddress()}
+    set {_uniqueStorage()._ref = newValue}
+  }
+  /// Returns true if `ref` has been explicitly set.
+  var hasRef: Bool {return _storage._ref != nil}
+  /// Clears the value of `ref`. Subsequent reads from it will return its default value.
+  mutating func clearRef() {_uniqueStorage()._ref = nil}
 
-    /// Returns true if `ref` has been explicitly set.
-    var hasRef: Bool { return _storage._ref != nil }
-    /// Clears the value of `ref`. Subsequent reads from it will return its default value.
-    mutating func clearRef() { _uniqueStorage()._ref = nil }
+  var existenceConfirmed: Bool {
+    get {return _storage._existenceConfirmed}
+    set {_uniqueStorage()._existenceConfirmed = newValue}
+  }
 
-    var existenceConfirmed: Bool {
-        get { return self._storage._existenceConfirmed }
-        set { _uniqueStorage()._existenceConfirmed = newValue }
-    }
+  var addressTerminated: Bool {
+    get {return _storage._addressTerminated}
+    set {_uniqueStorage()._addressTerminated = newValue}
+  }
 
-    var addressTerminated: Bool {
-        get { return self._storage._addressTerminated }
-        set { _uniqueStorage()._addressTerminated = newValue }
-    }
+  var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    var unknownFields = SwiftProtobuf.UnknownStorage()
+  init() {}
 
-    init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 struct ProtoSystemMessageACK {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var sequenceNr: UInt64 = 0
+  var sequenceNr: UInt64 = 0
 
-    var unknownFields = SwiftProtobuf.UnknownStorage()
+  var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    init() {}
+  init() {}
 }
 
 struct ProtoSystemMessageNACK {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    /// repeated missingSequenceNrs
-    var sequenceNr: UInt64 = 0
+  /// repeated missingSequenceNrs
+  var sequenceNr: UInt64 = 0
 
-    var unknownFields = SwiftProtobuf.UnknownStorage()
+  var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    init() {}
+  init() {}
 }
 
 struct ProtoSystemMessageEnvelope {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var sequenceNr: UInt64 {
-        get { return self._storage._sequenceNr }
-        set { _uniqueStorage()._sequenceNr = newValue }
-    }
+  var sequenceNr: UInt64 {
+    get {return _storage._sequenceNr}
+    set {_uniqueStorage()._sequenceNr = newValue}
+  }
 
-    var message: ProtoSystemMessage {
-        get { return self._storage._message ?? ProtoSystemMessage() }
-        set { _uniqueStorage()._message = newValue }
-    }
+  var message: ProtoSystemMessage {
+    get {return _storage._message ?? ProtoSystemMessage()}
+    set {_uniqueStorage()._message = newValue}
+  }
+  /// Returns true if `message` has been explicitly set.
+  var hasMessage: Bool {return _storage._message != nil}
+  /// Clears the value of `message`. Subsequent reads from it will return its default value.
+  mutating func clearMessage() {_uniqueStorage()._message = nil}
 
-    /// Returns true if `message` has been explicitly set.
-    var hasMessage: Bool { return _storage._message != nil }
-    /// Clears the value of `message`. Subsequent reads from it will return its default value.
-    mutating func clearMessage() { _uniqueStorage()._message = nil }
+  var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    var unknownFields = SwiftProtobuf.UnknownStorage()
+  init() {}
 
-    init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 extension ProtoSystemMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "SystemMessage"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "watch"),
-        2: .same(proto: "unwatch"),
-        3: .same(proto: "terminated"),
-    ]
+  static let protoMessageName: String = "SystemMessage"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "watch"),
+    2: .same(proto: "unwatch"),
+    3: .same(proto: "terminated"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _payload: ProtoSystemMessage.OneOf_Payload?
+  fileprivate class _StorageClass {
+    var _payload: ProtoSystemMessage.OneOf_Payload?
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._payload = source._payload
-        }
+    init(copying source: _StorageClass) {
+      _payload = source._payload
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1:
-                    var v: ProtoSystemMessage_Watch?
-                    if let current = _storage._payload {
-                        try decoder.handleConflictingOneOf()
-                        if case .watch(let m) = current { v = m }
-                    }
-                    try decoder.decodeSingularMessageField(value: &v)
-                    if let v = v { _storage._payload = .watch(v) }
-                case 2:
-                    var v: ProtoSystemMessage_Unwatch?
-                    if let current = _storage._payload {
-                        try decoder.handleConflictingOneOf()
-                        if case .unwatch(let m) = current { v = m }
-                    }
-                    try decoder.decodeSingularMessageField(value: &v)
-                    if let v = v { _storage._payload = .unwatch(v) }
-                case 3:
-                    var v: ProtoSystemMessage_Terminated?
-                    if let current = _storage._payload {
-                        try decoder.handleConflictingOneOf()
-                        if case .terminated(let m) = current { v = m }
-                    }
-                    try decoder.decodeSingularMessageField(value: &v)
-                    if let v = v { _storage._payload = .terminated(v) }
-                default: break
-                }
-            }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1:
+          var v: ProtoSystemMessage_Watch?
+          if let current = _storage._payload {
+            try decoder.handleConflictingOneOf()
+            if case .watch(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {_storage._payload = .watch(v)}
+        case 2:
+          var v: ProtoSystemMessage_Unwatch?
+          if let current = _storage._payload {
+            try decoder.handleConflictingOneOf()
+            if case .unwatch(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {_storage._payload = .unwatch(v)}
+        case 3:
+          var v: ProtoSystemMessage_Terminated?
+          if let current = _storage._payload {
+            try decoder.handleConflictingOneOf()
+            if case .terminated(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {_storage._payload = .terminated(v)}
+        default: break
         }
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            switch _storage._payload {
-            case .watch(let v)?:
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            case .unwatch(let v)?:
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-            case .terminated(let v)?:
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-            case nil: break
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      switch _storage._payload {
+      case .watch(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      case .unwatch(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      case .terminated(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      case nil: break
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoSystemMessage, rhs: ProtoSystemMessage) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._payload != rhs_storage._payload { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  static func ==(lhs: ProtoSystemMessage, rhs: ProtoSystemMessage) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._payload != rhs_storage._payload {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoSystemMessage_Watch: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "SystemMessage_Watch"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "watchee"),
-        2: .same(proto: "watcher"),
-    ]
+  static let protoMessageName: String = "SystemMessage_Watch"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "watchee"),
+    2: .same(proto: "watcher"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _watchee: ProtoActorAddress?
-        var _watcher: ProtoActorAddress?
+  fileprivate class _StorageClass {
+    var _watchee: ProtoActorAddress? = nil
+    var _watcher: ProtoActorAddress? = nil
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._watchee = source._watchee
-            self._watcher = source._watcher
-        }
+    init(copying source: _StorageClass) {
+      _watchee = source._watchee
+      _watcher = source._watcher
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularMessageField(value: &_storage._watchee)
-                case 2: try decoder.decodeSingularMessageField(value: &_storage._watcher)
-                default: break
-                }
-            }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularMessageField(value: &_storage._watchee)
+        case 2: try decoder.decodeSingularMessageField(value: &_storage._watcher)
+        default: break
         }
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if let v = _storage._watchee {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            }
-            if let v = _storage._watcher {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._watchee {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+      if let v = _storage._watcher {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoSystemMessage_Watch, rhs: ProtoSystemMessage_Watch) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._watchee != rhs_storage._watchee { return false }
-                if _storage._watcher != rhs_storage._watcher { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  static func ==(lhs: ProtoSystemMessage_Watch, rhs: ProtoSystemMessage_Watch) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._watchee != rhs_storage._watchee {return false}
+        if _storage._watcher != rhs_storage._watcher {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoSystemMessage_Unwatch: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "SystemMessage_Unwatch"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "watchee"),
-        2: .same(proto: "watcher"),
-    ]
+  static let protoMessageName: String = "SystemMessage_Unwatch"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "watchee"),
+    2: .same(proto: "watcher"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _watchee: ProtoActorAddress?
-        var _watcher: ProtoActorAddress?
+  fileprivate class _StorageClass {
+    var _watchee: ProtoActorAddress? = nil
+    var _watcher: ProtoActorAddress? = nil
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._watchee = source._watchee
-            self._watcher = source._watcher
-        }
+    init(copying source: _StorageClass) {
+      _watchee = source._watchee
+      _watcher = source._watcher
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularMessageField(value: &_storage._watchee)
-                case 2: try decoder.decodeSingularMessageField(value: &_storage._watcher)
-                default: break
-                }
-            }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularMessageField(value: &_storage._watchee)
+        case 2: try decoder.decodeSingularMessageField(value: &_storage._watcher)
+        default: break
         }
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if let v = _storage._watchee {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            }
-            if let v = _storage._watcher {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._watchee {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+      if let v = _storage._watcher {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoSystemMessage_Unwatch, rhs: ProtoSystemMessage_Unwatch) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._watchee != rhs_storage._watchee { return false }
-                if _storage._watcher != rhs_storage._watcher { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  static func ==(lhs: ProtoSystemMessage_Unwatch, rhs: ProtoSystemMessage_Unwatch) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._watchee != rhs_storage._watchee {return false}
+        if _storage._watcher != rhs_storage._watcher {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoSystemMessage_Terminated: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "SystemMessage_Terminated"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "ref"),
-        2: .same(proto: "existenceConfirmed"),
-        3: .same(proto: "addressTerminated"),
-    ]
+  static let protoMessageName: String = "SystemMessage_Terminated"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "ref"),
+    2: .same(proto: "existenceConfirmed"),
+    3: .same(proto: "addressTerminated"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _ref: ProtoActorAddress?
-        var _existenceConfirmed: Bool = false
-        var _addressTerminated: Bool = false
+  fileprivate class _StorageClass {
+    var _ref: ProtoActorAddress? = nil
+    var _existenceConfirmed: Bool = false
+    var _addressTerminated: Bool = false
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._ref = source._ref
-            self._existenceConfirmed = source._existenceConfirmed
-            self._addressTerminated = source._addressTerminated
-        }
+    init(copying source: _StorageClass) {
+      _ref = source._ref
+      _existenceConfirmed = source._existenceConfirmed
+      _addressTerminated = source._addressTerminated
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularMessageField(value: &_storage._ref)
-                case 2: try decoder.decodeSingularBoolField(value: &_storage._existenceConfirmed)
-                case 3: try decoder.decodeSingularBoolField(value: &_storage._addressTerminated)
-                default: break
-                }
-            }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularMessageField(value: &_storage._ref)
+        case 2: try decoder.decodeSingularBoolField(value: &_storage._existenceConfirmed)
+        case 3: try decoder.decodeSingularBoolField(value: &_storage._addressTerminated)
+        default: break
         }
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if let v = _storage._ref {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            }
-            if _storage._existenceConfirmed != false {
-                try visitor.visitSingularBoolField(value: _storage._existenceConfirmed, fieldNumber: 2)
-            }
-            if _storage._addressTerminated != false {
-                try visitor.visitSingularBoolField(value: _storage._addressTerminated, fieldNumber: 3)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._ref {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+      if _storage._existenceConfirmed != false {
+        try visitor.visitSingularBoolField(value: _storage._existenceConfirmed, fieldNumber: 2)
+      }
+      if _storage._addressTerminated != false {
+        try visitor.visitSingularBoolField(value: _storage._addressTerminated, fieldNumber: 3)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoSystemMessage_Terminated, rhs: ProtoSystemMessage_Terminated) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._ref != rhs_storage._ref { return false }
-                if _storage._existenceConfirmed != rhs_storage._existenceConfirmed { return false }
-                if _storage._addressTerminated != rhs_storage._addressTerminated { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  static func ==(lhs: ProtoSystemMessage_Terminated, rhs: ProtoSystemMessage_Terminated) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._ref != rhs_storage._ref {return false}
+        if _storage._existenceConfirmed != rhs_storage._existenceConfirmed {return false}
+        if _storage._addressTerminated != rhs_storage._addressTerminated {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoSystemMessageACK: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "SystemMessageACK"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "sequenceNr"),
-    ]
+  static let protoMessageName: String = "SystemMessageACK"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "sequenceNr"),
+  ]
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        while let fieldNumber = try decoder.nextFieldNumber() {
-            switch fieldNumber {
-            case 1: try decoder.decodeSingularUInt64Field(value: &self.sequenceNr)
-            default: break
-            }
-        }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularUInt64Field(value: &self.sequenceNr)
+      default: break
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        if self.sequenceNr != 0 {
-            try visitor.visitSingularUInt64Field(value: self.sequenceNr, fieldNumber: 1)
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.sequenceNr != 0 {
+      try visitor.visitSingularUInt64Field(value: self.sequenceNr, fieldNumber: 1)
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoSystemMessageACK, rhs: ProtoSystemMessageACK) -> Bool {
-        if lhs.sequenceNr != rhs.sequenceNr { return false }
-        if lhs.unknownFields != rhs.unknownFields { return false }
-        return true
-    }
+  static func ==(lhs: ProtoSystemMessageACK, rhs: ProtoSystemMessageACK) -> Bool {
+    if lhs.sequenceNr != rhs.sequenceNr {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoSystemMessageNACK: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "SystemMessageNACK"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "sequenceNr"),
-    ]
+  static let protoMessageName: String = "SystemMessageNACK"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "sequenceNr"),
+  ]
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        while let fieldNumber = try decoder.nextFieldNumber() {
-            switch fieldNumber {
-            case 1: try decoder.decodeSingularUInt64Field(value: &self.sequenceNr)
-            default: break
-            }
-        }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularUInt64Field(value: &self.sequenceNr)
+      default: break
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        if self.sequenceNr != 0 {
-            try visitor.visitSingularUInt64Field(value: self.sequenceNr, fieldNumber: 1)
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.sequenceNr != 0 {
+      try visitor.visitSingularUInt64Field(value: self.sequenceNr, fieldNumber: 1)
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoSystemMessageNACK, rhs: ProtoSystemMessageNACK) -> Bool {
-        if lhs.sequenceNr != rhs.sequenceNr { return false }
-        if lhs.unknownFields != rhs.unknownFields { return false }
-        return true
-    }
+  static func ==(lhs: ProtoSystemMessageNACK, rhs: ProtoSystemMessageNACK) -> Bool {
+    if lhs.sequenceNr != rhs.sequenceNr {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoSystemMessageEnvelope: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "SystemMessageEnvelope"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "sequenceNr"),
-        2: .same(proto: "message"),
-    ]
+  static let protoMessageName: String = "SystemMessageEnvelope"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "sequenceNr"),
+    2: .same(proto: "message"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _sequenceNr: UInt64 = 0
-        var _message: ProtoSystemMessage?
+  fileprivate class _StorageClass {
+    var _sequenceNr: UInt64 = 0
+    var _message: ProtoSystemMessage? = nil
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._sequenceNr = source._sequenceNr
-            self._message = source._message
-        }
+    init(copying source: _StorageClass) {
+      _sequenceNr = source._sequenceNr
+      _message = source._message
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularUInt64Field(value: &_storage._sequenceNr)
-                case 2: try decoder.decodeSingularMessageField(value: &_storage._message)
-                default: break
-                }
-            }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularUInt64Field(value: &_storage._sequenceNr)
+        case 2: try decoder.decodeSingularMessageField(value: &_storage._message)
+        default: break
         }
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if _storage._sequenceNr != 0 {
-                try visitor.visitSingularUInt64Field(value: _storage._sequenceNr, fieldNumber: 1)
-            }
-            if let v = _storage._message {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if _storage._sequenceNr != 0 {
+        try visitor.visitSingularUInt64Field(value: _storage._sequenceNr, fieldNumber: 1)
+      }
+      if let v = _storage._message {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoSystemMessageEnvelope, rhs: ProtoSystemMessageEnvelope) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._sequenceNr != rhs_storage._sequenceNr { return false }
-                if _storage._message != rhs_storage._message { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  static func ==(lhs: ProtoSystemMessageEnvelope, rhs: ProtoSystemMessageEnvelope) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._sequenceNr != rhs_storage._sequenceNr {return false}
+        if _storage._message != rhs_storage._message {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }

--- a/Sources/DistributedActors/Protobuf/WireProtocol.pb.swift
+++ b/Sources/DistributedActors/Protobuf/WireProtocol.pb.swift
@@ -28,293 +28,281 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that your are building against the same version of the API
 // that was used to generate this file.
-private struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-    struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
-    typealias Version = _2
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct ProtoHandshakeOffer {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var version: ProtoProtocolVersion {
-        get { return self._storage._version ?? ProtoProtocolVersion() }
-        set { _uniqueStorage()._version = newValue }
-    }
+  var version: ProtoProtocolVersion {
+    get {return _storage._version ?? ProtoProtocolVersion()}
+    set {_uniqueStorage()._version = newValue}
+  }
+  /// Returns true if `version` has been explicitly set.
+  var hasVersion: Bool {return _storage._version != nil}
+  /// Clears the value of `version`. Subsequent reads from it will return its default value.
+  mutating func clearVersion() {_uniqueStorage()._version = nil}
 
-    /// Returns true if `version` has been explicitly set.
-    var hasVersion: Bool { return _storage._version != nil }
-    /// Clears the value of `version`. Subsequent reads from it will return its default value.
-    mutating func clearVersion() { _uniqueStorage()._version = nil }
+  var from: ProtoUniqueNode {
+    get {return _storage._from ?? ProtoUniqueNode()}
+    set {_uniqueStorage()._from = newValue}
+  }
+  /// Returns true if `from` has been explicitly set.
+  var hasFrom: Bool {return _storage._from != nil}
+  /// Clears the value of `from`. Subsequent reads from it will return its default value.
+  mutating func clearFrom() {_uniqueStorage()._from = nil}
 
-    var from: ProtoUniqueNode {
-        get { return self._storage._from ?? ProtoUniqueNode() }
-        set { _uniqueStorage()._from = newValue }
-    }
+  /// In the future we may want to add additional information
+  /// about certain capabilities here. E.g. when a node supports
+  /// faster transport like InfiniBand and the likes, so we can
+  /// upgrade the connection in case both nodes support the fast
+  /// transport.
+  var to: ProtoNode {
+    get {return _storage._to ?? ProtoNode()}
+    set {_uniqueStorage()._to = newValue}
+  }
+  /// Returns true if `to` has been explicitly set.
+  var hasTo: Bool {return _storage._to != nil}
+  /// Clears the value of `to`. Subsequent reads from it will return its default value.
+  mutating func clearTo() {_uniqueStorage()._to = nil}
 
-    /// Returns true if `from` has been explicitly set.
-    var hasFrom: Bool { return _storage._from != nil }
-    /// Clears the value of `from`. Subsequent reads from it will return its default value.
-    mutating func clearFrom() { _uniqueStorage()._from = nil }
+  var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    /// In the future we may want to add additional information
-    /// about certain capabilities here. E.g. when a node supports
-    /// faster transport like InfiniBand and the likes, so we can
-    /// upgrade the connection in case both nodes support the fast
-    /// transport.
-    var to: ProtoNode {
-        get { return self._storage._to ?? ProtoNode() }
-        set { _uniqueStorage()._to = newValue }
-    }
+  init() {}
 
-    /// Returns true if `to` has been explicitly set.
-    var hasTo: Bool { return _storage._to != nil }
-    /// Clears the value of `to`. Subsequent reads from it will return its default value.
-    mutating func clearTo() { _uniqueStorage()._to = nil }
-
-    var unknownFields = SwiftProtobuf.UnknownStorage()
-
-    init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 struct ProtoHandshakeResponse {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var status: OneOf_Status? {
-        get { return self._storage._status }
-        set { _uniqueStorage()._status = newValue }
+  var status: OneOf_Status? {
+    get {return _storage._status}
+    set {_uniqueStorage()._status = newValue}
+  }
+
+  var accept: ProtoHandshakeAccept {
+    get {
+      if case .accept(let v)? = _storage._status {return v}
+      return ProtoHandshakeAccept()
     }
+    set {_uniqueStorage()._status = .accept(newValue)}
+  }
 
-    var accept: ProtoHandshakeAccept {
-        get {
-            if case .accept(let v)? = self._storage._status { return v }
-            return ProtoHandshakeAccept()
-        }
-        set { _uniqueStorage()._status = .accept(newValue) }
+  var reject: ProtoHandshakeReject {
+    get {
+      if case .reject(let v)? = _storage._status {return v}
+      return ProtoHandshakeReject()
     }
+    set {_uniqueStorage()._status = .reject(newValue)}
+  }
 
-    var reject: ProtoHandshakeReject {
-        get {
-            if case .reject(let v)? = self._storage._status { return v }
-            return ProtoHandshakeReject()
-        }
-        set { _uniqueStorage()._status = .reject(newValue) }
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  enum OneOf_Status: Equatable {
+    case accept(ProtoHandshakeAccept)
+    case reject(ProtoHandshakeReject)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtoHandshakeResponse.OneOf_Status, rhs: ProtoHandshakeResponse.OneOf_Status) -> Bool {
+      switch (lhs, rhs) {
+      case (.accept(let l), .accept(let r)): return l == r
+      case (.reject(let l), .reject(let r)): return l == r
+      default: return false
+      }
     }
+  #endif
+  }
 
-    var unknownFields = SwiftProtobuf.UnknownStorage()
+  init() {}
 
-    enum OneOf_Status: Equatable {
-        case accept(ProtoHandshakeAccept)
-        case reject(ProtoHandshakeReject)
-
-        #if !swift(>=4.1)
-        static func == (lhs: ProtoHandshakeResponse.OneOf_Status, rhs: ProtoHandshakeResponse.OneOf_Status) -> Bool {
-            switch (lhs, rhs) {
-            case (.accept(let l), .accept(let r)): return l == r
-            case (.reject(let l), .reject(let r)): return l == r
-            default: return false
-            }
-        }
-        #endif
-    }
-
-    init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 struct ProtoHandshakeAccept {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var version: ProtoProtocolVersion {
-        get { return self._storage._version ?? ProtoProtocolVersion() }
-        set { _uniqueStorage()._version = newValue }
-    }
+  var version: ProtoProtocolVersion {
+    get {return _storage._version ?? ProtoProtocolVersion()}
+    set {_uniqueStorage()._version = newValue}
+  }
+  /// Returns true if `version` has been explicitly set.
+  var hasVersion: Bool {return _storage._version != nil}
+  /// Clears the value of `version`. Subsequent reads from it will return its default value.
+  mutating func clearVersion() {_uniqueStorage()._version = nil}
 
-    /// Returns true if `version` has been explicitly set.
-    var hasVersion: Bool { return _storage._version != nil }
-    /// Clears the value of `version`. Subsequent reads from it will return its default value.
-    mutating func clearVersion() { _uniqueStorage()._version = nil }
+  var origin: ProtoUniqueNode {
+    get {return _storage._origin ?? ProtoUniqueNode()}
+    set {_uniqueStorage()._origin = newValue}
+  }
+  /// Returns true if `origin` has been explicitly set.
+  var hasOrigin: Bool {return _storage._origin != nil}
+  /// Clears the value of `origin`. Subsequent reads from it will return its default value.
+  mutating func clearOrigin() {_uniqueStorage()._origin = nil}
 
-    var origin: ProtoUniqueNode {
-        get { return self._storage._origin ?? ProtoUniqueNode() }
-        set { _uniqueStorage()._origin = newValue }
-    }
+  var from: ProtoUniqueNode {
+    get {return _storage._from ?? ProtoUniqueNode()}
+    set {_uniqueStorage()._from = newValue}
+  }
+  /// Returns true if `from` has been explicitly set.
+  var hasFrom: Bool {return _storage._from != nil}
+  /// Clears the value of `from`. Subsequent reads from it will return its default value.
+  mutating func clearFrom() {_uniqueStorage()._from = nil}
 
-    /// Returns true if `origin` has been explicitly set.
-    var hasOrigin: Bool { return _storage._origin != nil }
-    /// Clears the value of `origin`. Subsequent reads from it will return its default value.
-    mutating func clearOrigin() { _uniqueStorage()._origin = nil }
+  var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    var from: ProtoUniqueNode {
-        get { return self._storage._from ?? ProtoUniqueNode() }
-        set { _uniqueStorage()._from = newValue }
-    }
+  init() {}
 
-    /// Returns true if `from` has been explicitly set.
-    var hasFrom: Bool { return _storage._from != nil }
-    /// Clears the value of `from`. Subsequent reads from it will return its default value.
-    mutating func clearFrom() { _uniqueStorage()._from = nil }
-
-    var unknownFields = SwiftProtobuf.UnknownStorage()
-
-    init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 struct ProtoHandshakeReject {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var version: ProtoProtocolVersion {
-        get { return self._storage._version ?? ProtoProtocolVersion() }
-        set { _uniqueStorage()._version = newValue }
-    }
+  var version: ProtoProtocolVersion {
+    get {return _storage._version ?? ProtoProtocolVersion()}
+    set {_uniqueStorage()._version = newValue}
+  }
+  /// Returns true if `version` has been explicitly set.
+  var hasVersion: Bool {return _storage._version != nil}
+  /// Clears the value of `version`. Subsequent reads from it will return its default value.
+  mutating func clearVersion() {_uniqueStorage()._version = nil}
 
-    /// Returns true if `version` has been explicitly set.
-    var hasVersion: Bool { return _storage._version != nil }
-    /// Clears the value of `version`. Subsequent reads from it will return its default value.
-    mutating func clearVersion() { _uniqueStorage()._version = nil }
+  var origin: ProtoUniqueNode {
+    get {return _storage._origin ?? ProtoUniqueNode()}
+    set {_uniqueStorage()._origin = newValue}
+  }
+  /// Returns true if `origin` has been explicitly set.
+  var hasOrigin: Bool {return _storage._origin != nil}
+  /// Clears the value of `origin`. Subsequent reads from it will return its default value.
+  mutating func clearOrigin() {_uniqueStorage()._origin = nil}
 
-    var origin: ProtoUniqueNode {
-        get { return self._storage._origin ?? ProtoUniqueNode() }
-        set { _uniqueStorage()._origin = newValue }
-    }
+  /// In the reject case this is an `Node` instead of a `UniqueNode`,
+  /// to explicitly prevent this from forming an association.
+  var from: ProtoNode {
+    get {return _storage._from ?? ProtoNode()}
+    set {_uniqueStorage()._from = newValue}
+  }
+  /// Returns true if `from` has been explicitly set.
+  var hasFrom: Bool {return _storage._from != nil}
+  /// Clears the value of `from`. Subsequent reads from it will return its default value.
+  mutating func clearFrom() {_uniqueStorage()._from = nil}
 
-    /// Returns true if `origin` has been explicitly set.
-    var hasOrigin: Bool { return _storage._origin != nil }
-    /// Clears the value of `origin`. Subsequent reads from it will return its default value.
-    mutating func clearOrigin() { _uniqueStorage()._origin = nil }
+  var reason: String {
+    get {return _storage._reason}
+    set {_uniqueStorage()._reason = newValue}
+  }
 
-    /// In the reject case this is an `Node` instead of a `UniqueNode`,
-    /// to explicitly prevent this from forming an association.
-    var from: ProtoNode {
-        get { return self._storage._from ?? ProtoNode() }
-        set { _uniqueStorage()._from = newValue }
-    }
+  var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    /// Returns true if `from` has been explicitly set.
-    var hasFrom: Bool { return _storage._from != nil }
-    /// Clears the value of `from`. Subsequent reads from it will return its default value.
-    mutating func clearFrom() { _uniqueStorage()._from = nil }
+  init() {}
 
-    var reason: String {
-        get { return self._storage._reason }
-        set { _uniqueStorage()._reason = newValue }
-    }
-
-    var unknownFields = SwiftProtobuf.UnknownStorage()
-
-    init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 struct ProtoEnvelope {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var recipient: ProtoActorAddress {
-        get { return self._storage._recipient ?? ProtoActorAddress() }
-        set { _uniqueStorage()._recipient = newValue }
-    }
+  var recipient: ProtoActorAddress {
+    get {return _storage._recipient ?? ProtoActorAddress()}
+    set {_uniqueStorage()._recipient = newValue}
+  }
+  /// Returns true if `recipient` has been explicitly set.
+  var hasRecipient: Bool {return _storage._recipient != nil}
+  /// Clears the value of `recipient`. Subsequent reads from it will return its default value.
+  mutating func clearRecipient() {_uniqueStorage()._recipient = nil}
 
-    /// Returns true if `recipient` has been explicitly set.
-    var hasRecipient: Bool { return _storage._recipient != nil }
-    /// Clears the value of `recipient`. Subsequent reads from it will return its default value.
-    mutating func clearRecipient() { _uniqueStorage()._recipient = nil }
+  var serializerID: UInt32 {
+    get {return _storage._serializerID}
+    set {_uniqueStorage()._serializerID = newValue}
+  }
 
-    var serializerID: UInt32 {
-        get { return self._storage._serializerID }
-        set { _uniqueStorage()._serializerID = newValue }
-    }
+  var payload: Data {
+    get {return _storage._payload}
+    set {_uniqueStorage()._payload = newValue}
+  }
 
-    var payload: Data {
-        get { return self._storage._payload }
-        set { _uniqueStorage()._payload = newValue }
-    }
+  var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    var unknownFields = SwiftProtobuf.UnknownStorage()
+  init() {}
 
-    init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 /// System messages have to be reliable, therefore they need to be acknowledged
 /// by the receiving node.
 struct ProtoSystemEnvelope {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var sequenceNr: UInt64 {
-        get { return self._storage._sequenceNr }
-        set { _uniqueStorage()._sequenceNr = newValue }
-    }
+  var sequenceNr: UInt64 {
+    get {return _storage._sequenceNr}
+    set {_uniqueStorage()._sequenceNr = newValue}
+  }
 
-    var from: ProtoUniqueNode {
-        get { return self._storage._from ?? ProtoUniqueNode() }
-        set { _uniqueStorage()._from = newValue }
-    }
+  var from: ProtoUniqueNode {
+    get {return _storage._from ?? ProtoUniqueNode()}
+    set {_uniqueStorage()._from = newValue}
+  }
+  /// Returns true if `from` has been explicitly set.
+  var hasFrom: Bool {return _storage._from != nil}
+  /// Clears the value of `from`. Subsequent reads from it will return its default value.
+  mutating func clearFrom() {_uniqueStorage()._from = nil}
 
-    /// Returns true if `from` has been explicitly set.
-    var hasFrom: Bool { return _storage._from != nil }
-    /// Clears the value of `from`. Subsequent reads from it will return its default value.
-    mutating func clearFrom() { _uniqueStorage()._from = nil }
+  var serializerID: UInt32 {
+    get {return _storage._serializerID}
+    set {_uniqueStorage()._serializerID = newValue}
+  }
 
-    var serializerID: UInt32 {
-        get { return self._storage._serializerID }
-        set { _uniqueStorage()._serializerID = newValue }
-    }
+  var payload: Data {
+    get {return _storage._payload}
+    set {_uniqueStorage()._payload = newValue}
+  }
 
-    var payload: Data {
-        get { return self._storage._payload }
-        set { _uniqueStorage()._payload = newValue }
-    }
+  var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    var unknownFields = SwiftProtobuf.UnknownStorage()
+  init() {}
 
-    init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 struct ProtoSystemAck {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var sequenceNr: UInt64 {
-        get { return self._storage._sequenceNr }
-        set { _uniqueStorage()._sequenceNr = newValue }
-    }
+  var sequenceNr: UInt64 {
+    get {return _storage._sequenceNr}
+    set {_uniqueStorage()._sequenceNr = newValue}
+  }
 
-    var from: ProtoUniqueNode {
-        get { return self._storage._from ?? ProtoUniqueNode() }
-        set { _uniqueStorage()._from = newValue }
-    }
+  var from: ProtoUniqueNode {
+    get {return _storage._from ?? ProtoUniqueNode()}
+    set {_uniqueStorage()._from = newValue}
+  }
+  /// Returns true if `from` has been explicitly set.
+  var hasFrom: Bool {return _storage._from != nil}
+  /// Clears the value of `from`. Subsequent reads from it will return its default value.
+  mutating func clearFrom() {_uniqueStorage()._from = nil}
 
-    /// Returns true if `from` has been explicitly set.
-    var hasFrom: Bool { return _storage._from != nil }
-    /// Clears the value of `from`. Subsequent reads from it will return its default value.
-    mutating func clearFrom() { _uniqueStorage()._from = nil }
+  var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    var unknownFields = SwiftProtobuf.UnknownStorage()
+  init() {}
 
-    init() {}
-
-    fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 /// The version is represented as 4 bytes:
@@ -326,620 +314,620 @@ struct ProtoSystemAck {
 /// encode all values in a single uint32 and provide an extension to
 /// retrieve the specific values.
 struct ProtoProtocolVersion {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    // TODO: wasteful representation, keeping for now to iterate on handshake -- ktoso
-    var reserved: UInt32 = 0
+  /// TODO: wasteful representation, keeping for now to iterate on handshake -- ktoso
+  var reserved: UInt32 = 0
 
-    var major: UInt32 = 0
+  var major: UInt32 = 0
 
-    var minor: UInt32 = 0
+  var minor: UInt32 = 0
 
-    var patch: UInt32 = 0
+  var patch: UInt32 = 0
 
-    var unknownFields = SwiftProtobuf.UnknownStorage()
+  var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    init() {}
+  init() {}
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 extension ProtoHandshakeOffer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "HandshakeOffer"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "version"),
-        2: .same(proto: "from"),
-        3: .same(proto: "to"),
-    ]
+  static let protoMessageName: String = "HandshakeOffer"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "version"),
+    2: .same(proto: "from"),
+    3: .same(proto: "to"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _version: ProtoProtocolVersion?
-        var _from: ProtoUniqueNode?
-        var _to: ProtoNode?
+  fileprivate class _StorageClass {
+    var _version: ProtoProtocolVersion? = nil
+    var _from: ProtoUniqueNode? = nil
+    var _to: ProtoNode? = nil
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._version = source._version
-            self._from = source._from
-            self._to = source._to
-        }
+    init(copying source: _StorageClass) {
+      _version = source._version
+      _from = source._from
+      _to = source._to
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularMessageField(value: &_storage._version)
-                case 2: try decoder.decodeSingularMessageField(value: &_storage._from)
-                case 3: try decoder.decodeSingularMessageField(value: &_storage._to)
-                default: break
-                }
-            }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularMessageField(value: &_storage._version)
+        case 2: try decoder.decodeSingularMessageField(value: &_storage._from)
+        case 3: try decoder.decodeSingularMessageField(value: &_storage._to)
+        default: break
         }
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if let v = _storage._version {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            }
-            if let v = _storage._from {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-            }
-            if let v = _storage._to {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._version {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+      if let v = _storage._from {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      }
+      if let v = _storage._to {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoHandshakeOffer, rhs: ProtoHandshakeOffer) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._version != rhs_storage._version { return false }
-                if _storage._from != rhs_storage._from { return false }
-                if _storage._to != rhs_storage._to { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  static func ==(lhs: ProtoHandshakeOffer, rhs: ProtoHandshakeOffer) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._version != rhs_storage._version {return false}
+        if _storage._from != rhs_storage._from {return false}
+        if _storage._to != rhs_storage._to {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoHandshakeResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "HandshakeResponse"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "accept"),
-        2: .same(proto: "reject"),
-    ]
+  static let protoMessageName: String = "HandshakeResponse"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "accept"),
+    2: .same(proto: "reject"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _status: ProtoHandshakeResponse.OneOf_Status?
+  fileprivate class _StorageClass {
+    var _status: ProtoHandshakeResponse.OneOf_Status?
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._status = source._status
-        }
+    init(copying source: _StorageClass) {
+      _status = source._status
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1:
-                    var v: ProtoHandshakeAccept?
-                    if let current = _storage._status {
-                        try decoder.handleConflictingOneOf()
-                        if case .accept(let m) = current { v = m }
-                    }
-                    try decoder.decodeSingularMessageField(value: &v)
-                    if let v = v { _storage._status = .accept(v) }
-                case 2:
-                    var v: ProtoHandshakeReject?
-                    if let current = _storage._status {
-                        try decoder.handleConflictingOneOf()
-                        if case .reject(let m) = current { v = m }
-                    }
-                    try decoder.decodeSingularMessageField(value: &v)
-                    if let v = v { _storage._status = .reject(v) }
-                default: break
-                }
-            }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1:
+          var v: ProtoHandshakeAccept?
+          if let current = _storage._status {
+            try decoder.handleConflictingOneOf()
+            if case .accept(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {_storage._status = .accept(v)}
+        case 2:
+          var v: ProtoHandshakeReject?
+          if let current = _storage._status {
+            try decoder.handleConflictingOneOf()
+            if case .reject(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {_storage._status = .reject(v)}
+        default: break
         }
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            switch _storage._status {
-            case .accept(let v)?:
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            case .reject(let v)?:
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-            case nil: break
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      switch _storage._status {
+      case .accept(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      case .reject(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      case nil: break
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoHandshakeResponse, rhs: ProtoHandshakeResponse) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._status != rhs_storage._status { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  static func ==(lhs: ProtoHandshakeResponse, rhs: ProtoHandshakeResponse) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._status != rhs_storage._status {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoHandshakeAccept: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "HandshakeAccept"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "version"),
-        2: .same(proto: "origin"),
-        3: .same(proto: "from"),
-    ]
+  static let protoMessageName: String = "HandshakeAccept"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "version"),
+    2: .same(proto: "origin"),
+    3: .same(proto: "from"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _version: ProtoProtocolVersion?
-        var _origin: ProtoUniqueNode?
-        var _from: ProtoUniqueNode?
+  fileprivate class _StorageClass {
+    var _version: ProtoProtocolVersion? = nil
+    var _origin: ProtoUniqueNode? = nil
+    var _from: ProtoUniqueNode? = nil
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._version = source._version
-            self._origin = source._origin
-            self._from = source._from
-        }
+    init(copying source: _StorageClass) {
+      _version = source._version
+      _origin = source._origin
+      _from = source._from
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularMessageField(value: &_storage._version)
-                case 2: try decoder.decodeSingularMessageField(value: &_storage._origin)
-                case 3: try decoder.decodeSingularMessageField(value: &_storage._from)
-                default: break
-                }
-            }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularMessageField(value: &_storage._version)
+        case 2: try decoder.decodeSingularMessageField(value: &_storage._origin)
+        case 3: try decoder.decodeSingularMessageField(value: &_storage._from)
+        default: break
         }
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if let v = _storage._version {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            }
-            if let v = _storage._origin {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-            }
-            if let v = _storage._from {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._version {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+      if let v = _storage._origin {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      }
+      if let v = _storage._from {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoHandshakeAccept, rhs: ProtoHandshakeAccept) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._version != rhs_storage._version { return false }
-                if _storage._origin != rhs_storage._origin { return false }
-                if _storage._from != rhs_storage._from { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  static func ==(lhs: ProtoHandshakeAccept, rhs: ProtoHandshakeAccept) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._version != rhs_storage._version {return false}
+        if _storage._origin != rhs_storage._origin {return false}
+        if _storage._from != rhs_storage._from {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoHandshakeReject: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "HandshakeReject"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "version"),
-        2: .same(proto: "origin"),
-        3: .same(proto: "from"),
-        4: .same(proto: "reason"),
-    ]
+  static let protoMessageName: String = "HandshakeReject"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "version"),
+    2: .same(proto: "origin"),
+    3: .same(proto: "from"),
+    4: .same(proto: "reason"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _version: ProtoProtocolVersion?
-        var _origin: ProtoUniqueNode?
-        var _from: ProtoNode?
-        var _reason: String = String()
+  fileprivate class _StorageClass {
+    var _version: ProtoProtocolVersion? = nil
+    var _origin: ProtoUniqueNode? = nil
+    var _from: ProtoNode? = nil
+    var _reason: String = String()
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._version = source._version
-            self._origin = source._origin
-            self._from = source._from
-            self._reason = source._reason
-        }
+    init(copying source: _StorageClass) {
+      _version = source._version
+      _origin = source._origin
+      _from = source._from
+      _reason = source._reason
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularMessageField(value: &_storage._version)
-                case 2: try decoder.decodeSingularMessageField(value: &_storage._origin)
-                case 3: try decoder.decodeSingularMessageField(value: &_storage._from)
-                case 4: try decoder.decodeSingularStringField(value: &_storage._reason)
-                default: break
-                }
-            }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularMessageField(value: &_storage._version)
+        case 2: try decoder.decodeSingularMessageField(value: &_storage._origin)
+        case 3: try decoder.decodeSingularMessageField(value: &_storage._from)
+        case 4: try decoder.decodeSingularStringField(value: &_storage._reason)
+        default: break
         }
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if let v = _storage._version {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            }
-            if let v = _storage._origin {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-            }
-            if let v = _storage._from {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-            }
-            if !_storage._reason.isEmpty {
-                try visitor.visitSingularStringField(value: _storage._reason, fieldNumber: 4)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._version {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+      if let v = _storage._origin {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      }
+      if let v = _storage._from {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      }
+      if !_storage._reason.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._reason, fieldNumber: 4)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoHandshakeReject, rhs: ProtoHandshakeReject) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._version != rhs_storage._version { return false }
-                if _storage._origin != rhs_storage._origin { return false }
-                if _storage._from != rhs_storage._from { return false }
-                if _storage._reason != rhs_storage._reason { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  static func ==(lhs: ProtoHandshakeReject, rhs: ProtoHandshakeReject) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._version != rhs_storage._version {return false}
+        if _storage._origin != rhs_storage._origin {return false}
+        if _storage._from != rhs_storage._from {return false}
+        if _storage._reason != rhs_storage._reason {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoEnvelope: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "Envelope"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "recipient"),
-        2: .same(proto: "serializerId"),
-        3: .same(proto: "payload"),
-    ]
+  static let protoMessageName: String = "Envelope"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "recipient"),
+    2: .same(proto: "serializerId"),
+    3: .same(proto: "payload"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _recipient: ProtoActorAddress?
-        var _serializerID: UInt32 = 0
-        var _payload: Data = SwiftProtobuf.Internal.emptyData
+  fileprivate class _StorageClass {
+    var _recipient: ProtoActorAddress? = nil
+    var _serializerID: UInt32 = 0
+    var _payload: Data = SwiftProtobuf.Internal.emptyData
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._recipient = source._recipient
-            self._serializerID = source._serializerID
-            self._payload = source._payload
-        }
+    init(copying source: _StorageClass) {
+      _recipient = source._recipient
+      _serializerID = source._serializerID
+      _payload = source._payload
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularMessageField(value: &_storage._recipient)
-                case 2: try decoder.decodeSingularUInt32Field(value: &_storage._serializerID)
-                case 3: try decoder.decodeSingularBytesField(value: &_storage._payload)
-                default: break
-                }
-            }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularMessageField(value: &_storage._recipient)
+        case 2: try decoder.decodeSingularUInt32Field(value: &_storage._serializerID)
+        case 3: try decoder.decodeSingularBytesField(value: &_storage._payload)
+        default: break
         }
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if let v = _storage._recipient {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-            }
-            if _storage._serializerID != 0 {
-                try visitor.visitSingularUInt32Field(value: _storage._serializerID, fieldNumber: 2)
-            }
-            if !_storage._payload.isEmpty {
-                try visitor.visitSingularBytesField(value: _storage._payload, fieldNumber: 3)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._recipient {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+      if _storage._serializerID != 0 {
+        try visitor.visitSingularUInt32Field(value: _storage._serializerID, fieldNumber: 2)
+      }
+      if !_storage._payload.isEmpty {
+        try visitor.visitSingularBytesField(value: _storage._payload, fieldNumber: 3)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoEnvelope, rhs: ProtoEnvelope) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._recipient != rhs_storage._recipient { return false }
-                if _storage._serializerID != rhs_storage._serializerID { return false }
-                if _storage._payload != rhs_storage._payload { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  static func ==(lhs: ProtoEnvelope, rhs: ProtoEnvelope) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._recipient != rhs_storage._recipient {return false}
+        if _storage._serializerID != rhs_storage._serializerID {return false}
+        if _storage._payload != rhs_storage._payload {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoSystemEnvelope: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "SystemEnvelope"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "sequenceNr"),
-        2: .same(proto: "from"),
-        3: .same(proto: "serializerId"),
-        4: .same(proto: "payload"),
-    ]
+  static let protoMessageName: String = "SystemEnvelope"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "sequenceNr"),
+    2: .same(proto: "from"),
+    3: .same(proto: "serializerId"),
+    4: .same(proto: "payload"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _sequenceNr: UInt64 = 0
-        var _from: ProtoUniqueNode?
-        var _serializerID: UInt32 = 0
-        var _payload: Data = SwiftProtobuf.Internal.emptyData
+  fileprivate class _StorageClass {
+    var _sequenceNr: UInt64 = 0
+    var _from: ProtoUniqueNode? = nil
+    var _serializerID: UInt32 = 0
+    var _payload: Data = SwiftProtobuf.Internal.emptyData
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._sequenceNr = source._sequenceNr
-            self._from = source._from
-            self._serializerID = source._serializerID
-            self._payload = source._payload
-        }
+    init(copying source: _StorageClass) {
+      _sequenceNr = source._sequenceNr
+      _from = source._from
+      _serializerID = source._serializerID
+      _payload = source._payload
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularUInt64Field(value: &_storage._sequenceNr)
-                case 2: try decoder.decodeSingularMessageField(value: &_storage._from)
-                case 3: try decoder.decodeSingularUInt32Field(value: &_storage._serializerID)
-                case 4: try decoder.decodeSingularBytesField(value: &_storage._payload)
-                default: break
-                }
-            }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularUInt64Field(value: &_storage._sequenceNr)
+        case 2: try decoder.decodeSingularMessageField(value: &_storage._from)
+        case 3: try decoder.decodeSingularUInt32Field(value: &_storage._serializerID)
+        case 4: try decoder.decodeSingularBytesField(value: &_storage._payload)
+        default: break
         }
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if _storage._sequenceNr != 0 {
-                try visitor.visitSingularUInt64Field(value: _storage._sequenceNr, fieldNumber: 1)
-            }
-            if let v = _storage._from {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-            }
-            if _storage._serializerID != 0 {
-                try visitor.visitSingularUInt32Field(value: _storage._serializerID, fieldNumber: 3)
-            }
-            if !_storage._payload.isEmpty {
-                try visitor.visitSingularBytesField(value: _storage._payload, fieldNumber: 4)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if _storage._sequenceNr != 0 {
+        try visitor.visitSingularUInt64Field(value: _storage._sequenceNr, fieldNumber: 1)
+      }
+      if let v = _storage._from {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      }
+      if _storage._serializerID != 0 {
+        try visitor.visitSingularUInt32Field(value: _storage._serializerID, fieldNumber: 3)
+      }
+      if !_storage._payload.isEmpty {
+        try visitor.visitSingularBytesField(value: _storage._payload, fieldNumber: 4)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoSystemEnvelope, rhs: ProtoSystemEnvelope) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._sequenceNr != rhs_storage._sequenceNr { return false }
-                if _storage._from != rhs_storage._from { return false }
-                if _storage._serializerID != rhs_storage._serializerID { return false }
-                if _storage._payload != rhs_storage._payload { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  static func ==(lhs: ProtoSystemEnvelope, rhs: ProtoSystemEnvelope) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._sequenceNr != rhs_storage._sequenceNr {return false}
+        if _storage._from != rhs_storage._from {return false}
+        if _storage._serializerID != rhs_storage._serializerID {return false}
+        if _storage._payload != rhs_storage._payload {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoSystemAck: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "SystemAck"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "sequenceNr"),
-        2: .same(proto: "from"),
-    ]
+  static let protoMessageName: String = "SystemAck"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "sequenceNr"),
+    2: .same(proto: "from"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _sequenceNr: UInt64 = 0
-        var _from: ProtoUniqueNode?
+  fileprivate class _StorageClass {
+    var _sequenceNr: UInt64 = 0
+    var _from: ProtoUniqueNode? = nil
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._sequenceNr = source._sequenceNr
-            self._from = source._from
-        }
+    init(copying source: _StorageClass) {
+      _sequenceNr = source._sequenceNr
+      _from = source._from
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularUInt64Field(value: &_storage._sequenceNr)
-                case 2: try decoder.decodeSingularMessageField(value: &_storage._from)
-                default: break
-                }
-            }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularUInt64Field(value: &_storage._sequenceNr)
+        case 2: try decoder.decodeSingularMessageField(value: &_storage._from)
+        default: break
         }
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if _storage._sequenceNr != 0 {
-                try visitor.visitSingularUInt64Field(value: _storage._sequenceNr, fieldNumber: 1)
-            }
-            if let v = _storage._from {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if _storage._sequenceNr != 0 {
+        try visitor.visitSingularUInt64Field(value: _storage._sequenceNr, fieldNumber: 1)
+      }
+      if let v = _storage._from {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoSystemAck, rhs: ProtoSystemAck) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._sequenceNr != rhs_storage._sequenceNr { return false }
-                if _storage._from != rhs_storage._from { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  static func ==(lhs: ProtoSystemAck, rhs: ProtoSystemAck) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._sequenceNr != rhs_storage._sequenceNr {return false}
+        if _storage._from != rhs_storage._from {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoProtocolVersion: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "ProtocolVersion"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "reserved"),
-        2: .same(proto: "major"),
-        3: .same(proto: "minor"),
-        4: .same(proto: "patch"),
-    ]
+  static let protoMessageName: String = "ProtocolVersion"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "reserved"),
+    2: .same(proto: "major"),
+    3: .same(proto: "minor"),
+    4: .same(proto: "patch"),
+  ]
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        while let fieldNumber = try decoder.nextFieldNumber() {
-            switch fieldNumber {
-            case 1: try decoder.decodeSingularUInt32Field(value: &self.reserved)
-            case 2: try decoder.decodeSingularUInt32Field(value: &self.major)
-            case 3: try decoder.decodeSingularUInt32Field(value: &self.minor)
-            case 4: try decoder.decodeSingularUInt32Field(value: &self.patch)
-            default: break
-            }
-        }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularUInt32Field(value: &self.reserved)
+      case 2: try decoder.decodeSingularUInt32Field(value: &self.major)
+      case 3: try decoder.decodeSingularUInt32Field(value: &self.minor)
+      case 4: try decoder.decodeSingularUInt32Field(value: &self.patch)
+      default: break
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        if self.reserved != 0 {
-            try visitor.visitSingularUInt32Field(value: self.reserved, fieldNumber: 1)
-        }
-        if self.major != 0 {
-            try visitor.visitSingularUInt32Field(value: self.major, fieldNumber: 2)
-        }
-        if self.minor != 0 {
-            try visitor.visitSingularUInt32Field(value: self.minor, fieldNumber: 3)
-        }
-        if self.patch != 0 {
-            try visitor.visitSingularUInt32Field(value: self.patch, fieldNumber: 4)
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.reserved != 0 {
+      try visitor.visitSingularUInt32Field(value: self.reserved, fieldNumber: 1)
     }
+    if self.major != 0 {
+      try visitor.visitSingularUInt32Field(value: self.major, fieldNumber: 2)
+    }
+    if self.minor != 0 {
+      try visitor.visitSingularUInt32Field(value: self.minor, fieldNumber: 3)
+    }
+    if self.patch != 0 {
+      try visitor.visitSingularUInt32Field(value: self.patch, fieldNumber: 4)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoProtocolVersion, rhs: ProtoProtocolVersion) -> Bool {
-        if lhs.reserved != rhs.reserved { return false }
-        if lhs.major != rhs.major { return false }
-        if lhs.minor != rhs.minor { return false }
-        if lhs.patch != rhs.patch { return false }
-        if lhs.unknownFields != rhs.unknownFields { return false }
-        return true
-    }
+  static func ==(lhs: ProtoProtocolVersion, rhs: ProtoProtocolVersion) -> Bool {
+    if lhs.reserved != rhs.reserved {return false}
+    if lhs.major != rhs.major {return false}
+    if lhs.minor != rhs.minor {return false}
+    if lhs.patch != rhs.patch {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }

--- a/Sources/DistributedActorsBenchmarks/Protobuf/bench.pb.swift
+++ b/Sources/DistributedActorsBenchmarks/Protobuf/bench.pb.swift
@@ -28,406 +28,405 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that your are building against the same version of the API
 // that was used to generate this file.
-private struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-    struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
-    typealias Version = _2
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct ProtoSmallMessage {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var number: Int64 = 0
+  var number: Int64 = 0
 
-    var name: String = String()
+  var name: String = String()
 
-    var unknownFields = SwiftProtobuf.UnknownStorage()
+  var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    init() {}
+  init() {}
 }
 
 struct ProtoMediumMessage {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  var field01: String {
+    get {return _storage._field01}
+    set {_uniqueStorage()._field01 = newValue}
+  }
+
+  var field02: String {
+    get {return _storage._field02}
+    set {_uniqueStorage()._field02 = newValue}
+  }
+
+  var field03: Int32 {
+    get {return _storage._field03}
+    set {_uniqueStorage()._field03 = newValue}
+  }
+
+  var field04: ProtoMediumMessage.NestedMessage {
+    get {return _storage._field04 ?? ProtoMediumMessage.NestedMessage()}
+    set {_uniqueStorage()._field04 = newValue}
+  }
+  /// Returns true if `field04` has been explicitly set.
+  var hasField04: Bool {return _storage._field04 != nil}
+  /// Clears the value of `field04`. Subsequent reads from it will return its default value.
+  mutating func clearField04() {_uniqueStorage()._field04 = nil}
+
+  var field05: Bool {
+    get {return _storage._field05}
+    set {_uniqueStorage()._field05 = newValue}
+  }
+
+  var field06: Int32 {
+    get {return _storage._field06}
+    set {_uniqueStorage()._field06 = newValue}
+  }
+
+  var field07: Int64 {
+    get {return _storage._field07}
+    set {_uniqueStorage()._field07 = newValue}
+  }
+
+  var field08: Int64 {
+    get {return _storage._field08}
+    set {_uniqueStorage()._field08 = newValue}
+  }
+
+  var field09: Int64 {
+    get {return _storage._field09}
+    set {_uniqueStorage()._field09 = newValue}
+  }
+
+  var field10: Int64 {
+    get {return _storage._field10}
+    set {_uniqueStorage()._field10 = newValue}
+  }
+
+  var field11: Bool {
+    get {return _storage._field11}
+    set {_uniqueStorage()._field11 = newValue}
+  }
+
+  var field12: String {
+    get {return _storage._field12}
+    set {_uniqueStorage()._field12 = newValue}
+  }
+
+  var field13: Bool {
+    get {return _storage._field13}
+    set {_uniqueStorage()._field13 = newValue}
+  }
+
+  var field14: String {
+    get {return _storage._field14}
+    set {_uniqueStorage()._field14 = newValue}
+  }
+
+  var field15: String {
+    get {return _storage._field15}
+    set {_uniqueStorage()._field15 = newValue}
+  }
+
+  var field16: Int64 {
+    get {return _storage._field16}
+    set {_uniqueStorage()._field16 = newValue}
+  }
+
+  var field17: Int64 {
+    get {return _storage._field17}
+    set {_uniqueStorage()._field17 = newValue}
+  }
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  struct NestedMessage {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
 
-    var field01: String {
-        get { return self._storage._field01 }
-        set { _uniqueStorage()._field01 = newValue }
-    }
+    var field1: String = String()
 
-    var field02: String {
-        get { return self._storage._field02 }
-        set { _uniqueStorage()._field02 = newValue }
-    }
+    var field2: Int32 = 0
 
-    var field03: Int32 {
-        get { return self._storage._field03 }
-        set { _uniqueStorage()._field03 = newValue }
-    }
-
-    var field04: ProtoMediumMessage.NestedMessage {
-        get { return self._storage._field04 ?? ProtoMediumMessage.NestedMessage() }
-        set { _uniqueStorage()._field04 = newValue }
-    }
-
-    /// Returns true if `field04` has been explicitly set.
-    var hasField04: Bool { return _storage._field04 != nil }
-    /// Clears the value of `field04`. Subsequent reads from it will return its default value.
-    mutating func clearField04() { _uniqueStorage()._field04 = nil }
-
-    var field05: Bool {
-        get { return self._storage._field05 }
-        set { _uniqueStorage()._field05 = newValue }
-    }
-
-    var field06: Int32 {
-        get { return self._storage._field06 }
-        set { _uniqueStorage()._field06 = newValue }
-    }
-
-    var field07: Int64 {
-        get { return self._storage._field07 }
-        set { _uniqueStorage()._field07 = newValue }
-    }
-
-    var field08: Int64 {
-        get { return self._storage._field08 }
-        set { _uniqueStorage()._field08 = newValue }
-    }
-
-    var field09: Int64 {
-        get { return self._storage._field09 }
-        set { _uniqueStorage()._field09 = newValue }
-    }
-
-    var field10: Int64 {
-        get { return self._storage._field10 }
-        set { _uniqueStorage()._field10 = newValue }
-    }
-
-    var field11: Bool {
-        get { return self._storage._field11 }
-        set { _uniqueStorage()._field11 = newValue }
-    }
-
-    var field12: String {
-        get { return self._storage._field12 }
-        set { _uniqueStorage()._field12 = newValue }
-    }
-
-    var field13: Bool {
-        get { return self._storage._field13 }
-        set { _uniqueStorage()._field13 = newValue }
-    }
-
-    var field14: String {
-        get { return self._storage._field14 }
-        set { _uniqueStorage()._field14 = newValue }
-    }
-
-    var field15: String {
-        get { return self._storage._field15 }
-        set { _uniqueStorage()._field15 = newValue }
-    }
-
-    var field16: Int64 {
-        get { return self._storage._field16 }
-        set { _uniqueStorage()._field16 = newValue }
-    }
-
-    var field17: Int64 {
-        get { return self._storage._field17 }
-        set { _uniqueStorage()._field17 = newValue }
-    }
+    var field3: Int32 = 0
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    struct NestedMessage {
-        // SwiftProtobuf.Message conformance is added in an extension below. See the
-        // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-        // methods supported on all messages.
-
-        var field1: String = String()
-
-        var field2: Int32 = 0
-
-        var field3: Int32 = 0
-
-        var unknownFields = SwiftProtobuf.UnknownStorage()
-
-        init() {}
-    }
-
     init() {}
+  }
 
-    fileprivate var _storage = _StorageClass.defaultInstance
+  init() {}
+
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 extension ProtoSmallMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "SmallMessage"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "number"),
-        2: .same(proto: "name"),
-    ]
+  static let protoMessageName: String = "SmallMessage"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "number"),
+    2: .same(proto: "name"),
+  ]
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        while let fieldNumber = try decoder.nextFieldNumber() {
-            switch fieldNumber {
-            case 1: try decoder.decodeSingularInt64Field(value: &self.number)
-            case 2: try decoder.decodeSingularStringField(value: &self.name)
-            default: break
-            }
-        }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt64Field(value: &self.number)
+      case 2: try decoder.decodeSingularStringField(value: &self.name)
+      default: break
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        if self.number != 0 {
-            try visitor.visitSingularInt64Field(value: self.number, fieldNumber: 1)
-        }
-        if !self.name.isEmpty {
-            try visitor.visitSingularStringField(value: self.name, fieldNumber: 2)
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.number != 0 {
+      try visitor.visitSingularInt64Field(value: self.number, fieldNumber: 1)
     }
+    if !self.name.isEmpty {
+      try visitor.visitSingularStringField(value: self.name, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoSmallMessage, rhs: ProtoSmallMessage) -> Bool {
-        if lhs.number != rhs.number { return false }
-        if lhs.name != rhs.name { return false }
-        if lhs.unknownFields != rhs.unknownFields { return false }
-        return true
-    }
+  static func ==(lhs: ProtoSmallMessage, rhs: ProtoSmallMessage) -> Bool {
+    if lhs.number != rhs.number {return false}
+    if lhs.name != rhs.name {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoMediumMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "MediumMessage"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "field01"),
-        2: .same(proto: "field02"),
-        3: .same(proto: "field03"),
-        4: .same(proto: "field04"),
-        5: .same(proto: "field05"),
-        6: .same(proto: "field06"),
-        7: .same(proto: "field07"),
-        8: .same(proto: "field08"),
-        9: .same(proto: "field09"),
-        10: .same(proto: "field10"),
-        11: .same(proto: "field11"),
-        12: .same(proto: "field12"),
-        13: .same(proto: "field13"),
-        14: .same(proto: "field14"),
-        15: .same(proto: "field15"),
-        16: .same(proto: "field16"),
-        17: .same(proto: "field17"),
-    ]
+  static let protoMessageName: String = "MediumMessage"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "field01"),
+    2: .same(proto: "field02"),
+    3: .same(proto: "field03"),
+    4: .same(proto: "field04"),
+    5: .same(proto: "field05"),
+    6: .same(proto: "field06"),
+    7: .same(proto: "field07"),
+    8: .same(proto: "field08"),
+    9: .same(proto: "field09"),
+    10: .same(proto: "field10"),
+    11: .same(proto: "field11"),
+    12: .same(proto: "field12"),
+    13: .same(proto: "field13"),
+    14: .same(proto: "field14"),
+    15: .same(proto: "field15"),
+    16: .same(proto: "field16"),
+    17: .same(proto: "field17"),
+  ]
 
-    fileprivate class _StorageClass {
-        var _field01: String = String()
-        var _field02: String = String()
-        var _field03: Int32 = 0
-        var _field04: ProtoMediumMessage.NestedMessage?
-        var _field05: Bool = false
-        var _field06: Int32 = 0
-        var _field07: Int64 = 0
-        var _field08: Int64 = 0
-        var _field09: Int64 = 0
-        var _field10: Int64 = 0
-        var _field11: Bool = false
-        var _field12: String = String()
-        var _field13: Bool = false
-        var _field14: String = String()
-        var _field15: String = String()
-        var _field16: Int64 = 0
-        var _field17: Int64 = 0
+  fileprivate class _StorageClass {
+    var _field01: String = String()
+    var _field02: String = String()
+    var _field03: Int32 = 0
+    var _field04: ProtoMediumMessage.NestedMessage? = nil
+    var _field05: Bool = false
+    var _field06: Int32 = 0
+    var _field07: Int64 = 0
+    var _field08: Int64 = 0
+    var _field09: Int64 = 0
+    var _field10: Int64 = 0
+    var _field11: Bool = false
+    var _field12: String = String()
+    var _field13: Bool = false
+    var _field14: String = String()
+    var _field15: String = String()
+    var _field16: Int64 = 0
+    var _field17: Int64 = 0
 
-        static let defaultInstance = _StorageClass()
+    static let defaultInstance = _StorageClass()
 
-        private init() {}
+    private init() {}
 
-        init(copying source: _StorageClass) {
-            self._field01 = source._field01
-            self._field02 = source._field02
-            self._field03 = source._field03
-            self._field04 = source._field04
-            self._field05 = source._field05
-            self._field06 = source._field06
-            self._field07 = source._field07
-            self._field08 = source._field08
-            self._field09 = source._field09
-            self._field10 = source._field10
-            self._field11 = source._field11
-            self._field12 = source._field12
-            self._field13 = source._field13
-            self._field14 = source._field14
-            self._field15 = source._field15
-            self._field16 = source._field16
-            self._field17 = source._field17
-        }
+    init(copying source: _StorageClass) {
+      _field01 = source._field01
+      _field02 = source._field02
+      _field03 = source._field03
+      _field04 = source._field04
+      _field05 = source._field05
+      _field06 = source._field06
+      _field07 = source._field07
+      _field08 = source._field08
+      _field09 = source._field09
+      _field10 = source._field10
+      _field11 = source._field11
+      _field12 = source._field12
+      _field13 = source._field13
+      _field14 = source._field14
+      _field15 = source._field15
+      _field16 = source._field16
+      _field17 = source._field17
     }
+  }
 
-    fileprivate mutating func _uniqueStorage() -> _StorageClass {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = _StorageClass(copying: self._storage)
-        }
-        return self._storage
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
     }
+    return _storage
+  }
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        _ = self._uniqueStorage()
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            while let fieldNumber = try decoder.nextFieldNumber() {
-                switch fieldNumber {
-                case 1: try decoder.decodeSingularStringField(value: &_storage._field01)
-                case 2: try decoder.decodeSingularStringField(value: &_storage._field02)
-                case 3: try decoder.decodeSingularInt32Field(value: &_storage._field03)
-                case 4: try decoder.decodeSingularMessageField(value: &_storage._field04)
-                case 5: try decoder.decodeSingularBoolField(value: &_storage._field05)
-                case 6: try decoder.decodeSingularInt32Field(value: &_storage._field06)
-                case 7: try decoder.decodeSingularInt64Field(value: &_storage._field07)
-                case 8: try decoder.decodeSingularInt64Field(value: &_storage._field08)
-                case 9: try decoder.decodeSingularInt64Field(value: &_storage._field09)
-                case 10: try decoder.decodeSingularInt64Field(value: &_storage._field10)
-                case 11: try decoder.decodeSingularBoolField(value: &_storage._field11)
-                case 12: try decoder.decodeSingularStringField(value: &_storage._field12)
-                case 13: try decoder.decodeSingularBoolField(value: &_storage._field13)
-                case 14: try decoder.decodeSingularStringField(value: &_storage._field14)
-                case 15: try decoder.decodeSingularStringField(value: &_storage._field15)
-                case 16: try decoder.decodeSingularInt64Field(value: &_storage._field16)
-                case 17: try decoder.decodeSingularInt64Field(value: &_storage._field17)
-                default: break
-                }
-            }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeSingularStringField(value: &_storage._field01)
+        case 2: try decoder.decodeSingularStringField(value: &_storage._field02)
+        case 3: try decoder.decodeSingularInt32Field(value: &_storage._field03)
+        case 4: try decoder.decodeSingularMessageField(value: &_storage._field04)
+        case 5: try decoder.decodeSingularBoolField(value: &_storage._field05)
+        case 6: try decoder.decodeSingularInt32Field(value: &_storage._field06)
+        case 7: try decoder.decodeSingularInt64Field(value: &_storage._field07)
+        case 8: try decoder.decodeSingularInt64Field(value: &_storage._field08)
+        case 9: try decoder.decodeSingularInt64Field(value: &_storage._field09)
+        case 10: try decoder.decodeSingularInt64Field(value: &_storage._field10)
+        case 11: try decoder.decodeSingularBoolField(value: &_storage._field11)
+        case 12: try decoder.decodeSingularStringField(value: &_storage._field12)
+        case 13: try decoder.decodeSingularBoolField(value: &_storage._field13)
+        case 14: try decoder.decodeSingularStringField(value: &_storage._field14)
+        case 15: try decoder.decodeSingularStringField(value: &_storage._field15)
+        case 16: try decoder.decodeSingularInt64Field(value: &_storage._field16)
+        case 17: try decoder.decodeSingularInt64Field(value: &_storage._field17)
+        default: break
         }
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        try withExtendedLifetime(self._storage) { (_storage: _StorageClass) in
-            if !_storage._field01.isEmpty {
-                try visitor.visitSingularStringField(value: _storage._field01, fieldNumber: 1)
-            }
-            if !_storage._field02.isEmpty {
-                try visitor.visitSingularStringField(value: _storage._field02, fieldNumber: 2)
-            }
-            if _storage._field03 != 0 {
-                try visitor.visitSingularInt32Field(value: _storage._field03, fieldNumber: 3)
-            }
-            if let v = _storage._field04 {
-                try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
-            }
-            if _storage._field05 != false {
-                try visitor.visitSingularBoolField(value: _storage._field05, fieldNumber: 5)
-            }
-            if _storage._field06 != 0 {
-                try visitor.visitSingularInt32Field(value: _storage._field06, fieldNumber: 6)
-            }
-            if _storage._field07 != 0 {
-                try visitor.visitSingularInt64Field(value: _storage._field07, fieldNumber: 7)
-            }
-            if _storage._field08 != 0 {
-                try visitor.visitSingularInt64Field(value: _storage._field08, fieldNumber: 8)
-            }
-            if _storage._field09 != 0 {
-                try visitor.visitSingularInt64Field(value: _storage._field09, fieldNumber: 9)
-            }
-            if _storage._field10 != 0 {
-                try visitor.visitSingularInt64Field(value: _storage._field10, fieldNumber: 10)
-            }
-            if _storage._field11 != false {
-                try visitor.visitSingularBoolField(value: _storage._field11, fieldNumber: 11)
-            }
-            if !_storage._field12.isEmpty {
-                try visitor.visitSingularStringField(value: _storage._field12, fieldNumber: 12)
-            }
-            if _storage._field13 != false {
-                try visitor.visitSingularBoolField(value: _storage._field13, fieldNumber: 13)
-            }
-            if !_storage._field14.isEmpty {
-                try visitor.visitSingularStringField(value: _storage._field14, fieldNumber: 14)
-            }
-            if !_storage._field15.isEmpty {
-                try visitor.visitSingularStringField(value: _storage._field15, fieldNumber: 15)
-            }
-            if _storage._field16 != 0 {
-                try visitor.visitSingularInt64Field(value: _storage._field16, fieldNumber: 16)
-            }
-            if _storage._field17 != 0 {
-                try visitor.visitSingularInt64Field(value: _storage._field17, fieldNumber: 17)
-            }
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if !_storage._field01.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._field01, fieldNumber: 1)
+      }
+      if !_storage._field02.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._field02, fieldNumber: 2)
+      }
+      if _storage._field03 != 0 {
+        try visitor.visitSingularInt32Field(value: _storage._field03, fieldNumber: 3)
+      }
+      if let v = _storage._field04 {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+      }
+      if _storage._field05 != false {
+        try visitor.visitSingularBoolField(value: _storage._field05, fieldNumber: 5)
+      }
+      if _storage._field06 != 0 {
+        try visitor.visitSingularInt32Field(value: _storage._field06, fieldNumber: 6)
+      }
+      if _storage._field07 != 0 {
+        try visitor.visitSingularInt64Field(value: _storage._field07, fieldNumber: 7)
+      }
+      if _storage._field08 != 0 {
+        try visitor.visitSingularInt64Field(value: _storage._field08, fieldNumber: 8)
+      }
+      if _storage._field09 != 0 {
+        try visitor.visitSingularInt64Field(value: _storage._field09, fieldNumber: 9)
+      }
+      if _storage._field10 != 0 {
+        try visitor.visitSingularInt64Field(value: _storage._field10, fieldNumber: 10)
+      }
+      if _storage._field11 != false {
+        try visitor.visitSingularBoolField(value: _storage._field11, fieldNumber: 11)
+      }
+      if !_storage._field12.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._field12, fieldNumber: 12)
+      }
+      if _storage._field13 != false {
+        try visitor.visitSingularBoolField(value: _storage._field13, fieldNumber: 13)
+      }
+      if !_storage._field14.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._field14, fieldNumber: 14)
+      }
+      if !_storage._field15.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._field15, fieldNumber: 15)
+      }
+      if _storage._field16 != 0 {
+        try visitor.visitSingularInt64Field(value: _storage._field16, fieldNumber: 16)
+      }
+      if _storage._field17 != 0 {
+        try visitor.visitSingularInt64Field(value: _storage._field17, fieldNumber: 17)
+      }
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoMediumMessage, rhs: ProtoMediumMessage) -> Bool {
-        if lhs._storage !== rhs._storage {
-            let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-                let _storage = _args.0
-                let rhs_storage = _args.1
-                if _storage._field01 != rhs_storage._field01 { return false }
-                if _storage._field02 != rhs_storage._field02 { return false }
-                if _storage._field03 != rhs_storage._field03 { return false }
-                if _storage._field04 != rhs_storage._field04 { return false }
-                if _storage._field05 != rhs_storage._field05 { return false }
-                if _storage._field06 != rhs_storage._field06 { return false }
-                if _storage._field07 != rhs_storage._field07 { return false }
-                if _storage._field08 != rhs_storage._field08 { return false }
-                if _storage._field09 != rhs_storage._field09 { return false }
-                if _storage._field10 != rhs_storage._field10 { return false }
-                if _storage._field11 != rhs_storage._field11 { return false }
-                if _storage._field12 != rhs_storage._field12 { return false }
-                if _storage._field13 != rhs_storage._field13 { return false }
-                if _storage._field14 != rhs_storage._field14 { return false }
-                if _storage._field15 != rhs_storage._field15 { return false }
-                if _storage._field16 != rhs_storage._field16 { return false }
-                if _storage._field17 != rhs_storage._field17 { return false }
-                return true
-            }
-            if !storagesAreEqual { return false }
-        }
-        if lhs.unknownFields != rhs.unknownFields { return false }
+  static func ==(lhs: ProtoMediumMessage, rhs: ProtoMediumMessage) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._field01 != rhs_storage._field01 {return false}
+        if _storage._field02 != rhs_storage._field02 {return false}
+        if _storage._field03 != rhs_storage._field03 {return false}
+        if _storage._field04 != rhs_storage._field04 {return false}
+        if _storage._field05 != rhs_storage._field05 {return false}
+        if _storage._field06 != rhs_storage._field06 {return false}
+        if _storage._field07 != rhs_storage._field07 {return false}
+        if _storage._field08 != rhs_storage._field08 {return false}
+        if _storage._field09 != rhs_storage._field09 {return false}
+        if _storage._field10 != rhs_storage._field10 {return false}
+        if _storage._field11 != rhs_storage._field11 {return false}
+        if _storage._field12 != rhs_storage._field12 {return false}
+        if _storage._field13 != rhs_storage._field13 {return false}
+        if _storage._field14 != rhs_storage._field14 {return false}
+        if _storage._field15 != rhs_storage._field15 {return false}
+        if _storage._field16 != rhs_storage._field16 {return false}
+        if _storage._field17 != rhs_storage._field17 {return false}
         return true
+      }
+      if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoMediumMessage.NestedMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = ProtoMediumMessage.protoMessageName + ".NestedMessage"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "field1"),
-        2: .same(proto: "field2"),
-        3: .same(proto: "field3"),
-    ]
+  static let protoMessageName: String = ProtoMediumMessage.protoMessageName + ".NestedMessage"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "field1"),
+    2: .same(proto: "field2"),
+    3: .same(proto: "field3"),
+  ]
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        while let fieldNumber = try decoder.nextFieldNumber() {
-            switch fieldNumber {
-            case 1: try decoder.decodeSingularStringField(value: &self.field1)
-            case 2: try decoder.decodeSingularInt32Field(value: &self.field2)
-            case 3: try decoder.decodeSingularInt32Field(value: &self.field3)
-            default: break
-            }
-        }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self.field1)
+      case 2: try decoder.decodeSingularInt32Field(value: &self.field2)
+      case 3: try decoder.decodeSingularInt32Field(value: &self.field3)
+      default: break
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        if !self.field1.isEmpty {
-            try visitor.visitSingularStringField(value: self.field1, fieldNumber: 1)
-        }
-        if self.field2 != 0 {
-            try visitor.visitSingularInt32Field(value: self.field2, fieldNumber: 2)
-        }
-        if self.field3 != 0 {
-            try visitor.visitSingularInt32Field(value: self.field3, fieldNumber: 3)
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.field1.isEmpty {
+      try visitor.visitSingularStringField(value: self.field1, fieldNumber: 1)
     }
+    if self.field2 != 0 {
+      try visitor.visitSingularInt32Field(value: self.field2, fieldNumber: 2)
+    }
+    if self.field3 != 0 {
+      try visitor.visitSingularInt32Field(value: self.field3, fieldNumber: 3)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoMediumMessage.NestedMessage, rhs: ProtoMediumMessage.NestedMessage) -> Bool {
-        if lhs.field1 != rhs.field1 { return false }
-        if lhs.field2 != rhs.field2 { return false }
-        if lhs.field3 != rhs.field3 { return false }
-        if lhs.unknownFields != rhs.unknownFields { return false }
-        return true
-    }
+  static func ==(lhs: ProtoMediumMessage.NestedMessage, rhs: ProtoMediumMessage.NestedMessage) -> Bool {
+    if lhs.field1 != rhs.field1 {return false}
+    if lhs.field2 != rhs.field2 {return false}
+    if lhs.field3 != rhs.field3 {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }

--- a/Tests/DistributedActorsDocumentationTests/Protobuf/SerializationDocExamples.pb.swift
+++ b/Tests/DistributedActorsDocumentationTests/Protobuf/SerializationDocExamples.pb.swift
@@ -30,96 +30,97 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that your are building against the same version of the API
 // that was used to generate this file.
-private struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-    struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
-    typealias Version = _2
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct ProtoParkingGarageStatus {
-    // SwiftProtobuf.Message conformance is added in an extension below. See the
-    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-    // methods supported on all messages.
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
-    var type: ProtoParkingGarageStatus.TypeEnum = .available
+  var type: ProtoParkingGarageStatus.TypeEnum = .available
 
-    var unknownFields = SwiftProtobuf.UnknownStorage()
+  var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    enum TypeEnum: SwiftProtobuf.Enum {
-        typealias RawValue = Int
-        case available // = 0
-        case full // = 1
-        case UNRECOGNIZED(Int)
+  enum TypeEnum: SwiftProtobuf.Enum {
+    typealias RawValue = Int
+    case available // = 0
+    case full // = 1
+    case UNRECOGNIZED(Int)
 
-        init() {
-            self = .available
-        }
-
-        init?(rawValue: Int) {
-            switch rawValue {
-            case 0: self = .available
-            case 1: self = .full
-            default: self = .UNRECOGNIZED(rawValue)
-            }
-        }
-
-        var rawValue: Int {
-            switch self {
-            case .available: return 0
-            case .full: return 1
-            case .UNRECOGNIZED(let i): return i
-            }
-        }
+    init() {
+      self = .available
     }
 
-    init() {}
+    init?(rawValue: Int) {
+      switch rawValue {
+      case 0: self = .available
+      case 1: self = .full
+      default: self = .UNRECOGNIZED(rawValue)
+      }
+    }
+
+    var rawValue: Int {
+      switch self {
+      case .available: return 0
+      case .full: return 1
+      case .UNRECOGNIZED(let i): return i
+      }
+    }
+
+  }
+
+  init() {}
 }
 
 #if swift(>=4.2)
 
 extension ProtoParkingGarageStatus.TypeEnum: CaseIterable {
-    // The compiler won't synthesize support with the UNRECOGNIZED case.
-    static var allCases: [ProtoParkingGarageStatus.TypeEnum] = [
-        .available,
-        .full,
-    ]
+  // The compiler won't synthesize support with the UNRECOGNIZED case.
+  static var allCases: [ProtoParkingGarageStatus.TypeEnum] = [
+    .available,
+    .full,
+  ]
 }
 
-#endif // swift(>=4.2)
+#endif  // swift(>=4.2)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 extension ProtoParkingGarageStatus: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-    static let protoMessageName: String = "ParkingGarageStatus"
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        1: .same(proto: "type"),
-    ]
+  static let protoMessageName: String = "ParkingGarageStatus"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "type"),
+  ]
 
-    mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-        while let fieldNumber = try decoder.nextFieldNumber() {
-            switch fieldNumber {
-            case 1: try decoder.decodeSingularEnumField(value: &self.type)
-            default: break
-            }
-        }
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularEnumField(value: &self.type)
+      default: break
+      }
     }
+  }
 
-    func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-        if self.type != .available {
-            try visitor.visitSingularEnumField(value: self.type, fieldNumber: 1)
-        }
-        try self.unknownFields.traverse(visitor: &visitor)
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.type != .available {
+      try visitor.visitSingularEnumField(value: self.type, fieldNumber: 1)
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
 
-    static func == (lhs: ProtoParkingGarageStatus, rhs: ProtoParkingGarageStatus) -> Bool {
-        if lhs.type != rhs.type { return false }
-        if lhs.unknownFields != rhs.unknownFields { return false }
-        return true
-    }
+  static func ==(lhs: ProtoParkingGarageStatus, rhs: ProtoParkingGarageStatus) -> Bool {
+    if lhs.type != rhs.type {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
 extension ProtoParkingGarageStatus.TypeEnum: SwiftProtobuf._ProtoNameProviding {
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        0: .same(proto: "AVAILABLE"),
-        1: .same(proto: "FULL"),
-    ]
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "AVAILABLE"),
+    1: .same(proto: "FULL"),
+  ]
 }

--- a/scripts/validate_format.sh
+++ b/scripts/validate_format.sh
@@ -15,13 +15,16 @@
 
 set -u
 
+# verify that swiftformat is on the PATH
+command -v swiftformat >/dev/null 2>&1 || { echo >&2 "'swiftformat' could not be found. Please ensure it is installed and on the PATH."; exit 1; }
+
 printf "=> Checking format\n"
 FIRST_OUT="$(git status --porcelain)"
 # swiftformat does not scale so we loop ourselves
 shopt -u dotglob
 find Sources/* Tests/* -type d | while IFS= read -r d; do
   printf "   * checking $d... "
-  out=$(swiftformat $d 2>&1)
+  out=$(swiftformat --exclude "**/*.pb.swift" $d 2>&1)
   SECOND_OUT="$(git status --porcelain)"
   if [[ "$out" == *"error"*] && ["$out" != "*No eligible files" ]]; then
     printf "\033[0;31merror!\033[0m\n"


### PR DESCRIPTION
### Motivation:

swift-protobuf does not use the same formatting rules that we use, which means that every time we re-generate the protobuf sources, we also have to re-format those files. That's annoying and since they should not be manually touched anyway, it's better to exclude them from swiftformat completely.

### Result:

- Resolves #84 
- Protobuf sources will be ignored by the `validate_format.sh` script
- `validate_format.sh` will fail if `swiftformat` is not installed, instead of silently passing.
