### PR TITLE
Use EventLoopFuture.completeWith where possible #95

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -158,7 +158,7 @@ let targets: [PackageDescription.Target] = [
 ]
 
 let dependencies: [Package.Dependency] = [
-    .package(url: "https://github.com/apple/swift-nio.git", from: "2.7.0"),
+    .package(url: "https://github.com/apple/swift-nio.git", from: "2.8.0"),
     .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.2.0"),
     .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.2.0"),
 

--- a/Sources/DistributedActors/ActorRef+Ask.swift
+++ b/Sources/DistributedActors/ActorRef+Ask.swift
@@ -117,7 +117,7 @@ public struct AskResponse<Value> {
 }
 
 extension AskResponse: AsyncResult {
-    public func onComplete(_ callback: @escaping (Result<Value, ExecutionError>) -> Void) {
+    public func onComplete(_ callback: @escaping (Result<Value, Error>) -> Void) {
         self.nioFuture.onComplete { result in
             callback(result)
         }

--- a/Sources/DistributedActors/Behaviors.swift
+++ b/Sources/DistributedActors/Behaviors.swift
@@ -282,7 +282,7 @@ internal extension Behavior {
     ///
     /// MUST be canonicalized (to .suspended before storing in an `ActorCell`, as thr suspend behavior CAN NOT handle messages.
     @usableFromInline
-    static func suspend<T>(handler: @escaping (Result<T, ExecutionError>) throws -> Behavior<Message>) -> Behavior<Message> {
+    static func suspend<T>(handler: @escaping (Result<T, Error>) throws -> Behavior<Message>) -> Behavior<Message> {
         return Behavior(underlying: .suspend(handler: { result in
             try handler(result.map { $0 as! T }) // cast here is okay, as user APIs are typed, so we should always get a T
         }))
@@ -294,7 +294,7 @@ internal extension Behavior {
     /// This usually happens when an async operation that caused the suspension
     /// is completed.
     @usableFromInline
-    static func suspended(previousBehavior: Behavior<Message>, handler: @escaping (Result<Any, ExecutionError>) throws -> Behavior<Message>) -> Behavior<Message> {
+    static func suspended(previousBehavior: Behavior<Message>, handler: @escaping (Result<Any, Error>) throws -> Behavior<Message>) -> Behavior<Message> {
         return Behavior(underlying: .suspended(previousBehavior: previousBehavior, handler: handler))
     }
 
@@ -336,8 +336,8 @@ internal enum _Behavior<Message> {
 
     indirect case orElse(first: Behavior<Message>, second: Behavior<Message>)
 
-    case suspend(handler: (Result<Any, ExecutionError>) throws -> Behavior<Message>)
-    indirect case suspended(previousBehavior: Behavior<Message>, handler: (Result<Any, ExecutionError>) throws -> Behavior<Message>)
+    case suspend(handler: (Result<Any, Error>) throws -> Behavior<Message>)
+    indirect case suspended(previousBehavior: Behavior<Message>, handler: (Result<Any, Error>) throws -> Behavior<Message>)
 }
 
 @usableFromInline

--- a/Sources/DistributedActors/Cluster/SWIM/SWIMInstance.swift
+++ b/Sources/DistributedActors/Cluster/SWIM/SWIMInstance.swift
@@ -350,7 +350,7 @@ extension SWIM.Instance {
     }
 
     /// React to an `Ack` (or lack thereof within timeout)
-    func onPingRequestResponse(_ result: Result<SWIM.Ack, ExecutionError>, pingedMember member: ActorRef<SWIM.Message>) -> OnPingRequestResponseDirective {
+    func onPingRequestResponse(_ result: Result<SWIM.Ack, Error>, pingedMember member: ActorRef<SWIM.Message>) -> OnPingRequestResponseDirective {
         guard let lastKnownStatus = self.status(of: member) else {
             return .unknownMember
         }

--- a/Sources/DistributedActors/Cluster/SWIM/SWIMShell.swift
+++ b/Sources/DistributedActors/Cluster/SWIM/SWIMShell.swift
@@ -207,7 +207,7 @@ internal struct SWIMShell {
     /// - parameter pingReqOrigin: is set only when the ping that this is a reply to was originated as a `pingReq`.
     func handlePingResponse(
         context: ActorContext<SWIM.Message>,
-        result: Result<SWIM.Ack, ExecutionError>,
+        result: Result<SWIM.Ack, Error>,
         pingedMember: ActorRef<SWIM.Message>,
         pingReqOrigin: ActorRef<SWIM.Ack>?
     ) {
@@ -215,7 +215,7 @@ internal struct SWIMShell {
 
         switch result {
         case .failure(let err):
-            if let timeoutError = err.extractUnderlying(as: TimeoutError.self) {
+            if let timeoutError = err as? TimeoutError {
                 context.log.warning("Did not receive ack from [\(pingedMember)] within [\(timeoutError.timeout.prettyDescription)]. Sending ping requests to other members.")
             } else {
                 context.log.warning("\(err) Did not receive ack from [\(pingedMember)] within configured timeout. Sending ping requests to other members.")
@@ -233,7 +233,7 @@ internal struct SWIMShell {
         }
     }
 
-    func handlePingRequestResult(context: ActorContext<SWIM.Message>, result: Result<SWIM.Ack, ExecutionError>, pingedMember: ActorRef<SWIM.Message>) {
+    func handlePingRequestResult(context: ActorContext<SWIM.Message>, result: Result<SWIM.Ack, Error>, pingedMember: ActorRef<SWIM.Message>) {
         self.tracelog(context, .receive(pinged: pingedMember), message: result)
         // TODO: do we know here WHO replied to us actually? We know who they told us about (with the ping-req), could be useful to know
 

--- a/Sources/DistributedActors/Supervision.swift
+++ b/Sources/DistributedActors/Supervision.swift
@@ -846,7 +846,7 @@ internal enum SupervisionRestartDelayedBehavior<Message> {
         return .setup { context in
             context.timers._startResumeTimer(key: TimerKey("restartBackoff", isSystemTimer: true), delay: delay, resumeWith: WakeUp())
 
-            return .suspend { (result: Result<WakeUp, ExecutionError>) in
+            return .suspend { (result: Result<WakeUp, Error>) in
                 traceLog_Supervision("RESTART BACKOFF TRIGGER")
                 switch result {
                 case .failure(let error):

--- a/Sources/DistributedActors/SystemMessages.swift
+++ b/Sources/DistributedActors/SystemMessages.swift
@@ -70,7 +70,7 @@ internal enum SystemMessage: Equatable {
     case stop
 
     /// Sent to a suspended actor when the async operation it is waiting for completes
-    case resume(Result<Any, ExecutionError>)
+    case resume(Result<Any, Error>)
 
     /// WARNING: Sending a tombstone has very special meaning and should never be attempted outside of situations where
     /// the actor is semantically "done", i.e. it is currently terminating and is going to be released soon.
@@ -157,16 +157,4 @@ extension SystemMessage {
 
 extension SystemMessage {
     internal static let metaType: MetaType<SystemMessage> = MetaType(SystemMessage.self)
-}
-
-// ==== ----------------------------------------------------------------------------------------------------------------
-// MARK: Errors
-
-// TODO: document where this is intended to be used; supervision and suspension? should we separate the two?
-public struct ExecutionError: Error {
-    let underlying: Error
-
-    func extractUnderlying<ErrorType: Error>(as type: ErrorType.Type) -> ErrorType? {
-        return self.underlying as? ErrorType
-    }
 }

--- a/Tests/DistributedActorsTests/ActorAskTests.swift
+++ b/Tests/DistributedActorsTests/ActorAskTests.swift
@@ -159,11 +159,9 @@ final class ActorAskTests: XCTestCase {
             }
         })
 
-        var msg = "ExecutionError(underlying: "
-        msg += "DistributedActors.TimeoutError("
+        var msg = "TimeoutError("
         msg += "message: \"AskResponse<String> timed out after 100ms\", "
         msg += "timeout: TimeAmount(100ms, nanoseconds: 100000000))"
-        msg += ")"
         try p.expectMessage(msg)
     }
 


### PR DESCRIPTION
Also removes unnecessary ExecutionError from AsyncResult

### Motivation:

Gets rid of some nasty do/catch blocks

### Modifications:

See description

### Result:

- Resolves #95 
