### PR TITLE
+test improve formatting of eventually failures in shouldNotThrow

### DIFF
--- a/Sources/DistributedActorsTestKit/ShouldMatchers.swift
+++ b/Sources/DistributedActorsTestKit/ShouldMatchers.swift
@@ -357,6 +357,8 @@ public func shouldNotThrow<T>(file: StaticString = #file, line: UInt = #line, co
         switch error {
         case let eventuallyError as EventuallyError:
             msg = callSiteInfo.detailedMessage("Unexpected throw captured") + "\(eventuallyError.message)"
+        case CallSiteError.error(let message):
+            msg = callSiteInfo.detailedMessage("Unexpected throw captured") + "\(message)"
         default:
             msg = callSiteInfo.detailedMessage("Unexpected throw captured: [\(error)]")
         }


### PR DESCRIPTION
Nicer printouts 

### Motivation:

Without this:

```
        try shouldNotThrow {
            ^~~~~~~~~~~~~~~
error: Unexpected throw captured: [EventuallyError(message: "\n            try assertAssociated(secondReplacement, withExactly: [first.cluster.node])\n                     \u{1B}[0;31m^~~~~~~~~~~\nerror: No result within 5s for block at /Users/ktoso/code/actors/Tests/DistributedActorsTests/Cluster/AssociationClusteredTests.swift:103. Queried 2 times, within 5s. Last error: \n            try assertAssociated(secondReplacement, withExactly: [first.cluster.node])\n                                           \u{1B}[0;31m^~~~~~~~~~~~~~\nerror: Did not receive message of type [Set<UniqueNode>] within [3s], error: noMessagesInQueue\u{1B}[0;0m\u{1B}[0;0m", lastError: Optional(DistributedActorsTestKit.CallSiteError.error(message: "\n            try assertAssociated(secondReplacement, withExactly: [first.cluster.node])\n                                           \u{1B}[0;31m^~~~~~~~~~~~~~\nerror: Did not receive message of type [Set<UniqueNode>] within [3s], error: noMessagesInQueue\u{1B}[0;0m")))]
```

With this:

```
        try shouldNotThrow {
            ^~~~~~~~~~~~~~~
error: Unexpected throw captured
            try assertAssociated(secondReplacement, withExactly: [first.cluster.node])
                     ^~~~~~~~~~~
error: No result within 5s for block at /Users/ktoso/code/actors/Tests/DistributedActorsTests/Cluster/AssociationClusteredTests.swift:103. Queried 2 times, within 5s. Last error:
            try assertAssociated(secondReplacement, withExactly: [first.cluster.node])
                                           ^~~~~~~~~~~~~~
error: Did not receive message of type [Set<UniqueNode>] within [3s], error: noMessagesInQueue
```

### Result:

- Nicer error printouts when eventually things are nested in shouldNotThrow