### PR TITLE
=build also run leak tests on CI/docker

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -cl "swift test && ./scripts/integration_tests.sh"
+    command: /bin/bash -cl "swift test -Xswiftc -DSACT_TESTS_LEAKS && ./scripts/integration_tests.sh"
 
   bench:
     <<: *common


### PR DESCRIPTION
Also run in CI leak tests

### Motivation:

We didn't run leak tests on CI, we should :) 

### Modifications:

Enable in docker, no reason to not run them in there I think?

### Result:

- leak tests always run in docker
- including on CI