### PR TITLE
Fix ActorSystem leak caused by circular reference #160

### DIFF
--- a/Sources/DistributedActors/ActorShell.swift
+++ b/Sources/DistributedActors/ActorShell.swift
@@ -570,6 +570,7 @@ internal final class ActorShell<Message>: ActorContext<Message>, AbstractActor {
         // TODO: validate all the niling out; can we null out the cell itself?
         self._deathWatch = nil
         self.messageAdapters = []
+        self.subReceives = [:]
 
         // become stopped, if not already
         switch self.behavior.underlying {

--- a/Tests/DistributedActorsTests/ActorLeakingTests.swift
+++ b/Tests/DistributedActorsTests/ActorLeakingTests.swift
@@ -254,7 +254,7 @@ class ActorLeakingTests: XCTestCase {
 
         for _ in 1 ... 5 {
             let system = ActorSystem("Test")
-            system.shutdown()
+            system.shutdown().wait()
         }
 
         ActorSystem.actorSystemInitCounter.load().shouldEqual(initialSystemCount)


### PR DESCRIPTION
The problem occurs when closing over the ActorContext from a subReceive. Cleaning out the subReceives dict on ActorShell when terminating it solves the problem.

Resolves: #160 