### PR TITLE
=doc fix docs generation, not favicon

### DIFF
--- a/scripts/docs/generate_reference.sh
+++ b/scripts/docs/generate_reference.sh
@@ -49,8 +49,6 @@ asciidoctor \
   $root_path/Docs/index.adoc
 
 cp -r $root_path/Docs/images $target_dir/
-cp -r $root_path/Docs/images/favicon/android-icon-48x48.png $target_dir/images/sact.png
-cp -r $root_path/Docs/images/favicon/*.ico $target_dir/
 cp -r $root_path/Docs/stylesheets $target_dir/
 
 echo "Docs generated: $target_dir/index.html"


### PR DESCRIPTION
### Motivation:

We removed all icons we used to have before, though since we moved to github we don't run docs generation so we did not notice that this broke the generation.

### Modifications:

Don't move not existing favicon files -> don't fail on docs gen.

### Result:

- docs generation works again `./scripts/docs/generate_reference.sh`