### PR TITLE
Use prefixed name for probe in ClusteredNodesTestBase.assertAssociate…

### DIFF
--- a/Tests/DistributedActorsTests/Cluster/ClusteredNodesTestBase.swift
+++ b/Tests/DistributedActorsTests/Cluster/ClusteredNodesTestBase.swift
@@ -173,7 +173,7 @@ extension ClusteredNodesTestBase {
 
         let testKit = self.testKit(system)
 
-        let probe = testKit.spawnTestProbe("probe-assertAssociated", expecting: Set<UniqueNode>.self, file: file, line: line)
+        let probe = testKit.spawnTestProbe(.prefixed(with: "probe-assertAssociated"), expecting: Set<UniqueNode>.self, file: file, line: line)
         defer { probe.stop() }
 
         try testKit.eventually(within: timeout ?? .seconds(5), file: file, line: line, column: column) {


### PR DESCRIPTION
…d #156 

This should fix a race where another call to assertAssociated is issued before the old probe is fully stopped, causing an error because of the duplicated name.

Resolves: #156 