### PR TITLE
=docs reshuffle docs so generated jazzy docs look better

### DIFF
--- a/Sources/DistributedActorsTestKit/TestProbes.swift
+++ b/Sources/DistributedActorsTestKit/TestProbes.swift
@@ -145,6 +145,9 @@ extension ActorTestProbe: CustomStringConvertible {
     }
 }
 
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: Expecting messages
+
 extension ActorTestProbe {
     /// Expects a message to arrive at the TestProbe and returns it for further assertions.
     /// See also the `expectMessage(_:Message)` overload which provides automatic equality checking.
@@ -230,6 +233,55 @@ extension ActorTestProbe {
     }
 }
 
+extension ActorTestProbe where Message: Equatable {
+    /// Fails in nice readable ways:
+    ///
+    /// - Warning: Blocks the current thread until the `expectationTimeout` is exceeded or an message is received by the actor.
+    ///
+    ///
+    /// Example output:
+    ///
+    ///     sact/Tests/DistributedActorsTestKitTests/ActorTestProbeTests.swift:35: error: -[DistributedActorsTestKitTests.ActorTestProbeTests test_testProbe_expectMessage_shouldFailWhenNoMessageSentWithinTimeout] : XCTAssertTrue failed -
+    ///     try! probe.expectMessage("awaiting-forever")
+    ///                ^~~~~~~~~~~~~~
+    ///     error: Did not receive expected [awaiting-forever]:String within [1s], error: noMessagesInQueue
+    ///
+    public func expectMessage(_ message: Message, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
+        return try self.expectMessage(message, within: self.expectationTimeout, file: file, line: line, column: column)
+    }
+
+    public func expectMessage(_ message: Message, within timeout: TimeAmount, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
+        let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
+        do {
+            let receivedMessage = try self.receiveMessage(within: timeout)
+            self.lastMessageObserved = receivedMessage
+            guard receivedMessage == message else {
+                throw callSite.error(callSite.detailedMessage(got: receivedMessage, expected: message))
+            }
+        } catch {
+            let message = "Did not receive expected [\(message)]:\(type(of: message)) within [\(timeout.prettyDescription)], error: \(error)"
+            throw callSite.error(message)
+        }
+    }
+
+    public func expectMessageType<T>(_ type: T.Type, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
+        return try self.expectMessageType(type, within: self.expectationTimeout, file: file, line: line, column: column)
+    }
+
+    public func expectMessageType<T>(_ type: T.Type, within timeout: TimeAmount, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
+        let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
+
+        let receivedMessage = try self.receiveMessage(within: timeout)
+        self.lastMessageObserved = receivedMessage
+        guard receivedMessage is T else {
+            throw callSite.error(callSite.detailedMessage(got: receivedMessage, expected: type))
+        }
+    }
+}
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: Expecting multiple messages
+
 extension ActorTestProbe {
     /// Expects multiple messages to arrive at the TestProbe and returns it for further assertions.
     /// See also the `expectMessagesInAnyOrder([Message])` overload which provides automatic equality checking.
@@ -278,52 +330,6 @@ extension ActorTestProbe {
 }
 
 extension ActorTestProbe where Message: Equatable {
-    // MARK: Expecting messages
-
-    /// Fails in nice readable ways:
-    ///
-    /// - Warning: Blocks the current thread until the `expectationTimeout` is exceeded or an message is received by the actor.
-    ///
-    ///
-    /// Example output:
-    ///
-    ///     sact/Tests/DistributedActorsTestKitTests/ActorTestProbeTests.swift:35: error: -[DistributedActorsTestKitTests.ActorTestProbeTests test_testProbe_expectMessage_shouldFailWhenNoMessageSentWithinTimeout] : XCTAssertTrue failed -
-    ///     try! probe.expectMessage("awaiting-forever")
-    ///                ^~~~~~~~~~~~~~
-    ///     error: Did not receive expected [awaiting-forever]:String within [1s], error: noMessagesInQueue
-    ///
-    public func expectMessage(_ message: Message, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
-        return try self.expectMessage(message, within: self.expectationTimeout, file: file, line: line, column: column)
-    }
-
-    public func expectMessage(_ message: Message, within timeout: TimeAmount, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
-        let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
-        do {
-            let receivedMessage = try self.receiveMessage(within: timeout)
-            self.lastMessageObserved = receivedMessage
-            guard receivedMessage == message else {
-                throw callSite.error(callSite.detailedMessage(got: receivedMessage, expected: message))
-            }
-        } catch {
-            let message = "Did not receive expected [\(message)]:\(type(of: message)) within [\(timeout.prettyDescription)], error: \(error)"
-            throw callSite.error(message)
-        }
-    }
-
-    public func expectMessageType<T>(_ type: T.Type, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
-        return try self.expectMessageType(type, within: self.expectationTimeout, file: file, line: line, column: column)
-    }
-
-    public func expectMessageType<T>(_ type: T.Type, within timeout: TimeAmount, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
-        let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
-
-        let receivedMessage = try self.receiveMessage(within: timeout)
-        self.lastMessageObserved = receivedMessage
-        guard receivedMessage is T else {
-            throw callSite.error(callSite.detailedMessage(got: receivedMessage, expected: type))
-        }
-    }
-
     public func expectMessagesInAnyOrder(_ _messages: [Message], file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
         return try self.expectMessagesInAnyOrder(_messages, within: self.expectationTimeout, file: file, line: line, column: column)
     }
@@ -348,10 +354,17 @@ extension ActorTestProbe where Message: Equatable {
             throw callSite.error(message)
         }
     }
+}
 
-    // ==== ------------------------------------------------------------------------------------------------------------
-    // MARK: Clearing buffered messages (for expectations)
+// ==== ------------------------------------------------------------------------------------------------------------
+// MARK: Clearing buffered messages (for expectations)
 
+extension ActorTestProbe {
+    /// Clear any buffered messages from the probe's queue.
+    ///
+    /// Blocks until no more message remains to be dropped.
+    /// Note that if the probe is concurrently being sent messages as it is clearing them, this may result in spinning forever,
+    /// or for in-deterministic amounts of time.
     public func clearMessages() {
         do {
             while try self.maybeExpectMessage() != nil {
@@ -379,6 +392,16 @@ extension ActorTestProbe: ReceivesMessages {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: TestProbes can intercept all messages send to a Behavior
 
+public extension ActorTestProbe {
+    // TODO: would be nice to be able to also intercept system messages hm...
+
+    func interceptAllMessages(sentTo behavior: Behavior<Message>) -> Behavior<Message> {
+        let interceptor: Interceptor<Message> = ProbeInterceptor(probe: self)
+        return .intercept(behavior: behavior, with: interceptor)
+    }
+}
+
+/// Allows intercepting messages
 public final class ProbeInterceptor<Message>: Interceptor<Message> {
     let probe: ActorTestProbe<Message>
 
@@ -391,17 +414,6 @@ public final class ProbeInterceptor<Message>: Interceptor<Message> {
         return try target.interpretMessage(context: context, message: message)
     }
 }
-
-public extension ActorTestProbe {
-    // TODO: would be nice to be able to also intercept system messages hm...
-
-    func interceptAllMessages(sentTo behavior: Behavior<Message>) -> Behavior<Message> {
-        let interceptor: Interceptor<Message> = ProbeInterceptor(probe: self)
-        return .intercept(behavior: behavior, with: interceptor)
-    }
-}
-
-// MARK: Watching Actors
 
 extension ActorTestProbe {
     @discardableResult
@@ -428,6 +440,7 @@ extension ActorTestProbe {
         }
     }
 
+    // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: Failure helpers
 
     /// Returns a failure with additional information of the probes last observed messages.
@@ -452,6 +465,7 @@ extension ActorTestProbe {
         return callSite.error(fullMessage)
     }
 
+    // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: Expecting messages with matching/extracting callbacks
 
     /// Expects a message and applies the nested logic to extract values out of it.
@@ -474,9 +488,12 @@ extension ActorTestProbe {
             throw callSite.error(message)
         }
     }
+}
 
-    // MARK: Expecting no message/signal within a timeout
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: Expecting no message/signal within a timeout
 
+extension ActorTestProbe {
     /// Asserts that no message is received by the probe during the specified timeout.
     /// Useful for making sure that after some "terminal" message no other messages are sent.
     ///
@@ -499,9 +516,12 @@ extension ActorTestProbe {
             throw callSite.error(message)
         }
     }
+}
 
-    // MARK: Expecting termination signals
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: Expecting signals
 
+extension ActorTestProbe {
     /// Expects a signal to be enqueued to this actor within the default `expectationTimeout`.
     public func expectSignal(file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws -> SystemMessage {
         let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
@@ -513,6 +533,7 @@ extension ActorTestProbe {
         return got
     }
 
+    /// Expects the `expected` system message
     public func expectSignal(expected: SystemMessage, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
         let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
 
@@ -521,18 +542,21 @@ extension ActorTestProbe {
             throw callSite.error(callSite.detailedMessage(got: got, expected: expected))
         }
     }
+}
 
-    // MARK: Death watch methods
-
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: Death watch methods
+extension ActorTestProbe {
     /// Instructs this probe to watch the passed in actor.
-    /// The watchee actor is from now on being watched and we will receive `.terminated` signals about it.
+    /// The `watchee` actor is from now on being watched and we will receive `.terminated` signals about it.
     ///
     /// There is no difference between keeping the passed in reference or using the returned ref from this method.
     /// The actor is the being watched subject, not a specific reference to it.
     ///
     /// This enables it to use `expectTerminated` to await for the watched actors termination.
     ///
-    /// Returns: reference to the passed in watchee actor.
+    /// - Returns: reference to the passed in `watchee` actor.
+    /// - SeeAlso: `DeathWatch`
     @discardableResult
     public func watch<M>(_ watchee: ActorRef<M>, file: String = #file, line: UInt = #line) -> ActorRef<M> {
         self.internalRef.tell(ProbeCommands.watchCommand(who: watchee.asAddressable(), file: file, line: line))
@@ -546,7 +570,8 @@ extension ActorTestProbe {
     /// If you want to avoid such race, you can implement your own small actor which performs the watching
     /// and forwards signals appropriately to a probe to trigger the assertions in the tests main thread.
     ///
-    /// Returns: reference to the passed in watchee actor.
+    /// - Returns: reference to the passed in watchee actor.
+    /// - SeeAlso: `DeathWatch`
     @discardableResult
     public func unwatch<M>(_ watchee: ActorRef<M>) -> ActorRef<M> {
         self.internalRef.tell(ProbeCommands.unwatchCommand(who: watchee.asAddressable()))
@@ -558,6 +583,7 @@ extension ActorTestProbe {
     /// - Warning: Remember to first `watch` the actor you are expecting termination for,
     ///            otherwise the termination signal will never be received.
     /// - Returns: the matched `.terminated` message
+    /// - SeeAlso: `DeathWatch`
     @discardableResult
     // TODO: expectTermination(of: ...) maybe nicer wording?
     public func expectTerminated<T>(_ ref: ActorRef<T>, within timeout: TimeAmount? = nil, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws -> Signals.Terminated {
@@ -577,8 +603,9 @@ extension ActorTestProbe {
 
     /// Awaits termination of all passed in actors in any order within the default `expectationTimeout`.
     ///
-    /// - Warning: Remember to first `watch` the actors you are expecting termination for,
-    ///            otherwise the termination signal will never be received.
+    /// - ***Warning**: Remember to first `watch` the actors you are expecting termination for,
+    ///                 otherwise the termination signal will never be received.
+    /// - SeeAlso: `DeathWatch`
     public func expectTerminatedInAnyOrder(_ refs: [AddressableActorRef], file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
         let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
         var pathSet: Set<ActorAddress> = Set(refs.map { $0.address })
@@ -595,9 +622,16 @@ extension ActorTestProbe {
             }
         }
     }
+}
 
-    // MARK: Stopping test probes
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: Test probe Lifecycle control
 
+extension ActorTestProbe {
+    /// Stops the test probe, asynchronously.
+    ///
+    /// - **Warning**: Since this action is asynchronous, in order to be certain that a probe has terminated before performing another task,
+    ///              you may need to watch and expect it to terminate before moving on.
     public func stop() {
         // we send the stop command as normal message in order to not "overtake" other commands that were sent to it
         // not strictly required, but can yield more predictable results when used from tests after all


### PR DESCRIPTION
Better looking testkit docs

### Motivation:

probe docs were all over the place, weirdly ordered and not all MARK were in order / as expected

### Modifications:

- reorder MARK and functions

### Result:

![Screen Shot 2019-09-26 at 12 30 49](https://user-images.githubusercontent.com/120979/65656081-7a4ba600-e059-11e9-94c4-44a0d269173e.png)
