### PR TITLE
CRDT: Fix logic for reading with .all consistency

### DIFF
--- a/Sources/DistributedActors/CRDT/CRDTReplicatorShell.swift
+++ b/Sources/DistributedActors/CRDT/CRDTReplicatorShell.swift
@@ -247,6 +247,13 @@ extension CRDT.Replicator {
                 case .data:
                     localConfirmed = true
                 case .notFound:
+                    // The operation fails to meet `.all` consistency, which requires local and all remote members to
+                    // have the CRDT, if the CRDT is not found locally.
+                    if case .all = consistency { // cannot use guard since we cannot negate `case`
+                        replyTo.tell(.failure(.consistencyError(.failedToFulfill)))
+                        return
+                    }
+
                     // Not found locally but we can make it up by reading from an additional remote member
                     localConfirmed = false
                 }

--- a/Tests/DistributedActorsTests/CRDT/CRDTReplicatorShellTests.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTReplicatorShellTests.swift
@@ -378,8 +378,9 @@ final class CRDTReplicatorShellTests: ClusteredNodesTestBase {
         // Register owner so replicator has a copy of g1 and will notify the owner on g1 updates
         _ = try self.makeCRDTOwnerTestProbe(system: self.remoteSystem, testKit: self.remoteTestKit, id: id, data: g1Remote.asAnyStateBasedCRDT)
 
-        // Tell local replicator to read g1 with .all consistency. Remote copies of g1 should be merged with local.
-        self.localSystem.replicator.tell(.localCommand(.read(id, consistency: .all, timeout: self.timeout, replyTo: readP.ref)))
+        // Tell local replicator to read g1 with .atLeast(1) consistency. Local doesn't have it but can be fulfilled
+        // by remote instead. Remote copies of g1 should be merged with local.
+        self.localSystem.replicator.tell(.localCommand(.read(id, consistency: .atLeast(1), timeout: self.timeout, replyTo: readP.ref)))
         guard case .success(let data) = try readP.expectMessage() else { throw readP.error() }
 
         // `read` returns the underlying CRDT


### PR DESCRIPTION
Motivation:
`read` with `.all` consistency should fail if local return `.notFound`.

Currently we only require all remote members to have the CRDT. Even when local doesn't have the CRDT, the operation is still considered successful, and that's incorrect.

Modifications:
- For `read` `.all`, the CRDT must be found in local and all remote members. If local returns `.notFound`, abort and return `.failedToFulfill` error immediately (i.e., no need to make remote calls). `.atLeast` and `.quorum` might still be fulfillable when local fails.
- Change `test_localCommand_read_doesNotExistLocally_shouldBeOK_shouldUpdateLocalStoreWithRemoteData` to use `.atLeast(1)`. The test writes CRDT to remote but not local, but that should be sufficient for `.atLeast`.

Results:
`.all` handling for `read` is correct. Still unclear what causes https://github.com/apple/swift-distributed-actors/issues/172 though.
