### PR TITLE
+act actor system init with name override and settings

### DIFF
--- a/Sources/DistributedActors/ActorSystem.swift
+++ b/Sources/DistributedActors/ActorSystem.swift
@@ -128,6 +128,19 @@ public final class ActorSystem {
         self.init(settings: settings)
     }
 
+    /// Creates a named `ActorSystem`.
+    /// The passed in name is going to override the setting's cluster node name.
+    ///
+    /// - Faults: when configuration closure performs very illegal action, e.g. reusing a serializer identifier
+    public convenience init(_ name: String, settings: ActorSystemSettings) {
+        var settings = settings
+        settings.cluster.node.systemName = name
+        self.init(settings: settings)
+    }
+
+    /// Creates an `ActorSystem` using the passed in settings.
+    ///
+    /// - Faults: when configuration closure performs very illegal action, e.g. reusing a serializer identifier
     public init(settings: ActorSystemSettings) {
         var settings = settings
         self.name = settings.cluster.node.systemName


### PR DESCRIPTION
### Motivation:

When we use ProcessIsolated we get settings passed int, but may want to
select the human readable name.

### Modifications:

- new init for system

### Result:

- possible to write: 

```swift
let isolated = ProcessIsolated { boot in
    return ActorSystem("ExampleApp", settings: boot.settings)
}
```