### PR TITLE
Fix build warnings

### DIFF
--- a/Sources/DistributedActors/Cluster/ClusterShellState.swift
+++ b/Sources/DistributedActors/Cluster/ClusterShellState.swift
@@ -406,7 +406,7 @@ extension ClusterShellState {
 
         self.log.trace("Membership updated \(self.membership.prettyDescription(label: "\(self.selfNode)")), by \(event)")
 
-        let takenActions = self.tryPerformLeaderTasks()
+        _ = self.tryPerformLeaderTasks()
         // TODO: actions may want to be acted upon, they're like directives, we currently have no such need though;
         // such actions be e.g. "kill association right away" or "asap tell that node .down" directly without waiting for gossip etc
     }

--- a/Sources/DistributedActors/Cluster/DowningStrategy/DowningStrategy.swift
+++ b/Sources/DistributedActors/Cluster/DowningStrategy/DowningStrategy.swift
@@ -104,7 +104,7 @@ internal struct DowningStrategyShell {
 
     func receiveClusterEvent(_ context: ActorContext<Message>, event: ClusterEvent) throws {
         switch event {
-        case .snapshot(let membership):
+        case .snapshot:
             () // ignore, we don't need the full membership for decisions // TODO: or do we...
         case .leadershipChange(let change):
             let directive = try self.strategy.onLeaderChange(to: change.newLeader)

--- a/Sources/DistributedActors/Cluster/DowningStrategy/TimeoutBasedDowningStrategy.swift
+++ b/Sources/DistributedActors/Cluster/DowningStrategy/TimeoutBasedDowningStrategy.swift
@@ -51,7 +51,7 @@ extension TimeoutBasedDowningStrategy: DowningStrategy {
     }
 
     func onLeaderChange(to leader: Member?) throws -> DowningStrategyDirectives.LeaderChangeDirective {
-        try self.membership.applyLeadershipChange(to: leader)
+        _ = try self.membership.applyLeadershipChange(to: leader)
 
         if self.isLeader, !self._markAsDown.isEmpty {
             defer { self._markAsDown = [] }

--- a/Sources/DistributedActors/Cluster/SWIM/SWIMShell.swift
+++ b/Sources/DistributedActors/Cluster/SWIM/SWIMShell.swift
@@ -104,11 +104,11 @@ internal struct SWIMShell {
             if !self.swim.isMember(target) {
                 self.ensureAssociated(context, remoteNode: target.address.node) { result in
                     switch result {
-                    case .success(let remoteAddress):
+                    case .success:
                         self.swim.addMember(target, status: lastKnownStatus) // TODO: push into SWIM?
                         self.sendPing(context: context, to: target, lastKnownStatus: lastKnownStatus, pingReqOrigin: replyTo)
                     case .failure(let error):
-                        context.log.warning("Unable to obtain association for remote \(target.address)... Maybe it was tombstoned?")
+                        context.log.warning("Unable to obtain association for remote \(target.address)... Maybe it was tombstoned? Error: \(error)")
                     }
                 }
             } else {

--- a/Tests/DistributedActorsTests/Cluster/AssociationClusteredTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/AssociationClusteredTests.swift
@@ -88,8 +88,6 @@ final class ClusterAssociationTests: ClusteredNodesTestBase {
             secondReplacement.cluster.events.subscribe(secondReplacementEventsProbe.ref)
             second.cluster.events.subscribe(secondReplacementEventsProbe.ref)
 
-            let replacementUniqueAddress = secondReplacement.cluster.node
-
             // the new replacement node is now going to initiate a handshake with 'local' which knew about the previous
             // instance (oldRemote) on the same node; It should accept this new handshake, and ban the previous node.
             secondReplacement.cluster.join(node: first.cluster.node.node)

--- a/Tests/DistributedActorsTests/Cluster/DowningStrategy/TimeoutBasedDowningInstanceTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/DowningStrategy/TimeoutBasedDowningInstanceTests.swift
@@ -50,7 +50,7 @@ final class TimeoutBasedDowningInstanceTests: XCTestCase {
         try shouldNotThrow {
             self.instance.isLeader.shouldBeFalse()
 
-            self.instance.membership.join(self.otherNode)
+            _ = self.instance.membership.join(self.otherNode)
             let directive = try self.instance.onLeaderChange(to: self.otherMember)
             // we the node does not become the leader, the directive should be `.none`
             guard case .none = directive else {
@@ -62,10 +62,10 @@ final class TimeoutBasedDowningInstanceTests: XCTestCase {
 
     func test_onLeaderChange_whenLeaderAndNewLeaderIsOtherAddress_shouldLoseLeadership() throws {
         try shouldNotThrow {
-            self.instance.membership.join(self.selfNode)
-            self.instance.membership.join(self.otherNode)
+            _ = self.instance.membership.join(self.selfNode)
+            _ = self.instance.membership.join(self.otherNode)
 
-            try self.instance.onLeaderChange(to: self.selfMember)
+            _ = try self.instance.onLeaderChange(to: self.selfMember)
             self.instance.isLeader.shouldBeTrue()
             let directive = try self.instance.onLeaderChange(to: self.otherMember)
             // when losing leadership, the directive should be `.none`
@@ -84,14 +84,14 @@ final class TimeoutBasedDowningInstanceTests: XCTestCase {
     }
 
     func test_onLeaderChange_whenLeaderAndNewLeaderIsSelfAddress_shouldStayLeader() throws {
-        try self.instance.membership.applyLeadershipChange(to: self.selfMember)
+        _ = try self.instance.membership.applyLeadershipChange(to: self.selfMember)
         self.instance.isLeader.shouldBeTrue()
         _ = try self.instance.onLeaderChange(to: self.selfMember)
         self.instance.isLeader.shouldBeTrue()
     }
 
     func test_onLeaderChange_whenLeaderAndNoNewLeaderIsElected_shouldLoseLeadership() throws {
-        try self.instance.membership.applyLeadershipChange(to: self.selfMember)
+        _ = try self.instance.membership.applyLeadershipChange(to: self.selfMember)
         self.instance.isLeader.shouldBeTrue()
         _ = try self.instance.onLeaderChange(to: nil)
         self.instance.isLeader.shouldBeFalse()
@@ -133,7 +133,7 @@ final class TimeoutBasedDowningInstanceTests: XCTestCase {
 
     func test_onTimeout_whenCurrentlyLeader_shouldReturnMarkAsDown() throws {
         let member = Member(node: otherNode, status: .up)
-        try instance.membership.applyLeadershipChange(to: self.selfMember)
+        _ = try instance.membership.applyLeadershipChange(to: self.selfMember)
         self.instance._unreachable.insert(member.node)
         let directive = self.instance.onTimeout(member)
 

--- a/Tests/DistributedActorsTests/Cluster/LeadershipTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/LeadershipTests.swift
@@ -36,7 +36,7 @@ final class LeadershipTests: XCTestCase {
     func test_LowestReachableMember_selectLeader() throws {
         let selection = Leadership.LowestReachableMember(minimumNrOfMembers: 3)
 
-        var membership = self.initialMembership
+        let membership = self.initialMembership
 
         let change: LeadershipChange? = try selection.select(context: self.fakeContext, membership: membership).future.wait()
         change.shouldEqual(LeadershipChange(oldLeader: nil, newLeader: self.firstMember))
@@ -68,7 +68,7 @@ final class LeadershipTests: XCTestCase {
         (try selection.select(context: self.fakeContext, membership: membership).future.wait())
             .shouldEqual(LeadershipChange(oldLeader: nil, newLeader: self.firstMember))
 
-        membership.mark(self.firstMember.node, as: .down)
+        _ = membership.mark(self.firstMember.node, as: .down)
         (try selection.select(context: self.fakeContext, membership: membership).future.wait())
             .shouldEqual(LeadershipChange(oldLeader: nil, newLeader: self.secondMember))
     }
@@ -82,7 +82,7 @@ final class LeadershipTests: XCTestCase {
         (try selection.select(context: self.fakeContext, membership: membership).future.wait())
             .shouldEqual(LeadershipChange(oldLeader: nil, newLeader: self.firstMember))
 
-        membership.mark(self.firstMember.node, reachability: .unreachable)
+        _ = membership.mark(self.firstMember.node, reachability: .unreachable)
         (try selection.select(context: self.fakeContext, membership: membership).future.wait())
             .shouldEqual(LeadershipChange(oldLeader: nil, newLeader: self.secondMember))
     }

--- a/Tests/DistributedActorsTests/Cluster/SWIM/SWIMShellTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/SWIM/SWIMShellTests.swift
@@ -387,7 +387,7 @@ final class SWIMShellTests: ClusteredNodesTestBase {
             settings.failureDetector.probeInterval = .milliseconds(100)
 
             let firstSwim: ActorRef<SWIM.Message> = try self.testKit(first)._eventuallyResolve(address: ._swim(on: first.cluster.node))
-            var secondSwim: ActorRef<SWIM.Message> = try self.testKit(second)._eventuallyResolve(address: ._swim(on: second.cluster.node))
+            let secondSwim: ActorRef<SWIM.Message> = try self.testKit(second)._eventuallyResolve(address: ._swim(on: second.cluster.node))
 
             let localRefRemote = second._resolveKnownRemote(firstSwim, onRemoteSystem: first)
 


### PR DESCRIPTION
Motivation:
Build warnings get repeated a dozen of times, burying real errors.

Modifications:
Address warnings as directed.

Result:
Less warnings in build.
