### PR TITLE
Separate build for samples, so main build does not depend on random libs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.orig
 
 /.build
+/Samples/.build
 /.SourceKitten
 /Packages
 .xcode

--- a/Package.swift
+++ b/Package.swift
@@ -131,39 +131,8 @@ let targets: [PackageDescription.Target] = [
     ),
 
     // ==== ----------------------------------------------------------------------------------------------------------------
-    // MARK: Samples
-
-    .target(
-        name: "SampleDiningPhilosophers",
-        dependencies: ["DistributedActors"],
-        path: "Samples/SampleDiningPhilosophers"
-    ),
-    .target(
-        name: "SampleLetItCrash",
-        dependencies: ["DistributedActors"],
-        path: "Samples/SampleLetItCrash"
-    ),
-    .target(
-        name: "SampleCluster",
-        dependencies: ["DistributedActors"],
-        path: "Samples/SampleCluster"
-    ),
-    .target(
-        name: "SampleMetrics",
-        dependencies: [
-            "DistributedActors",
-            "SwiftPrometheus",
-        ],
-        path: "Samples/SampleMetrics"
-    ),
-    .target(
-        name: "SampleGenActors",
-        dependencies: [
-            "DistributedActors"
-        ],
-        // TODO: make possible to run `swift genActors` here somehow
-        path: "Samples/SampleGenActors"
-    ),
+    // MARK: Samples are defined in Samples/Package.swift
+    // ==== ----------------------------------------------------------------------------------------------------------------
 
     // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: Internals; NOT SUPPORTED IN ANY WAY
@@ -200,9 +169,6 @@ var dependencies: [Package.Dependency] = [
     // swift-syntax is Swift version dependent, and added  as such below
     .package(url: "https://github.com/stencilproject/Stencil.git", from: "0.13.0"), // BSD license
     .package(url: "https://github.com/JohnSundell/Files", from: "4.0.0"), // MIT license
-
-    // ~~~ only for samples ~~~
-    .package(url: "https://github.com/MrLotU/SwiftPrometheus", .branch("master")),
 ]
 
 #if swift(>=5.1)
@@ -240,29 +206,6 @@ let package = Package(
         .executable(
             name: "DistributedActorsBenchmarks",
             targets: ["DistributedActorsBenchmarks"]
-        ),
-
-        /* ---  samples --- */
-
-        .executable(
-            name: "SampleDiningPhilosophers",
-            targets: ["SampleDiningPhilosophers"]
-        ),
-        .executable(
-            name: "SampleLetItCrash",
-            targets: ["SampleLetItCrash"]
-        ),
-        .executable(
-            name: "SampleCluster",
-            targets: ["SampleCluster"]
-        ),
-        .executable(
-            name: "SampleMetrics",
-            targets: ["SampleMetrics"]
-        ),
-        .executable(
-            name: "SampleGenActors",
-            targets: ["SampleGenActors"]
         ),
     ],
 

--- a/Samples/Package.swift
+++ b/Samples/Package.swift
@@ -1,0 +1,81 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let targets: [PackageDescription.Target] = [
+    // ==== ----------------------------------------------------------------------------------------------------------------
+    // MARK: Samples
+
+    .target(
+        name: "SampleDiningPhilosophers",
+        dependencies: ["DistributedActors"],
+        path: "SampleDiningPhilosophers"
+    ),
+    .target(
+        name: "SampleLetItCrash",
+        dependencies: ["DistributedActors"],
+        path: "SampleLetItCrash"
+    ),
+    .target(
+        name: "SampleCluster",
+        dependencies: ["DistributedActors"],
+        path: "SampleCluster"
+    ),
+    .target(
+        name: "SampleMetrics",
+        dependencies: [
+            "DistributedActors",
+            "SwiftPrometheus",
+        ],
+        path: "SampleMetrics"
+    ),
+    .target(
+        name: "SampleGenActors",
+        dependencies: [
+            "DistributedActors"
+        ],
+        path: "SampleGenActors"
+    ),
+]
+
+var dependencies: [Package.Dependency] = [
+    // ~~~ parent ~~~
+    .package(path: "../"),
+    // ~~~ only for samples ~~~
+    .package(url: "https://github.com/MrLotU/SwiftPrometheus", .branch("master")),
+]
+
+let package = Package(
+    name: "swift-distributed-actors-samples",
+    products: [
+        /* ---  samples --- */
+
+        .executable(
+            name: "SampleDiningPhilosophers",
+            targets: ["SampleDiningPhilosophers"]
+        ),
+        .executable(
+            name: "SampleLetItCrash",
+            targets: ["SampleLetItCrash"]
+        ),
+        .executable(
+            name: "SampleCluster",
+            targets: ["SampleCluster"]
+        ),
+        .executable(
+            name: "SampleMetrics",
+            targets: ["SampleMetrics"]
+        ),
+        .executable(
+            name: "SampleGenActors",
+            targets: ["SampleGenActors"]
+        ),
+    ],
+
+    dependencies: dependencies,
+
+    targets: targets,
+
+    cxxLanguageStandard: .cxx11
+)

--- a/scripts/sanity.sh
+++ b/scripts/sanity.sh
@@ -16,6 +16,9 @@
 set -eu
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# ensure samples build correctly
+cd $here/Samples && swift build; cd $here
+
 bash $here/validate_license_header.sh
 bash $here/validate_format.sh
 bash $here/validate_linux_tests_generated.sh


### PR DESCRIPTION
**Motivation:**

To avoid the main project pulling in SwiftPrometheus etc, as we do not
really use it anywhere in there, but only in the samples, so it should
not show up in normal builds.

**Modifications:**

Separate Package.swift for all Samples

**Result:**

- Cleaner separation between samples dependencies and the project itself
- @tomerd this is cleaner but I definitely do want to ensure samples are also built... It is nicer to have samples in the same project for that purpose I would say -- do you think we should split the projects or keep as one? The main reason to split is that we depend on Prometheus for the samples, and may on some other things as well in the future... WDYT?

OR should we just not depend on anything in Samples and keep the project structure as is? For refactoring and renaming etc it matters and is easier to keep all in the same project... the sanity check then does not have to be weird either.

---

tl;dr; I made the change, but actually think keeping all in one Package.swift is better after all... perhaps we simply should remove any "just for samples" dependencies, and if we have such samples, put them outside of the repo? WDYT @tomerd 