### PR TITLE
[DO NOT MERGE] Discussion about better UX for Receptionist

### DIFF
--- a/IntegrationTests/tests_02_process_isolated/it_ProcessIsolated_respawnsServants/main.swift
+++ b/IntegrationTests/tests_02_process_isolated/it_ProcessIsolated_respawnsServants/main.swift
@@ -31,7 +31,7 @@ let isolated = ProcessIsolated { boot in
 
 pprint("Started process: \(getpid()) with roles: \(isolated.roles)")
 
-let workersKey = Receptionist.RegistrationKey(String.self, id: "workers")
+let workersKey = Receptionist.GroupIdentifier(String.self, id: "workers")
 
 // though one can ensure to only run if in a process of a given role:
 try isolated.run(on: .master) {

--- a/Sources/DistributedActors/AsyncResult.swift
+++ b/Sources/DistributedActors/AsyncResult.swift
@@ -18,6 +18,7 @@ import NIO
 public protocol AsyncResult {
     associatedtype Value
 
+    // TODO: hide this, it's not safe; https://github.com/apple/swift-distributed-actors/issues/202
     /// Registers a callback that is executed when the `AsyncResult` is available.
     func onComplete(_ callback: @escaping (Result<Value, Error>) -> Void)
 

--- a/Sources/DistributedActors/Pattern/WorkerPool.swift
+++ b/Sources/DistributedActors/Pattern/WorkerPool.swift
@@ -32,7 +32,7 @@ public class WorkerPool<Message> {
     public enum Selector {
         /// Instructs the `WorkerPool` to subscribe to given receptionist key, and add/remove
         /// any actors which register/leave with the receptionist using this key.
-        case dynamic(Receptionist.RegistrationKey<Message>)
+        case dynamic(Receptionist.GroupIdentifier<Message>)
         // TODO: let awaitAtLeast: Int // before starting to direct traffic
 
         /// Instructs the `WorkerPool` to use only the specified actors for routing.
@@ -84,9 +84,9 @@ internal extension WorkerPool {
     func initial() -> PoolBehavior {
         return .setup { context in
             switch self.selector {
-            case .dynamic(let key):
+            case .dynamic(let group):
                 context.system.receptionist.subscribe(
-                    key: key,
+                    group: group,
                     subscriber: context.messageAdapter(from: Receptionist.Listing<Message>.self) { listing in
                         context.log.log(level: self.settings.logLevel, "Got listing for \(self.selector): \(listing)")
                         return .listing(listing)

--- a/Tests/DistributedActorsDocumentationTests/ActorDocExamples.swift
+++ b/Tests/DistributedActorsDocumentationTests/ActorDocExamples.swift
@@ -183,10 +183,10 @@ class ActorDocExamples: XCTestCase {
 
     func example_receptionist_register() {
         // tag::receptionist_register[]
-        let key = Receptionist.RegistrationKey(String.self, id: "my-actor") // <1>
+        let group = Receptionist.GroupIdentifier(String.self, id: "my-actor") // <1>
 
         let behavior: Behavior<String> = .setup { context in
-            context.system.receptionist.tell(Receptionist.Register(context.myself, key: key)) // <2>
+            context.receptionist.checkIn(group: group) // <2>
 
             return .receiveMessage { _ in
                 // ...
@@ -199,7 +199,7 @@ class ActorDocExamples: XCTestCase {
     }
 
     func example_receptionist_lookup() {
-        let key = Receptionist.RegistrationKey(String.self, id: "my-actor")
+        let key = Receptionist.GroupIdentifier(String.self, id: "my-actor")
         let system = ActorSystem("LookupExample")
         // tag::receptionist_lookup[]
         let result = system.receptionist.ask(for: Receptionist.Listing.self, timeout: .seconds(1)) { // <1>
@@ -216,10 +216,10 @@ class ActorDocExamples: XCTestCase {
     }
 
     func example_receptionist_subscribe() {
-        let key = Receptionist.RegistrationKey(String.self, id: "my-actor")
+        let group = Receptionist.GroupIdentifier(String.self, id: "my-actor")
         // tag::receptionist_subscribe[]
         let behavior: Behavior<Receptionist.Listing<String>> = .setup { context in
-            context.system.receptionist.tell(Receptionist.Subscribe(key: key, subscriber: context.myself)) // <1>
+            context.receptionist.subscribe(group: group, subscriber: context.myself) // <1>
 
             return .receiveMessage {
                 for ref in $0.refs {

--- a/Tests/DistributedActorsTests/Cluster/ClusterReceptionistClusteredTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/ClusterReceptionistClusteredTests.swift
@@ -22,7 +22,7 @@ class ClusterReceptionistTests: ClusteredNodesTestBase {
         let (local, remote) = setUpPair()
 
         let probe = self.testKit(local).spawnTestProbe(expecting: String.self)
-        let registeredProbe = self.testKit(local).spawnTestProbe(expecting: Receptionist.Registered<String>.self)
+        let registeredProbe = self.testKit(local).spawnTestProbe(expecting: Receptionist.CheckInConfirmed<String>.self)
         let lookupProbe = self.testKit(local).spawnTestProbe(expecting: Receptionist.Listing<String>.self)
 
         local.cluster.join(node: remote.cluster.node.node)
@@ -36,7 +36,7 @@ class ClusterReceptionistTests: ClusteredNodesTestBase {
             }
         )
 
-        let key = Receptionist.RegistrationKey(String.self, id: "test")
+        let key = Receptionist.GroupIdentifier(String.self, id: "test")
 
         remote.receptionist.tell(Receptionist.Subscribe(key: key, subscriber: lookupProbe.ref))
 
@@ -61,7 +61,7 @@ class ClusterReceptionistTests: ClusteredNodesTestBase {
         }
 
         let probe = self.testKit(local).spawnTestProbe(expecting: String.self)
-        let registeredProbe = self.testKit(local).spawnTestProbe(expecting: Receptionist.Registered<String>.self)
+        let registeredProbe = self.testKit(local).spawnTestProbe(expecting: Receptionist.CheckInConfirmed<String>.self)
         let lookupProbe = self.testKit(local).spawnTestProbe(expecting: Receptionist.Listing<String>.self)
 
         let ref: ActorRef<String> = try local.spawn(
@@ -72,7 +72,7 @@ class ClusterReceptionistTests: ClusteredNodesTestBase {
             }
         )
 
-        let key = Receptionist.RegistrationKey(String.self, id: "test")
+        let key = Receptionist.GroupIdentifier(String.self, id: "test")
 
         remote.receptionist.tell(Receptionist.Subscribe(key: key, subscriber: lookupProbe.ref))
 
@@ -99,7 +99,7 @@ class ClusterReceptionistTests: ClusteredNodesTestBase {
             $0.cluster.receptionistSyncInterval = .milliseconds(100)
         }
 
-        let registeredProbe = self.testKit(local).spawnTestProbe("registeredProbe", expecting: Receptionist.Registered<String>.self)
+        let registeredProbe = self.testKit(local).spawnTestProbe("registeredProbe", expecting: Receptionist.CheckInConfirmed<String>.self)
         let localLookupProbe = self.testKit(local).spawnTestProbe("localLookupProbe", expecting: Receptionist.Listing<String>.self)
         let remoteLookupProbe = self.testKit(remote).spawnTestProbe("remoteLookupProbe", expecting: Receptionist.Listing<String>.self)
 
@@ -112,7 +112,7 @@ class ClusterReceptionistTests: ClusteredNodesTestBase {
         let refC: ActorRef<String> = try remote.spawn("refC", behavior)
         let refD: ActorRef<String> = try remote.spawn("refD", behavior)
 
-        let key = Receptionist.RegistrationKey(String.self, id: "test")
+        let key = Receptionist.GroupIdentifier(String.self, id: "test")
 
         local.receptionist.tell(Receptionist.Register(refA, key: key, replyTo: registeredProbe.ref))
         _ = try registeredProbe.expectMessage()
@@ -148,7 +148,7 @@ class ClusterReceptionistTests: ClusteredNodesTestBase {
             $0.cluster.receptionistSyncInterval = .milliseconds(100)
         }
 
-        let registeredProbe = self.testKit(local).spawnTestProbe(expecting: Receptionist.Registered<String>.self)
+        let registeredProbe = self.testKit(local).spawnTestProbe(expecting: Receptionist.CheckInConfirmed<String>.self)
         let remoteLookupProbe = self.testKit(remote).spawnTestProbe(expecting: Receptionist.Listing<String>.self)
 
         let behavior: Behavior<String> = .receiveMessage { _ in
@@ -158,7 +158,7 @@ class ClusterReceptionistTests: ClusteredNodesTestBase {
         let refA: ActorRef<String> = try local.spawn(.anonymous, behavior)
         let refB: ActorRef<String> = try local.spawn(.anonymous, behavior)
 
-        let key = Receptionist.RegistrationKey(String.self, id: "test")
+        let key = Receptionist.GroupIdentifier(String.self, id: "test")
 
         local.receptionist.tell(Receptionist.Register(refA, key: key, replyTo: registeredProbe.ref))
         _ = try registeredProbe.expectMessage()

--- a/Tests/DistributedActorsTests/Pattern/WorkerPoolTests.swift
+++ b/Tests/DistributedActorsTests/Pattern/WorkerPoolTests.swift
@@ -32,7 +32,7 @@ final class WorkerPoolTests: XCTestCase {
     }
 
     func test_workerPool_registerNewlyStartedActors() throws {
-        let workerKey = Receptionist.RegistrationKey(String.self, id: "request-workers")
+        let workerKey = Receptionist.GroupIdentifier(String.self, id: "request-workers")
 
         let pA: ActorTestProbe<String> = self.testKit.spawnTestProbe("pA")
         let pB: ActorTestProbe<String> = self.testKit.spawnTestProbe("pB")
@@ -40,7 +40,7 @@ final class WorkerPoolTests: XCTestCase {
 
         func worker(p: ActorTestProbe<String>) -> Behavior<String> {
             return .setup { context in
-                context.system.receptionist.register(context.myself, key: workerKey) // could ask and await on the registration
+                context.system.receptionist.checkIn(context.myself, key: workerKey) // could ask and await on the registration
 
                 return .receive { context, work in
                     p.tell("work:\(work) at \(context.name)")
@@ -77,7 +77,7 @@ final class WorkerPoolTests: XCTestCase {
     }
 
     func test_workerPool_dynamic_removeDeadActors() throws {
-        let workerKey = Receptionist.RegistrationKey(String.self, id: "request-workers")
+        let workerKey = Receptionist.GroupIdentifier(String.self, id: "request-workers")
 
         let pA: ActorTestProbe<String> = self.testKit.spawnTestProbe("pA")
         let pB: ActorTestProbe<String> = self.testKit.spawnTestProbe("pB")
@@ -85,7 +85,7 @@ final class WorkerPoolTests: XCTestCase {
 
         func worker(p: ActorTestProbe<String>) -> Behavior<String> {
             return .setup { context in
-                context.system.receptionist.register(context.myself, key: workerKey) // could ask and await on the registration
+                context.system.receptionist.checkIn(context.myself, key: workerKey) // could ask and await on the registration
 
                 return .receive { context, work in
                     if work == "stop" {

--- a/Tests/DistributedActorsTests/ReceptionistTests.swift
+++ b/Tests/DistributedActorsTests/ReceptionistTests.swift
@@ -51,11 +51,11 @@ class ReceptionistTests: XCTestCase {
             }
         )
 
-        let key = Receptionist.RegistrationKey(String.self, id: "test")
+        let key = Receptionist.GroupIdentifier(String.self, id: "test")
 
-        receptionist.tell(Receptionist.Register(refA, key: key))
-        receptionist.tell(Receptionist.Register(refB, key: key))
-        receptionist.tell(Receptionist.Lookup(key: key, replyTo: lookupProbe.ref))
+        receptionist.checkIn(refA, key: key)
+        receptionist.checkIn(refB, key: key)
+        receptionist.lookup(key: key, replyTo: lookupProbe.ref)
 
         let listing = try lookupProbe.expectMessage()
 
@@ -78,12 +78,12 @@ class ReceptionistTests: XCTestCase {
             }
         )
 
-        let key = Receptionist.RegistrationKey(String.self, id: "test")
+        let key = Receptionist.GroupIdentifier(String.self, id: "test")
 
-        receptionist.tell(Receptionist.Register(ref, key: key))
+        receptionist.checkIn(ref, key: key)
 
-        let unknownKey = Receptionist.RegistrationKey(String.self, id: "unknown")
-        receptionist.tell(Receptionist.Lookup(key: unknownKey, replyTo: lookupProbe.ref))
+        let unknownKey = Receptionist.GroupIdentifier(String.self, id: "unknown")
+        receptionist.lookup(key: unknownKey, replyTo: lookupProbe.ref)
 
         let listing = try lookupProbe.expectMessage()
 
@@ -101,12 +101,12 @@ class ReceptionistTests: XCTestCase {
             }
         )
 
-        let key = Receptionist.RegistrationKey(String.self, id: "test")
+        let key = Receptionist.GroupIdentifier(String.self, id: "test")
 
-        receptionist.tell(Receptionist.Register(ref, key: key))
-        receptionist.tell(Receptionist.Register(ref, key: key))
+        receptionist.checkIn(ref, key: key)
+        receptionist.checkIn(ref, key: key)
 
-        receptionist.tell(Receptionist.Lookup(key: key, replyTo: lookupProbe.ref))
+        receptionist.lookup(key: key, replyTo: lookupProbe.ref))
 
         let listing = try lookupProbe.expectMessage()
 
@@ -115,7 +115,7 @@ class ReceptionistTests: XCTestCase {
 
     func test_receptionist_shouldReplyWithRegistered() throws {
         let receptionist = try system.spawn("receptionist", LocalReceptionist.behavior)
-        let probe: ActorTestProbe<Receptionist.Registered<String>> = self.testKit.spawnTestProbe()
+        let probe: ActorTestProbe<Receptionist.CheckInConfirmed<String>> = self.testKit.spawnTestProbe()
 
         let ref: ActorRef<String> = try system.spawn(
             .anonymous,
@@ -124,7 +124,7 @@ class ReceptionistTests: XCTestCase {
             }
         )
 
-        let key = Receptionist.RegistrationKey(String.self, id: "test")
+        let key = Receptionist.GroupIdentifier(String.self, id: "test")
 
         receptionist.tell(Receptionist.Register(ref, key: key, replyTo: probe.ref))
 
@@ -145,14 +145,14 @@ class ReceptionistTests: XCTestCase {
             }
         )
 
-        let key = Receptionist.RegistrationKey(String.self, id: "test")
+        let key = Receptionist.GroupIdentifier(String.self, id: "test")
 
-        receptionist.tell(Receptionist.Register(ref, key: key))
+        receptionist.checkIn(ref, key: key)
 
         ref.tell("stop")
 
         try self.testKit.eventually(within: .seconds(1)) {
-            receptionist.tell(Receptionist.Lookup(key: key, replyTo: lookupProbe.ref))
+            receptionist.lookup(key: key, replyTo: lookupProbe.ref))
             let message = try lookupProbe.expectMessage()
 
             // TODO: modify TestKit to allow usage of matchers instead
@@ -180,7 +180,7 @@ class ReceptionistTests: XCTestCase {
             }
         )
 
-        let key = Receptionist.RegistrationKey(String.self, id: "test")
+        let key = Receptionist.GroupIdentifier(String.self, id: "test")
 
         receptionist.tell(Receptionist.Subscribe(key: key, subscriber: lookupProbe.ref))
         try lookupProbe.expectMessage(Receptionist.Listing(refs: []))


### PR DESCRIPTION
Some first steps to make receptionist simpler to understand and use. 
This is more of a brain dump and discussion starter than a complete PR. 
We'll also have to think how it is to work with Actorable 🤔 

See here @tomerd and comment in line perhaps or with alternative ideas? I did not add the callback style stuff yet since we'd want decide which way we go... expose a callback or a "actor safe future" after all... 

I did not go all the way... tho wanted to poke around a bit, will take it all the way once we had a chance to discuss what we want:

- do we stop pretending we don't have some future concept (because anything based off context we can make safe); how would we avoid confusion with "our onComplete" being safe and "others" not -- that's a prime worry why we didn't add any methods onto `AskResult` or `AsyncResult` to begin with
- returning underlying futures is a no-go, it's unsafe -- and we'll also want to hide the onComplete that we currently have surfaced https://github.com/apple/swift-distributed-actors/issues/202

Changes / ideas for discussion:

- rewording from "register" to "check in"
  - taking the hotel metaphore further
  - yay / nay?
- since registering is not a thing, the ID we use to identify is now `GroupIdentifier` reads better to me than `Registration` since registrations make it sound like we can manage them but we don't really. We only identify as "part of a group checkin in to the same receptionist".
- introduction of `context.receptionist` which allows us to do `context.receptionist.checkIn(group:)`
  - this also will allow us to do `context.receptionist.lookup(group) { listing in ... }`, though with a caveat that then we lose concurrency control... 
    - if we just returned a "future" people can decide if they need to "await" (`context.awaitResult`) (i.e. not process any new messages until this lookup completes), or "whenever it completes" (`context.onResultAsync`)
- the `context.receptionist` allows checking in "myself" easier, but also allows checking in others, which we need because adapters and sub receives.
- the `lookup` method on actor ref was missing anyway, so added that

--- 

For reference, in an optimal world where we could do what we want, the API would likely look like this perhaps:

```swift
system.receptionist.checkIn/register(ref, group: scouts) // void

// not existing today:
system.receptionist.lookup(group: scouts) // Future<Listing<M>>
system.receptionist.subscribe(group: scouts) // Publisher<Listing<M>>

// ----- 

context.receptionist.checkIn(group: scouts) // registers `context.myself`

// does not exist today, could exist:
context.receptionist.checkIn() // IFF we wanted to make "no group == group by the type of the actor", this could be interesting...

// would be good, best if we had async await, otherwise we need behavior combinators do deal with those sane-ly:

let lookup = context.receptionist.lookup(group: scouts) // : AskResponse<Lookup<M>> // could be Future but we avoid this on purpose
let lookup = await context.receptionist.lookup(group: scouts) // not existing, can't make it today

// right now we can do two things with an AskResponse: AsyncResponse:
// 1)
return context.awaitResult(lookup) { res in 
} // which will not process any other messages (i.e. "suspends the actor") until lookup completes
// this is super useful for initialization -- i.e. "I can't do anything until I find my workers anyway"

// or 2)
context.noResultAsync(lookup) { res in }
// which does not suspend the actor, and function runs _on actor context_ (safely, regardless where the future inside lookupcame from)
// though this also means the state of the actor could have been changed between issuing the lookup and it completing; so this is more "tricky", and rather an optimization than good default.

// - now if we made the lookup accept a closure we lose the 1)/2) granular control, or would  have to introduce it in another way

// for subscribe we could definitely make a safe way to run subscribers, "in" actor context, 
// through this means we'd have to depend on Combine... which may be tricky;
// it would be a nice API though:
context.receptionist.subscribe(group: scouts).foreach { listing in 
} // we'd implement our own Publisher wrapper that would delegate all execution here to the actor ocntext so it would be safe...


// the mixed feelings APIs; I'm worried about making every API do callback style, as we lose compositionality... specifically with:
context.receptionist.lookup(group: scouts) { foundScouts in 
...
} // we LOST the explicitness of "accept new messages, run whenever" or "do not accept new messages until this listing has returned"
// these matter in reality -- sometimes you need a listing to be able to process _anything_
// so you do want to make `context.awaitResult(futureListing)` rather than just fire an onComplete on it...
```

We cannot (should not) expose "just a future" if we cannot make it safe, i.e. right now one could take `askResponse.nioFuture.onComplete {` but that is unsafe, since it is not on the same execution context as the actor... We'd need to have some "common API for Future/Task" and then whichever we return from Ask we'd ensure that it always is safe, i.e. ran on the actor's context (vs. any other random event loop or other context)

--- 


tl;dr; the "return a value that can be awaited on is the far better design, but we are lacking such common type so we either have to make one (Future or Task), and make it Actor-safe, or we have to invent some other APIs.

Very open to feedback, let's see what the best we can do here is :)