### PR TITLE
Make ActorOwned extensions available to LWWMap

### DIFF
--- a/Sources/DistributedActors/CRDT/CRDT+LWWMap.swift
+++ b/Sources/DistributedActors/CRDT/CRDT+LWWMap.swift
@@ -22,7 +22,7 @@ extension CRDT {
     /// - SeeAlso: Akka's [`LWWMap`](https://github.com/akka/akka/blob/master/akka-distributed-data/src/main/scala/akka/cluster/ddata/LWWMap.scala)
     /// - SeeAlso: `CRDT.ORMap`
     /// - SeeAlso: `CRDT.LWWRegister`
-    public struct LWWMap<Key: Hashable, Value>: NamedDeltaCRDT {
+    public struct LWWMap<Key: Hashable, Value>: NamedDeltaCRDT, LWWMapOperations {
         public typealias Delta = ORMapDelta<Key, LWWRegister<Value>>
 
         public let replicaId: ReplicaId
@@ -126,7 +126,7 @@ extension CRDT {
 
 public protocol LWWMapOperations: ORMapWithResettableValue {
     subscript(key: Key) -> Value? { get }
-    func set(forKey key: Key, value: Value)
+    mutating func set(forKey key: Key, value: Value)
 }
 
 // See comments in CRDT.ORSet

--- a/Sources/DistributedActors/CRDT/CRDT+ORMap.swift
+++ b/Sources/DistributedActors/CRDT/CRDT+ORMap.swift
@@ -249,7 +249,7 @@ public protocol ORMapWithUnsafeRemove {
     mutating func unsafeRemoveAllValues()
 }
 
-public protocol ORMapWithResettableValue: ORMapWithUnsafeRemove where Value: ResettableCRDT {
+public protocol ORMapWithResettableValue: ORMapWithUnsafeRemove {
     mutating func resetValue(forKey key: Key)
 
     mutating func resetAllValues()


### PR DESCRIPTION
Motivation:
`CRDT.LWWMap` doesn't conform to `LWWMapOperations` so many `ActorOwned` extensions defined for associated types are not available to `ActorOwned<CRDT.LWWMap>`.

Modification:
- Conform `CRDT.LWWMap` to `LWWMapOperations`
- Delete `Value` type constraint on `ORMapWithResettableValue` because that's already specified in `CRDT.ORMap` extension.

Results:
Methods defined in `LWWMapOperations` are available to `ActorOwned<CRDT.LWWMap>`.
