### PR TITLE
Remove "mutator" param from ActorOwned<LWWMap>.set

### DIFF
--- a/Sources/DistributedActors/CRDT/CRDT+LWWMap.swift
+++ b/Sources/DistributedActors/CRDT/CRDT+LWWMap.swift
@@ -135,7 +135,7 @@ extension CRDT.ActorOwned where DataType: LWWMapOperations {
         return self.data.underlying
     }
 
-    public func set(forKey key: DataType.Key, value: DataType.Value, writeConsistency consistency: CRDT.OperationConsistency, timeout: TimeAmount, mutator: (inout DataType.Value) -> Void) -> OperationResult<DataType> {
+    public func set(forKey key: DataType.Key, value: DataType.Value, writeConsistency consistency: CRDT.OperationConsistency, timeout: TimeAmount) -> OperationResult<DataType> {
         // Set value for key locally then propagate
         self.data.set(forKey: key, value: value)
         return self.write(consistency: consistency, timeout: timeout)


### PR DESCRIPTION
Motivation:
Copy-paste error. The `set` method for `ActorOwned<CRDT.LWWMap>` does not require `mutator` like `ActorOwned<CRDT.ORMap>.update` does.

Modification:
Remove `mutator` param.

Results:
`ActorOwned<CRDT.LWWMap>.set` doesn't require `mutator` param.
