### PR TITLE
Revert "Make .ignore an assignable behavior"

### DIFF
--- a/Sources/DistributedActors/Behaviors.swift
+++ b/Sources/DistributedActors/Behaviors.swift
@@ -506,7 +506,7 @@ public extension Behavior {
 
         // illegal to attempt interpreting at the following behaviors (e.g. should have been canonicalized before):
         case .same: fatalError("Illegal attempt to interpret message with .same behavior! Behavior should have been canonicalized. This is a bug, please open a ticket.", file: file, line: line)
-        case .ignore: return .same
+        case .ignore: fatalError("Illegal attempt to interpret message with .ignore behavior! Behavior should have been canonicalized before interpreting; This is a bug, please open a ticket.", file: file, line: line)
         case .unhandled: fatalError("Illegal attempt to interpret message with .unhandled behavior! Behavior should have been canonicalized before interpreting; This is a bug, please open a ticket.", file: file, line: line)
 
         case .setup: fatalError("Illegal attempt to interpret message with .setup behavior! Behaviors MUST be canonicalized before interpreting. This is a bug, please open a ticket.", file: file, line: line)
@@ -698,7 +698,7 @@ internal extension Behavior {
     @inlinable
     var isChanging: Bool {
         switch self.underlying {
-        case .same, .unhandled: return false
+        case .same, .ignore, .unhandled: return false
         default: return true
         }
     }
@@ -729,7 +729,7 @@ internal extension Behavior {
 
                 case .same where self.isSetup: throw IllegalBehaviorError.illegalTransition(from: self, to: next)
                 case .same: return base
-                case .ignore: return canonical
+                case .ignore: return base
                 case .unhandled: return base
                 case .class: return canonical
 

--- a/Tests/DistributedActorsTests/BehaviorTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/BehaviorTests+XCTest.swift
@@ -65,7 +65,6 @@ extension BehaviorTests {
             ("test_onResultAsync_shouldAllowChangingBehaviorWhileFutureIsNotCompleted", test_onResultAsync_shouldAllowChangingBehaviorWhileFutureIsNotCompleted),
             ("test_onResultAsyncThrowing_shouldExecuteContinuationWhenFutureSucceeds", test_onResultAsyncThrowing_shouldExecuteContinuationWhenFutureSucceeds),
             ("test_onResultAsyncThrowing_shouldFailActorWhenFutureFails", test_onResultAsyncThrowing_shouldFailActorWhenFutureFails),
-            ("test_ignore_shouldIgnoreAllIncomingMessages", test_ignore_shouldIgnoreAllIncomingMessages),
         ]
     }
 }

--- a/Tests/DistributedActorsTests/BehaviorTests.swift
+++ b/Tests/DistributedActorsTests/BehaviorTests.swift
@@ -1219,27 +1219,4 @@ class BehaviorTests: XCTestCase {
         promise.fail(error)
         try probe.expectTerminated(ref)
     }
-
-    func test_ignore_shouldIgnoreAllIncomingMessages() throws {
-        let p = self.testKit.spawnTestProbe(expecting: String.self)
-        let behavior: Behavior<String> = .receiveMessage { message in
-            p.tell("receive:\(message)")
-
-            return .ignore // from now on, all messages will be ignored
-        }
-
-        let ref = try system.spawn(.anonymous, behavior)
-
-        ref.tell("first")
-        try p.expectMessage("receive:first")
-
-        ref.tell("second")
-        try p.expectNoMessage(for: .milliseconds(50))
-
-        ref.tell("third")
-        try p.expectNoMessage(for: .milliseconds(50))
-
-        ref.tell("fourth")
-        try p.expectNoMessage(for: .milliseconds(50))
-    }
 }

--- a/Tests/DistributedActorsTests/ParentChildActorTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/ParentChildActorTests+XCTest.swift
@@ -36,7 +36,6 @@ extension ParentChildActorTests {
             ("test_spawnWatch_shouldSpawnAWatchedActor", test_spawnWatch_shouldSpawnAWatchedActor),
             ("test_stopParent_shouldWaitForChildrenToStop", test_stopParent_shouldWaitForChildrenToStop),
             ("test_spawnStopSpawnManyTimesWithSameName_shouldProperlyTerminateAllChildren", test_spawnStopSpawnManyTimesWithSameName_shouldProperlyTerminateAllChildren),
-            ("test_contextStop_shouldBeAbleToStopChildInBehaviorIgnore", test_contextStop_shouldBeAbleToStopChildInBehaviorIgnore),
         ]
     }
 }

--- a/Tests/DistributedActorsTests/ParentChildActorTests.swift
+++ b/Tests/DistributedActorsTests/ParentChildActorTests.swift
@@ -527,27 +527,4 @@ class ParentChildActorTests: XCTestCase {
         let messages = try p.expectMessages(count: childCount)
         messages.sorted().shouldEqual((1 ... childCount).sorted())
     }
-
-    func test_contextStop_shouldBeAbleToStopChildInBehaviorIgnore() throws {
-        let p = self.testKit.spawnTestProbe(expecting: ActorRef<Never>.self)
-
-        let behavior: Behavior<String> = .setup { context in
-            let childRef = try context.spawn(.prefixed(with: "child"), of: Never.self, .ignore)
-
-            p.tell(childRef)
-
-            return .receiveMessage { _ in
-                try context.stop(child: childRef)
-                return .same
-            }
-        }
-
-        let ref = try self.system.spawn(.prefixed(with: "parent"), behavior)
-
-        let childRef = try p.expectMessage()
-        p.watch(childRef)
-
-        ref.tell("stopChild")
-        try p.expectTerminated(childRef)
-    }
 }


### PR DESCRIPTION

This reverts commit 8fac613f8d6c576f03568023aac3be567bb81ad8.

### Motivation:

- We thought it's a good idea, but it's more dangerous than useful.

Longer story, so this allows to "become ignore (or rather ignoring)". This makes the actor _unresponsive_ to _any_ message, unless it becomes another _specific_ behavior (not just .same), from some other wakeup like onResultAsync or similar. In reality this is very rare and it is too easy to accidentally 

Note also that the docs do not document the current behavior, but the previous one of "ignore one message" (which is not what happens right now).

This also means we are not implementing the "Maybe: ignore maybe should become ignoring" ticket. One can implement the same with a simple `.receive { _ in .same }` which looks more scary as it should.

I'm also considering entirely dropping `.ignore`, currently it adds more confusion than usefulness, WDYT? @drexin 


### Modifications:

- Make it such .ignore is "drop one message" as it is documented

### Result:

- Reverts  #94 #119