### PR TITLE
!asyncresult #202 hide AsyncResult.onComplete, as people accidentally invoke it

### DIFF
--- a/Sources/DistributedActors/ActorContext.swift
+++ b/Sources/DistributedActors/ActorContext.swift
@@ -294,7 +294,7 @@ public class ActorContext<Message>: ActorRefFactory {
     ///                   and modify actor state from here.
     /// - Returns: a behavior that causes the actor to suspend until the `AsyncResult` completes
     public func awaitResult<AR: AsyncResult>(of asyncResult: AR, timeout: TimeAmount, _ continuation: @escaping (Result<AR.Value, Error>) throws -> Behavior<Message>) -> Behavior<Message> {
-        asyncResult.withTimeout(after: timeout).onComplete { [weak selfRef = self.myself._unsafeUnwrapCell] result in
+        asyncResult.withTimeout(after: timeout)._onComplete { [weak selfRef = self.myself._unsafeUnwrapCell] result in
             selfRef?.sendSystemMessage(.resume(result.map { $0 }))
         }
         return .suspend(handler: continuation)
@@ -346,7 +346,7 @@ public class ActorContext<Message>: ActorRefFactory {
             shell.behavior = try shell.behavior.canonicalize(shell, next: nextBehavior)
         }
 
-        asyncResult.withTimeout(after: timeout).onComplete { res in
+        asyncResult.withTimeout(after: timeout)._onComplete { res in
             asyncCallback.invoke(res)
         }
     }

--- a/Sources/DistributedActors/ActorRef+Ask.swift
+++ b/Sources/DistributedActors/ActorRef+Ask.swift
@@ -117,8 +117,8 @@ public struct AskResponse<Value> {
 }
 
 extension AskResponse: AsyncResult {
-    public func onComplete(_ callback: @escaping (Result<Value, Error>) -> Void) {
-        self.nioFuture.onComplete { result in
+    public func _onComplete(_ callback: @escaping (Result<Value, Error>) -> Void) {
+        self.nioFuture._onComplete { result in
             callback(result)
         }
     }

--- a/Sources/DistributedActors/CRDT/CRDT.swift
+++ b/Sources/DistributedActors/CRDT/CRDT.swift
@@ -380,8 +380,8 @@ public enum CRDT {
                 self.dataFuture = dataFuture
             }
 
-            public func onComplete(_ callback: @escaping (Swift.Result<DataType, Swift.Error>) -> Void) {
-                self.dataFuture.onComplete(callback)
+            public func _onComplete(_ callback: @escaping (Swift.Result<DataType, Swift.Error>) -> Void) {
+                self.dataFuture.whenComplete(callback)
             }
 
             public func withTimeout(after timeout: TimeAmount) -> OperationResult<DataType> {

--- a/Sources/DistributedActors/Cluster/ClusterShell.swift
+++ b/Sources/DistributedActors/Cluster/ClusterShell.swift
@@ -436,7 +436,7 @@ extension ClusterShell {
         }
 
         let whenHandshakeComplete = state.eventLoopGroup.next().makePromise(of: Wire.HandshakeResponse.self)
-        whenHandshakeComplete.futureResult.onComplete { result in
+        whenHandshakeComplete.futureResult.whenComplete { result in
             switch result {
             case .success(.accept(let accept)):
                 /// we need to switch here, since we MAY have been attached to an ongoing handshake which may have been initiated
@@ -464,7 +464,7 @@ extension ClusterShell {
             return self.connectSendHandshakeOffer(context, state, initiated: initiated)
 
         case .wasOfferedHandshake, .inFlight, .completed:
-            // the reply will be handled already by the future.onComplete we've set up above here
+            // the reply will be handled already by the future.whenComplete we've set up above here
             // so nothing to do here, just become the next state
             return self.ready(state: state)
         }

--- a/Sources/DistributedActors/Cluster/Leadership.swift
+++ b/Sources/DistributedActors/Cluster/Leadership.swift
@@ -80,8 +80,8 @@ public struct LeaderElectionResult: AsyncResult {
         self.future = future
     }
 
-    public func onComplete(_ callback: @escaping (Result<LeadershipChange?, Error>) -> Void) {
-        self.future.onComplete(callback)
+    public func _onComplete(_ callback: @escaping (Result<LeadershipChange?, Error>) -> Void) {
+        self.future.whenComplete(callback)
     }
 
     public func withTimeout(after timeout: TimeAmount) -> LeaderElectionResult {

--- a/Sources/DistributedActors/Cluster/TransportPipelines.swift
+++ b/Sources/DistributedActors/Cluster/TransportPipelines.swift
@@ -118,7 +118,7 @@ final class ReceivingHandshakeHandler: ChannelInboundHandler, RemovableChannelHa
             let promise = context.eventLoop.makePromise(of: Wire.HandshakeResponse.self)
             self.cluster.tell(.inbound(.handshakeOffer(offer, channel: context.channel, replyTo: promise)))
 
-            promise.futureResult.onComplete { res in
+            promise.futureResult.whenComplete { res in
                 switch res {
                 case .failure(let err):
                     context.fireErrorCaught(err)
@@ -485,7 +485,7 @@ internal final class SystemMessageRedeliveryHandler: ChannelDuplexHandler {
         self.redeliveryScheduled = context.eventLoop.scheduleTask(in: nextRedeliveryDelay.toNIO) {
             RedeliveryTick()
         }
-        self.redeliveryScheduled?.futureResult.onComplete { _ in
+        self.redeliveryScheduled?.futureResult.whenComplete { _ in
             self.redeliveryScheduled = nil
             self.onRedeliveryTick(context)
         }

--- a/Tests/DistributedActorsTests/CRDT/CRDTActorOwnedTests.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTActorOwnedTests.swift
@@ -66,7 +66,7 @@ final class CRDTActorOwnedTests: XCTestCase {
             return .receiveMessage { message in
                 switch message {
                 case .increment(let amount, let consistency, let timeout, let replyTo):
-                    g.increment(by: amount, writeConsistency: consistency, timeout: timeout).onComplete { result in
+                    g.increment(by: amount, writeConsistency: consistency, timeout: timeout)._onComplete { result in
                         switch result {
                         case .success(let g):
                             replyTo.tell(g.value)
@@ -75,7 +75,7 @@ final class CRDTActorOwnedTests: XCTestCase {
                         }
                     }
                 case .read(let consistency, let timeout, let replyTo):
-                    g.read(atConsistency: consistency, timeout: timeout).onComplete { result in
+                    g.read(atConsistency: consistency, timeout: timeout)._onComplete { result in
                         switch result {
                         case .success(let g):
                             replyTo.tell(g.value)
@@ -84,7 +84,7 @@ final class CRDTActorOwnedTests: XCTestCase {
                         }
                     }
                 case .delete(let consistency, let timeout, let replyTo):
-                    g.deleteFromCluster(consistency: consistency, timeout: timeout).onComplete { result in
+                    g.deleteFromCluster(consistency: consistency, timeout: timeout)._onComplete { result in
                         switch result {
                         case .success:
                             replyTo.tell(())
@@ -241,7 +241,7 @@ final class CRDTActorOwnedTests: XCTestCase {
             return .receiveMessage { message in
                 switch message {
                 case .add(let element, let consistency, let timeout, let replyTo):
-                    s.add(element, writeConsistency: consistency, timeout: timeout).onComplete { result in
+                    s.add(element, writeConsistency: consistency, timeout: timeout)._onComplete { result in
                         switch result {
                         case .success(let s):
                             replyTo.tell(s.elements)
@@ -250,7 +250,7 @@ final class CRDTActorOwnedTests: XCTestCase {
                         }
                     }
                 case .remove(let element, let consistency, let timeout, let replyTo):
-                    s.remove(element, writeConsistency: consistency, timeout: timeout).onComplete { result in
+                    s.remove(element, writeConsistency: consistency, timeout: timeout)._onComplete { result in
                         switch result {
                         case .success(let s):
                             replyTo.tell(s.elements)
@@ -259,7 +259,7 @@ final class CRDTActorOwnedTests: XCTestCase {
                         }
                     }
                 case .read(let consistency, let timeout, let replyTo):
-                    s.read(atConsistency: consistency, timeout: timeout).onComplete { result in
+                    s.read(atConsistency: consistency, timeout: timeout)._onComplete { result in
                         switch result {
                         case .success(let s):
                             replyTo.tell(s.elements)
@@ -368,7 +368,7 @@ final class CRDTActorOwnedTests: XCTestCase {
                 case .increment(let key, let amount, let consistency, let timeout, let replyTo):
                     m.update(key: key, writeConsistency: consistency, timeout: timeout) {
                         $0.increment(by: amount)
-                    }.onComplete { result in
+                    }._onComplete { result in
                         switch result {
                         case .success(let m):
                             replyTo.tell(m.underlying)
@@ -377,7 +377,7 @@ final class CRDTActorOwnedTests: XCTestCase {
                         }
                     }
                 case .removeValue(let key, let consistency, let timeout, let replyTo):
-                    m.unsafeRemoveValue(forKey: key, writeConsistency: consistency, timeout: timeout).onComplete { result in
+                    m.unsafeRemoveValue(forKey: key, writeConsistency: consistency, timeout: timeout)._onComplete { result in
                         switch result {
                         case .success(let m):
                             replyTo.tell(m.underlying)
@@ -386,7 +386,7 @@ final class CRDTActorOwnedTests: XCTestCase {
                         }
                     }
                 case .read(let consistency, let timeout, let replyTo):
-                    m.read(atConsistency: consistency, timeout: timeout).onComplete { result in
+                    m.read(atConsistency: consistency, timeout: timeout)._onComplete { result in
                         switch result {
                         case .success(let m):
                             replyTo.tell(m.underlying)

--- a/Tests/DistributedActorsTests/Pattern/WorkerPoolTests.swift
+++ b/Tests/DistributedActorsTests/Pattern/WorkerPoolTests.swift
@@ -173,12 +173,12 @@ final class WorkerPoolTests: XCTestCase {
         let answerB: AskResponse<String> = workers.ask(for: String.self, timeout: .seconds(1)) { WorkerPoolQuestion(id: "BBB", replyTo: $0) }
 
         try self.testKit.eventually(within: .seconds(1)) {
-            answerA.nioFuture.onComplete { res in
+            answerA.nioFuture._onComplete { res in
                 pA.tell("\(res)")
             }
         }
         try self.testKit.eventually(within: .seconds(1)) {
-            answerB.nioFuture.onComplete { res in
+            answerB.nioFuture._onComplete { res in
                 pB.tell("\(res)")
             }
         }


### PR DESCRIPTION
### Motivation:

The `onComplete` function has to be declared on our `AsyncResult` protocol, and sadly we cannot have internal functions in the protocol. So anyone can adopt it, but also they can invoke the onComplete which is unsafe -- it is only to be used by the runtime to invoke and wrap with safe invocation context. 

So we use it internally to implement the "safe methods" by:

```
    public func onResultAsync<AR: AsyncResult>(of asyncResult: AR, timeout: TimeAmount, _ continuation: @escaping (Result<AR.Value, Error>) throws -> Behavior<Message>) {
// ... 
        asyncResult.withTimeout(after: timeout)._onComplete { res in
            asyncCallback.invoke(res)
        }
```

but noone else should be invoking it.

### Modifications:

- sadly we cannot do any tricks with making the func internal...
  - i tried some other internal protocol that the public one extends, though sadly that's illegal;
  - we also cannot have an internal func, nor can we add it as an extension, since it has to be part of the protocol

Option B:

- we COULD have `internal protocol _AsyncResult` which we'd _also_ implement for all types that adopt `AsyncResult`, and we'd put the _onComplete there, yet to invoke it we'd always force cast the `AsyncResult` to `_AsyncResult` and invoke the thing... I wonder if that's doable, but it could work if we _really_ want to hide the function...

For the time being, I'm okey with having it as `_onComplete` as and documented to "dont call this".
Perhaps we could have some other protocol that people could implement that would allow for "safe execution"

### Result:

- Resolves #202 