### PR TITLE
=build Make the gen_linux_tests ignore .orig files

### DIFF
--- a/scripts/generate_linux_tests.rb
+++ b/scripts/generate_linux_tests.rb
@@ -207,7 +207,7 @@ Dir[testsDirectory + '/*'].each do |subDirectory|
       if File.directory? fileName
         directoryHasClasses |= findTestClasses(fileName, allFiles)
         next
-      elsif !(File.file? fileName) || !(fileName =~ /Test(s?)\.swift/)
+      elsif !(File.file? fileName) || !(fileName =~ /Test(s?)\.swift$/)
         next
       end
 


### PR DESCRIPTION
### Motivation:

If one has *.orig files of `Tests.swift` files locally, the generate_linux_tests script would generate thr same line twice.


### Modifications:

- ignore files not exactly ending with `.swift`

### Result:

- less silly double lines of a test file in LinuxMain