### PR TITLE
+actorable introduce Myself typealias, to encourage sharing "right" type

### DIFF
--- a/Sources/DistributedActors/GenActors/Actorable.swift
+++ b/Sources/DistributedActors/GenActors/Actorable.swift
@@ -31,7 +31,7 @@ public protocol Actorable {
     associatedtype Message
 
     /// Represents a handle to this actor (`myself`), that is safe to pass to other actors, threads, and even nodes.
-    public typealias Myself = Actor<Self>
+    typealias Myself = Actor<Self>
 
     // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: GenActor filled in functions


### PR DESCRIPTION
### Motivation:

- Actors should only ever expose their "refs", in Actorable this means one may only expose the `Actor<Self>` (which is similar to `ActorRef<Self.Message>`.

We want to encourage sharing Myself, but sharing Self is unsafe, thus being easier to type the right thing is good.

### Modifications:

- introduce typealias `Myself`

### Result:

- easier to type the "right" type (`Myself`), than having to type `Actor<Self>`