### PR TITLE
=subreceive,actorpath less restrictive path validation for <> #201

### DIFF
--- a/Sources/DistributedActors/ActorAddress.swift
+++ b/Sources/DistributedActors/ActorAddress.swift
@@ -224,7 +224,7 @@ internal enum ActorLocation: Hashable {
 ///
 /// Names of user actors MUST:
 /// - not start with `$` (those names are reserved for Swift Distributed Actors internal system actors)
-/// - contain only ASCII characters and select special characters (listed in `ValidPathSymbols.extraSymbols`
+/// - contain only ASCII characters and select special characters (listed in `ValidPathSymbols.extraSymbols`)
 ///
 /// - Example: `/user/lightbulbMaster/lightbulb-2012`
 public struct ActorPath: PathRelationships, Hashable {
@@ -445,7 +445,7 @@ private struct ValidActorPathSymbols {
     static let zero: UnicodeScalar = "0"
     static let nine: UnicodeScalar = "9"
 
-    static let extraSymbols: String.UnicodeScalarView = "-_.*$+:@&=,!~';".unicodeScalars
+    static let extraSymbols: String.UnicodeScalarView = "-_.*$+:@&=,!~';<>".unicodeScalars
 }
 
 struct ActorName {

--- a/Sources/DistributedActors/ActorContext.swift
+++ b/Sources/DistributedActors/ActorContext.swift
@@ -449,9 +449,6 @@ public struct SubReceiveId<SubMessage>: Hashable, Equatable {
 
     public init(_: SubMessage.Type) {
         let typeName = String(reflecting: SubMessage.self)
-            .replacingOccurrences(of: "<", with: "-")
-            .replacingOccurrences(of: ">", with: "-") // TODO: workaround this since names will be gone...?
-
         self.id = typeName
     }
 

--- a/Sources/DistributedActors/GenActors/Actor+Context+Receptionist.swift
+++ b/Sources/DistributedActors/GenActors/Actor+Context+Receptionist.swift
@@ -118,7 +118,7 @@ extension Actor.Context {
             let promise = self.context.system._eventLoopGroup.next().makePromise(of: Reception.Listing<Act>.self)
             self.underlying.system.receptionist.tell(SystemReceptionist.Lookup(
                 key: key.underlying,
-                replyTo: self.underlying.subReceive("lookup-\(key)", SystemReceptionist.Listing<Act.Message>.self) { listing in
+                replyTo: self.underlying.subReceive("lookup-\(type(of: key))", SystemReceptionist.Listing<Act.Message>.self) { listing in
                     let actors = Set(listing.refs.map { ref in
                         Actor<Act>(ref: ref)
                     })

--- a/Sources/DistributedActors/GenActors/ActorableOwned.swift
+++ b/Sources/DistributedActors/GenActors/ActorableOwned.swift
@@ -36,8 +36,6 @@ public final class ActorableOwned<T> {
 
     public init<Owner>(_ context: Owner.Myself.Context, type: T.Type = T.self) where Owner: Actorable {
         let typeName = String(reflecting: T.self)
-            .replacingOccurrences(of: "<", with: "-")
-            .replacingOccurrences(of: ">", with: "-") // TODO: workaround this since names will be gone...?
 
         self._cell = nil
         self.__onUpdate = { _ in () }

--- a/Tests/DistributedActorsTests/ActorSubReceiveTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/ActorSubReceiveTests+XCTest.swift
@@ -24,6 +24,7 @@ extension ActorSubReceiveTests {
     static var allTests: [(String, (ActorSubReceiveTests) -> () throws -> Void)] {
         return [
             ("test_subReceive_shouldBeAbleToReceiveMessages", test_subReceive_shouldBeAbleToReceiveMessages),
+            ("test_subReceiveId_fromGenericType_shouldNotBlowUp", test_subReceiveId_fromGenericType_shouldNotBlowUp),
             ("test_subReceive_shouldBeAbleToModifyActorState", test_subReceive_shouldBeAbleToModifyActorState),
             ("test_subReceive_shouldBeWatchable", test_subReceive_shouldBeWatchable),
             ("test_subReceive_shouldShareLifetimeWithParent", test_subReceive_shouldShareLifetimeWithParent),

--- a/Tests/DistributedActorsTests/Actorable/ActorContextReceptionistTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Actorable/ActorContextReceptionistTests+XCTest.swift
@@ -25,6 +25,7 @@ extension ActorContextReceptionTests {
         return [
             ("test_autoUpdatedListing_updatesAutomatically", test_autoUpdatedListing_updatesAutomatically),
             ("test_autoUpdatedListing_invokesOnUpdate", test_autoUpdatedListing_invokesOnUpdate),
+            ("test_lookup_ofGenericType", test_lookup_ofGenericType),
         ]
     }
 }

--- a/Tests/DistributedActorsTests/Actorable/ActorContextReceptionistTests.swift
+++ b/Tests/DistributedActorsTests/Actorable/ActorContextReceptionistTests.swift
@@ -52,4 +52,11 @@ final class ActorContextReceptionTests: XCTestCase {
         let listing1: Reception.Listing<OwnerOfThings> = Reception.Listing<OwnerOfThings>(actors: Set([owner]))
         try p.expectMessage(listing1)
     }
+
+    func test_lookup_ofGenericType() throws {
+        let p = self.testKit.spawnTestProbe(expecting: Reception.Listing<OwnerOfThings>.self)
+        let owner: Actor<OwnerOfThings> = try self.system.spawn("owner") { OwnerOfThings(context: $0, probe: p.ref) }
+
+        let reply = owner.performLookup()
+    }
 }

--- a/Tests/DistributedActorsTests/Actorable/OwnerOfThings+GenCodable.swift
+++ b/Tests/DistributedActorsTests/Actorable/OwnerOfThings+GenCodable.swift
@@ -17,6 +17,7 @@
 //===----------------------------------------------------------------------===//
 
 import DistributedActors
+import class NIO.EventLoopFuture
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: DO NOT EDIT: Codable conformance for OwnerOfThings.Message
 // TODO: This will not be required, once Swift synthesizes Codable conformances for enums with associated values
@@ -25,11 +26,13 @@ extension OwnerOfThings.Message: Codable {
     // TODO: Check with Swift team which style of discriminator to aim for
     public enum DiscriminatorKeys: String, Decodable {
         case readLastObservedValue
+        case performLookup
     }
 
     public enum CodingKeys: CodingKey {
         case _case
         case readLastObservedValue__replyTo
+        case performLookup__replyTo
     }
 
     public init(from decoder: Decoder) throws {
@@ -38,6 +41,9 @@ extension OwnerOfThings.Message: Codable {
         case .readLastObservedValue:
             let _replyTo = try container.decode(ActorRef<Reception.Listing<OwnerOfThings>?>.self, forKey: CodingKeys.readLastObservedValue__replyTo)
             self = .readLastObservedValue(_replyTo: _replyTo)
+        case .performLookup:
+            let _replyTo = try container.decode(ActorRef<Result<Reception.Listing<OwnerOfThings>, Error>>.self, forKey: CodingKeys.performLookup__replyTo)
+            self = .performLookup(_replyTo: _replyTo)
         }
     }
 
@@ -47,6 +53,9 @@ extension OwnerOfThings.Message: Codable {
         case .readLastObservedValue(let _replyTo):
             try container.encode(DiscriminatorKeys.readLastObservedValue.rawValue, forKey: CodingKeys._case)
             try container.encode(_replyTo, forKey: CodingKeys.readLastObservedValue__replyTo)
+        case .performLookup(let _replyTo):
+            try container.encode(DiscriminatorKeys.performLookup.rawValue, forKey: CodingKeys._case)
+            try container.encode(_replyTo, forKey: CodingKeys.performLookup__replyTo)
         }
     }
 }

--- a/Tests/DistributedActorsTests/Actorable/OwnerOfThings.swift
+++ b/Tests/DistributedActorsTests/Actorable/OwnerOfThings.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import DistributedActors
+import class NIO.EventLoopFuture
 
 struct OwnerOfThings: Actorable {
     let context: Myself.Context
@@ -30,6 +31,11 @@ struct OwnerOfThings: Actorable {
 
     func readLastObservedValue() -> Reception.Listing<OwnerOfThings>? {
         self.ownedListing.lastObservedValue
+    }
+
+    func performLookup() -> EventLoopFuture<Reception.Listing<OwnerOfThings>> {
+        let reply = self.context.receptionist.lookup(.init(OwnerOfThings.self, id: "all/owners"))
+        return reply._nioFuture
     }
 }
 


### PR DESCRIPTION
### Modifications:

Expand allowed special chars by < and >.
There's no real reason we don't allow them, the list of chars is arbitrary tbh.

### Result:

- Resolves: SubReceiveId with generic types creates invalid path #201
- Allows us to do `lookup-\(type(of: key))` for receptionist which is quite nice