### PR TITLE
+actorable allow Props to be passed to actorable spawns

### DIFF
--- a/Sources/DistributedActors/GenActors/Actorable+ActorSystem.swift
+++ b/Sources/DistributedActors/GenActors/Actorable+ActorSystem.swift
@@ -20,8 +20,8 @@ extension ActorSystem {
     ///
     /// The actor is immediately available to receive messages, which may be sent to it using function calls, which are turned into message-sends.
     /// The underlying `ActorRef<Message>` is available as `ref` on the returned actor, and allows passing the actor to `Behavior` style APIs.
-    public func spawn<A: Actorable>(_ naming: ActorNaming, _ makeActorable: @escaping (Actor<A>.Context) -> A) throws -> Actor<A> {
-        let ref = try self.spawn(naming, of: A.Message.self, Behavior<A.Message>.setup { context in
+    public func spawn<A: Actorable>(_ naming: ActorNaming, props: Props = Props(), _ makeActorable: @escaping (Actor<A>.Context) -> A) throws -> Actor<A> {
+        let ref = try self.spawn(naming, of: A.Message.self, props: props, Behavior<A.Message>.setup { context in
             A.makeBehavior(instance: makeActorable(.init(underlying: context)))
         })
         return Actor(ref: ref)
@@ -29,8 +29,8 @@ extension ActorSystem {
 
     // TODO: discuss the autoclosure with Swift team -- it looks nicer, but is also scarier for "accidentally close over some mutable thing"
     // TODO: does it matter if supervision is gone though? I think not actually, so that's excellent...
-    public func spawn<A: Actorable>(_ naming: ActorNaming, _ makeActorable: @autoclosure @escaping () -> A) throws -> Actor<A> {
-        let ref = try self.spawn(naming, of: A.Message.self, A.makeBehavior(instance: makeActorable()))
+    public func spawn<A: Actorable>(_ naming: ActorNaming, props: Props = Props(), _ makeActorable: @autoclosure @escaping () -> A) throws -> Actor<A> {
+        let ref = try self.spawn(naming, of: A.Message.self, props: props, A.makeBehavior(instance: makeActorable()))
         return Actor(ref: ref)
     }
 }


### PR DESCRIPTION
Actorable may use props -- and continue using current supervision, until we ship the replacements.
