### PR TITLE
=reception avoid leaking NIO promise by timing it out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .swift-version
 
 *.orig
+*.app
 
 /.build
 /Samples/.build

--- a/Tests/DistributedActorsTests/Actorable/OwnerOfThings.swift
+++ b/Tests/DistributedActorsTests/Actorable/OwnerOfThings.swift
@@ -34,7 +34,7 @@ struct OwnerOfThings: Actorable {
     }
 
     func performLookup() -> EventLoopFuture<Reception.Listing<OwnerOfThings>> {
-        let reply = self.context.receptionist.lookup(.init(OwnerOfThings.self, id: "all/owners"))
+        let reply = self.context.receptionist.lookup(.init(OwnerOfThings.self, id: "all/owners"), timeout: .effectivelyInfinite)
         return reply._nioFuture
     }
 }


### PR DESCRIPTION
### Motivation:

Promise would leak causing a crash; 

### Modifications:

Use `ask` which is safe due to the timeout it applies.

### Result:

- Resolves https://github.com/apple/swift-distributed-actors/issues/293
- no more crashes if the lookup does not get a reply for whatever reason
