### PR TITLE
=backoff Dont hardcode backoff cap default #302

### DIFF
--- a/Sources/DistributedActors/Backoff.swift
+++ b/Sources/DistributedActors/Backoff.swift
@@ -68,10 +68,10 @@ public enum Backoff {
     public static func exponential(
         initialInterval: TimeAmount = ExponentialBackoffStrategy.Defaults.initialInterval,
         multiplier: Double = ExponentialBackoffStrategy.Defaults.multiplier,
-        maxInterval: TimeAmount = ExponentialBackoffStrategy.Defaults.capInterval,
+        capInterval: TimeAmount = ExponentialBackoffStrategy.Defaults.capInterval,
         randomFactor: Double = ExponentialBackoffStrategy.Defaults.randomFactor
     ) -> ExponentialBackoffStrategy {
-        return .init(initialInterval: initialInterval, multiplier: multiplier, capInterval: maxInterval, randomFactor: randomFactor)
+        .init(initialInterval: initialInterval, multiplier: multiplier, capInterval: capInterval, randomFactor: randomFactor)
     }
 }
 
@@ -143,7 +143,7 @@ public struct ExponentialBackoffStrategy: BackoffStrategy {
     public struct Defaults {
         public static let initialInterval: TimeAmount = .milliseconds(200)
         public static let multiplier: Double = 1.5
-        public static let capInterval: TimeAmount = .seconds(30)
+        public static let capInterval: TimeAmount = .effectivelyInfinite
         public static let randomFactor: Double = 0.25
 
         // TODO: We could also implement taking a Clock, and using it see if there's a total limit exceeded

--- a/Tests/DistributedActorsTests/BackoffStrategyTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/BackoffStrategyTests+XCTest.swift
@@ -29,6 +29,7 @@ extension BackoffStrategyTests {
             ("test_exponentialBackoff_shouldAllowDisablingRandomFactor", test_exponentialBackoff_shouldAllowDisablingRandomFactor),
             ("test_exponentialBackoff_reset_shouldResetBackoffIntervals", test_exponentialBackoff_reset_shouldResetBackoffIntervals),
             ("test_exponentialBackoff_shouldNotExceedMaximumBackoff", test_exponentialBackoff_shouldNotExceedMaximumBackoff),
+            ("test_exponentialBackoff_withLargeInitial_shouldAdjustCap", test_exponentialBackoff_withLargeInitial_shouldAdjustCap),
         ]
     }
 }

--- a/Tests/DistributedActorsTests/BackoffStrategyTests.swift
+++ b/Tests/DistributedActorsTests/BackoffStrategyTests.swift
@@ -72,10 +72,14 @@ class BackoffStrategyTests: XCTestCase {
     func test_exponentialBackoff_shouldNotExceedMaximumBackoff() {
         let max = TimeAmount.seconds(1)
         let maxRandomNoise = max * 1.25
-        var backoff = Backoff.exponential(initialInterval: .milliseconds(500), maxInterval: max)
+        var backoff = Backoff.exponential(initialInterval: .milliseconds(500), capInterval: max)
         backoff.next()?.shouldBeLessThanOrEqual(max + maxRandomNoise)
         backoff.next()?.shouldBeLessThanOrEqual(max + maxRandomNoise)
         backoff.next()?.shouldBeLessThanOrEqual(max + maxRandomNoise)
         backoff.next()?.shouldBeLessThanOrEqual(max + maxRandomNoise)
+    }
+
+    func test_exponentialBackoff_withLargeInitial_shouldAdjustCap() {
+        Backoff.exponential(initialInterval: .seconds(60)) // cap used to be hardcoded which would cause this to precondition crash
     }
 }


### PR DESCRIPTION
### Motivation:

Hardcoded cap limit caused crashes if initial > than that limit.

### Modifications:

No need to hardcode the cap; it is limited by nr of restarts in supervision, and also if people want a cap, they should set it explicitly

### Result:

- Resolves #302 Dont hardcode backoff cap default
