### PR TITLE
+swim make swim settings public

### DIFF
--- a/Sources/DistributedActors/Cluster/SWIM/SWIMSettings.swift
+++ b/Sources/DistributedActors/Cluster/SWIM/SWIMSettings.swift
@@ -24,22 +24,22 @@ public struct SWIMSettings {
 
     /// Optional "SWIM instance name" to be included in log statements,
     /// useful when multiple instances of SWIM are run on the same process (e.g. for debugging).
-    var name: String?
+    public var name: String?
 
     // var timeSource: TimeSource // TODO would be nice?
 
-    var gossip: SWIMGossipSettings = .default
+    public var gossip: SWIMGossipSettings = .default
 
-    var failureDetector: SWIMFailureDetectorSettings = .default
+    public var failureDetector: SWIMFailureDetectorSettings = .default
 
     /// When enabled traces _all_ incoming SWIM protocol communication (remote messages).
     /// These logs will contain SWIM.Instance metadata, as offered by `SWIM.Instance.metadata`.
     /// All logs will be prefixed using `[tracelog:SWIM]`, for easier grepping and inspecting only logs related to the SWIM instance.
     // TODO: how to make this nicely dynamically changeable during runtime
     #if SACT_TRACELOG_SWIM
-    var traceLogLevel: Logger.Level? = .warning
+    public var traceLogLevel: Logger.Level? = .warning
     #else
-    var traceLogLevel: Logger.Level?
+    public var traceLogLevel: Logger.Level?
     #endif
 }
 
@@ -57,14 +57,14 @@ public struct SWIMGossipSettings {
 
     /// Interval at which gossip messages should be issued.
     /// Every `interval` a `fanout` number of gossip messages will be sent. // TODO which fanout?
-    var probeInterval: TimeAmount = .seconds(1)
+    public var probeInterval: TimeAmount = .seconds(1)
 
     // FIXME: investigate size of messages and find good default
     //
     // max number of messages included in any gossip payload
-    var maxNumberOfMessages: Int = 20
+    public var maxNumberOfMessages: Int = 20
 
-    var maxGossipCountPerMessage: Int = 6
+    public var maxGossipCountPerMessage: Int = 6
 }
 
 // ==== ----------------------------------------------------------------------------------------------------------------
@@ -80,7 +80,7 @@ public struct SWIMFailureDetectorSettings {
     /// In case of small clusters where nr. of neighbors is smaller than this value, the most neighbors available will
     /// be asked to issue an indirect probe. E.g. a 3 node cluster, configured with `indirectChecks = 3` has only `1`
     /// remaining node it can ask for an indirect probe (since 1 node is ourselves, and 1 node is the potentially suspect node itself).
-    var indirectProbeCount: Int = 3 {
+    public var indirectProbeCount: Int = 3 {
         willSet {
             precondition(newValue >= 0, "`indirectChecks` MUST NOT be < 0. It is recommended to have it be no lower than 3.")
         }
@@ -91,9 +91,9 @@ public struct SWIMFailureDetectorSettings {
     /// Suspicion timeouts are specified as number of probe intervals. E.g. a `probeInterval`
     /// of 300 milliseconds and `suspicionTimeoutMax` means that a suspicious node will be
     /// marked `.dead` after approx. 900ms.
-    var suspicionTimeoutPeriodsMax: Int = 10
-    var suspicionTimeoutPeriodsMin: Int = 10
+    public var suspicionTimeoutPeriodsMax: Int = 10
+    public var suspicionTimeoutPeriodsMin: Int = 10
 
-    var probeInterval: TimeAmount = .seconds(1)
-    var pingTimeout: TimeAmount = .milliseconds(300)
+    public var probeInterval: TimeAmount = .seconds(1)
+    public var pingTimeout: TimeAmount = .milliseconds(300)
 }


### PR DESCRIPTION
### Motivation:

Users can't tune SWIM today.

### Modifications:

- make settings public

### Result:

- users can tune SWIM failure detector et al settings