### PR TITLE
Changing from with to without leader should publish LeadershipChange

### DIFF
--- a/Sources/DistributedActors/Cluster/Leadership.swift
+++ b/Sources/DistributedActors/Cluster/Leadership.swift
@@ -230,7 +230,15 @@ extension Leadership {
             guard membersToSelectAmong.count >= self.minimumNumberOfMembersToDecide else {
                 // not enough members to make a decision yet
                 context.log.trace("Not enough members to select leader from, minimum nr of members [\(membersToSelectAmong.count)/\(self.minimumNumberOfMembersToDecide)]")
-                return .init(context.loop.next().makeSucceededFuture(nil))
+
+                if let currentLeader = membership.leader {
+                    // Clear current leader and trigger `LeadershipChange`
+                    let change = try! membership.applyLeadershipChange(to: nil) // try! safe because we are changing leader to nil
+                    context.log.trace("Removing leader [\(currentLeader)]")
+                    return .init(context.loop.next().makeSucceededFuture(change))
+                } else {
+                    return .init(context.loop.next().makeSucceededFuture(nil))
+                }
             }
 
             // select the leader, by lowest address

--- a/Tests/DistributedActorsTests/Cluster/LeadershipTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Cluster/LeadershipTests+XCTest.swift
@@ -25,6 +25,7 @@ extension LeadershipTests {
         return [
             ("test_LowestReachableMember_selectLeader", test_LowestReachableMember_selectLeader),
             ("test_LowestReachableMember_notEnoughMembersToDecide", test_LowestReachableMember_notEnoughMembersToDecide),
+            ("test_LowestReachableMember_notEnoughMembersToDecide_fromWithToWithoutLeader", test_LowestReachableMember_notEnoughMembersToDecide_fromWithToWithoutLeader),
             ("test_LowestReachableMember_whenCurrentLeaderDown", test_LowestReachableMember_whenCurrentLeaderDown),
             ("test_LowestReachableMember_whenCurrentLeaderUnreachable", test_LowestReachableMember_whenCurrentLeaderUnreachable),
         ]

--- a/Tests/DistributedActorsTests/Cluster/LeadershipTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/LeadershipTests.swift
@@ -59,6 +59,23 @@ final class LeadershipTests: XCTestCase {
         change2.shouldEqual(LeadershipChange(oldLeader: nil, newLeader: self.secondMember))
     }
 
+    func test_LowestReachableMember_notEnoughMembersToDecide_fromWithToWithoutLeader() throws {
+        let selection = Leadership.LowestReachableMember(minimumNrOfMembers: 3)
+
+        var membership = self.initialMembership
+        _ = try! membership.applyLeadershipChange(to: self.firstMember) // try! because `firstMember` is a member
+
+        let leader = membership.leader
+        leader.shouldNotBeNil()
+
+        _ = membership.remove(self.firstMember.node)
+
+        // 2 members -> not enough to make decision anymore
+        // Since we go from a leader to without, there should be a change
+        let change: LeadershipChange? = try selection.runElection(context: self.fakeContext, membership: membership).future.wait()
+        change.shouldEqual(LeadershipChange(oldLeader: leader, newLeader: nil))
+    }
+
     func test_LowestReachableMember_whenCurrentLeaderDown() throws {
         let selection = Leadership.LowestReachableMember(minimumNrOfMembers: 3)
 


### PR DESCRIPTION
Motivation:
`.leadershipChange` `ClusterEvent` is not published when membership leader goes from non-`nil` to `nil`. See https://github.com/apple/swift-distributed-actors/issues/331.

Modifications:
Update logic to apply leadership change (to `nil`) if current leader is non-`nil`.

Result:
Resolves https://github.com/apple/swift-distributed-actors/issues/331.
