### PR TITLE
=test,receptionist #335 Too aggressive test, removal may take a moment

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -208,7 +208,7 @@ targets.append(contentsOf: [
 #endif
 
 var dependencies: [Package.Dependency] = [
-    .package(url: "https://github.com/apple/swift-nio.git", from: "2.8.0"),
+    .package(url: "https://github.com/apple/swift-nio.git", from: "2.12.0"),
     .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.2.0"),
     .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.2.0"),
 


### PR DESCRIPTION
### Motivation:

Test was added recently and is way too aggressive -- the removal/adding is all async, thus assertion must be `eventually`.

### Modifications:

- eventually the receptionist will update the listing

### Result:

- Resolves https://github.com/apple/swift-distributed-actors/issues/335
