### PR TITLE
LeadershipChange to use init? rather than faulting when new/old leaders equal

### DIFF
--- a/Sources/DistributedActors/Cluster/Leadership.swift
+++ b/Sources/DistributedActors/Cluster/Leadership.swift
@@ -98,9 +98,12 @@ public struct LeadershipChange: Equatable {
     public let oldLeader: Member?
     public let newLeader: Member?
 
-    /// - Faults when: the `oldLeader` and the `newLeader` are equal.
-    public init(oldLeader: Member?, newLeader: Member?) {
-        assert(oldLeader != newLeader, "A leadership change MUST NOT be from/to the same member. Both values were: \(oldLeader, orElse: "<no-leader>")")
+    /// A change is only returned when `oldLeader` and `newLeader` are different.
+    /// In order to avoid issuing changes which would be no-ops, the initializer fails if they are equal.
+    public init?(oldLeader: Member?, newLeader: Member?) {
+        guard oldLeader != newLeader else {
+            return nil
+        }
         self.oldLeader = oldLeader
         self.newLeader = newLeader
     }

--- a/Tests/DistributedActorsTests/Cluster/ClusterLeaderActionsTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/ClusterLeaderActionsTests.swift
@@ -181,7 +181,7 @@ final class ClusterLeaderActionsTests: ClusteredNodesTestBase {
             eventsOnFirstSub.shouldContain(.membershipChange(.init(node: second.cluster.node, fromStatus: nil, toStatus: .joining)))
             eventsOnFirstSub.shouldContain(.membershipChange(.init(node: first.cluster.node, fromStatus: .joining, toStatus: .up)))
             eventsOnFirstSub.shouldContain(.membershipChange(.init(node: second.cluster.node, fromStatus: .joining, toStatus: .up)))
-            eventsOnFirstSub.shouldContain(.leadershipChange(.init(oldLeader: nil, newLeader: .init(node: first.cluster.node, status: .joining))))
+            eventsOnFirstSub.shouldContain(.leadershipChange(LeadershipChange(oldLeader: nil, newLeader: .init(node: first.cluster.node, status: .joining))!)) // !-safe, since new/old leader known to be different
 
             // on non-leader node
             let eventsOnSecondSub = try p2.expectMessages(count: 6)
@@ -190,7 +190,7 @@ final class ClusterLeaderActionsTests: ClusteredNodesTestBase {
             eventsOnSecondSub.shouldContain(.membershipChange(.init(node: second.cluster.node, fromStatus: .joining, toStatus: .joining)))
             eventsOnSecondSub.shouldContain(.membershipChange(.init(node: first.cluster.node, fromStatus: .up, toStatus: .up))) // FIXME: by doing a real gossip rather then sending "the member" this will be fixed
             eventsOnSecondSub.shouldContain(.membershipChange(.init(node: second.cluster.node, fromStatus: .up, toStatus: .up))) // FIXME: by doing a real gossip rather then sending "the member" this will be fixed
-            eventsOnSecondSub.shouldContain(.leadershipChange(.init(oldLeader: nil, newLeader: .init(node: first.cluster.node, status: .joining))))
+            eventsOnSecondSub.shouldContain(.leadershipChange(LeadershipChange(oldLeader: nil, newLeader: .init(node: first.cluster.node, status: .joining))!)) // !-safe, since new/old leader known to be different
         }
     }
 }

--- a/Tests/DistributedActorsTests/Cluster/Protobuf/ClusterEvents+SerializationTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/Protobuf/ClusterEvents+SerializationTests.swift
@@ -47,7 +47,7 @@ final class ClusterEventsSerializationTests: XCTestCase {
     func test_serializationOf_leadershipChange() throws {
         let old = Member(node: UniqueNode(node: Node(systemName: "first", host: "1.1.1.1", port: 7337), nid: .random()), status: .joining)
         let new = Member(node: UniqueNode(node: Node(systemName: "first", host: "1.2.2.1", port: 2222), nid: .random()), status: .up)
-        let event = ClusterEvent.leadershipChange(.init(oldLeader: old, newLeader: new))
+        let event = ClusterEvent.leadershipChange(LeadershipChange(oldLeader: old, newLeader: new)!) // !-safe, since new/old leader known to be different
 
         let proto = try event.toProto(context: self.context)
         let back = try ClusterEvent(fromProto: proto, context: context)


### PR DESCRIPTION
### Motivation:

Faulting is a bit "hard" esp since this may happen in some codepath and the actual right thing is to return `nil` meaning "no change"

### Modifications:

- move away from faulting and do `init?` instead when creating changes

### Result:

- less risk of crashing process