### PR TITLE
=test,cluster #336 Harden test to not bind already bound port

### DIFF
--- a/Tests/DistributedActorsTests/Cluster/AssociationClusteredTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/AssociationClusteredTests.swift
@@ -79,7 +79,8 @@ final class ClusterAssociationTests: ClusteredNodesTestBase {
             try assertAssociated(second, withExactly: first.cluster.node)
 
             let oldSecond = second
-            oldSecond.shutdown() // kill remote node
+            let shutdown = oldSecond.shutdown() // kill remote node
+            try shutdown.wait(atMost: .seconds(3))
 
             let secondReplacement = self.setUpNode(secondName + "-REPLACEMENT") { settings in
                 settings.cluster.bindPort = remotePort

--- a/Tests/DistributedActorsTests/Cluster/ClusteredNodesTestBase.swift
+++ b/Tests/DistributedActorsTests/Cluster/ClusteredNodesTestBase.swift
@@ -221,8 +221,12 @@ extension ClusteredNodesTestBase {
                 var diff = Set(associatedNodes)
                 diff.formSymmetricDifference(exactlyNodes)
                 guard diff.isEmpty else {
-                    throw TestError("[\(system)] did not associate the expected nodes: [\(exactlyNodes)]. " +
-                        "Associated nodes: \(reflecting: associatedNodes), expected nodes: \(reflecting: exactlyNodes), diff: \(reflecting: diff).")
+                    throw TestError(
+                        """
+                        [\(system)] did not associate the expected nodes: [\(exactlyNodes)].
+                          Associated nodes: \(reflecting: associatedNodes), expected nodes: \(reflecting: exactlyNodes),
+                          diff: \(reflecting: diff).
+                        """)
                 }
             }
         }


### PR DESCRIPTION
### Motivation:

- Fleaky test
  - reason: we did not wait for the previous system to be done unbinding() before we start another one on the same port, thus failing to bind.

### Modifications:

- added missing await on the shutting down of the previous system

### Result:

- Resolves #336 