### PR TITLE
=await Ensure supervision works for context.awaitResult

### DIFF
--- a/Sources/DistributedActors/ActorLogging.swift
+++ b/Sources/DistributedActors/ActorLogging.swift
@@ -70,11 +70,11 @@ public struct ActorLogger {
         }
 
         var proxyHandler = ActorOriginLogHandler(context)
-        proxyHandler.metadata["actorPath"] = .lazyStringConvertible { [weak context = context] in context?.path.description ?? "INVALID" }
+        proxyHandler.metadata["actorPath"] = "\(context.path)"
         if context.system.settings.cluster.enabled {
-            proxyHandler.metadata["node"] = .string("\(context.system.settings.cluster.node)")
+            proxyHandler.metadata["node"] = "\(context.system.settings.cluster.node)"
         } else {
-            proxyHandler.metadata["nodeName"] = .string(context.system.name)
+            proxyHandler.metadata["nodeName"] = "\(context.system.name)"
         }
 
         var log = Logger(label: "\(context.path)", factory: { _ in proxyHandler })

--- a/Sources/DistributedActors/ActorRefProvider.swift
+++ b/Sources/DistributedActors/ActorRefProvider.swift
@@ -125,7 +125,7 @@ internal struct LocalActorRefProvider: _ActorRefProvider {
     private let root: Guardian
 
     var rootAddress: ActorAddress {
-        return self.root.address
+        self.root.address
     }
 
     init(root: Guardian) {

--- a/Sources/DistributedActors/ActorSystem.swift
+++ b/Sources/DistributedActors/ActorSystem.swift
@@ -282,11 +282,11 @@ public final class ActorSystem {
         }
     }
 
+    #if SACT_TESTS_LEAKS
     deinit {
-        #if SACT_TESTS_LEAKS
         _ = ActorSystem.actorSystemInitCounter.sub(1)
-        #endif
     }
+    #endif
 
     public struct Shutdown {
         private let receptacle: BlockingReceptacle<Void>
@@ -364,7 +364,7 @@ public final class ActorSystem {
 
 extension ActorSystem: Equatable {
     public static func == (lhs: ActorSystem, rhs: ActorSystem) -> Bool {
-        return ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
+        ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
     }
 }
 

--- a/Sources/DistributedActors/Cluster/ClusterSettings.swift
+++ b/Sources/DistributedActors/Cluster/ClusterSettings.swift
@@ -106,7 +106,7 @@ public struct ClusterSettings {
             case .none:
                 return nil
             case .lowestAddress(let nr):
-                return Leadership.LowestReachableMember(minimumNrOfMembers: nr)
+                return Leadership.LowestAddressMember(minimumNrOfMembers: nr)
             }
         }
     }

--- a/Sources/DistributedActors/Supervision.swift
+++ b/Sources/DistributedActors/Supervision.swift
@@ -389,7 +389,7 @@ internal enum ProcessingAction<Message> {
     case message(Message)
     case signal(Signal)
     case closure(ActorClosureCarry)
-    case continuation(() throws -> Behavior<Message>)
+    case continuation(() throws -> Behavior<Message>) // TODO: make it a Carry type for better debugging
     case subMessage(SubMessageCarry)
 }
 

--- a/Tests/DistributedActorsTests/BehaviorTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/BehaviorTests+XCTest.swift
@@ -53,6 +53,7 @@ extension BehaviorTests {
             ("test_awaitResult_shouldResumeActorWithFailureResultWhenFutureTimesOut", test_awaitResult_shouldResumeActorWithFailureResultWhenFutureTimesOut),
             ("test_awaitResult_shouldWorkWhenReturnedInsideInitialSetup", test_awaitResult_shouldWorkWhenReturnedInsideInitialSetup),
             ("test_awaitResult_shouldCrashWhenReturnedInsideInitialSetup_andReturnSameOnResume", test_awaitResult_shouldCrashWhenReturnedInsideInitialSetup_andReturnSameOnResume),
+            ("test_awaitResult_allowBecomingIntoSetup", test_awaitResult_allowBecomingIntoSetup),
             ("test_awaitResultThrowing_shouldCrashActorWhenFutureTimesOut", test_awaitResultThrowing_shouldCrashActorWhenFutureTimesOut),
             ("test_suspendedActor_shouldKeepProcessingSystemMessages", test_suspendedActor_shouldKeepProcessingSystemMessages),
             ("test_suspendedActor_shouldKeepProcessingSignals", test_suspendedActor_shouldKeepProcessingSignals),

--- a/Tests/DistributedActorsTests/Cluster/AssociationClusteredTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/AssociationClusteredTests.swift
@@ -75,8 +75,8 @@ final class ClusterAssociationTests: ClusteredNodesTestBase {
 
             first.cluster.join(node: second.cluster.node.node)
 
-            try assertAssociated(first, withExactly: second.cluster.node)
-            try assertAssociated(second, withExactly: first.cluster.node)
+            try assertAssociated(first, withExactly: second.cluster.node, verbose: true)
+            try assertAssociated(second, withExactly: first.cluster.node, verbose: true)
 
             let oldSecond = second
             let shutdown = oldSecond.shutdown() // kill remote node
@@ -94,8 +94,8 @@ final class ClusterAssociationTests: ClusteredNodesTestBase {
             secondReplacement.cluster.join(node: first.cluster.node.node)
 
             // verify we are associated ONLY with the appropriate nodes now;
-            try assertAssociated(first, withExactly: [secondReplacement.cluster.node])
-            try assertAssociated(secondReplacement, withExactly: [first.cluster.node])
+            try assertAssociated(first, withExactly: [secondReplacement.cluster.node], verbose: true)
+            try assertAssociated(secondReplacement, withExactly: [first.cluster.node], verbose: true)
         }
     }
 

--- a/Tests/DistributedActorsTests/Cluster/LeadershipTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Cluster/LeadershipTests+XCTest.swift
@@ -27,7 +27,7 @@ extension LeadershipTests {
             ("test_LowestReachableMember_notEnoughMembersToDecide", test_LowestReachableMember_notEnoughMembersToDecide),
             ("test_LowestReachableMember_notEnoughMembersToDecide_fromWithToWithoutLeader", test_LowestReachableMember_notEnoughMembersToDecide_fromWithToWithoutLeader),
             ("test_LowestReachableMember_whenCurrentLeaderDown", test_LowestReachableMember_whenCurrentLeaderDown),
-            ("test_LowestReachableMember_whenCurrentLeaderUnreachable_enoughMembers", test_LowestReachableMember_whenCurrentLeaderUnreachable_enoughMembers),
+            ("test_LowestReachableMember_whenCurrentLeaderDown_enoughMembers", test_LowestReachableMember_whenCurrentLeaderDown_enoughMembers),
             ("test_LowestReachableMember_whenCurrentLeaderUnreachable_notEnoughMinMembers", test_LowestReachableMember_whenCurrentLeaderUnreachable_notEnoughMinMembers),
             ("test_LowestReachableMember_keepLeader_notEnoughMembers_DO_NOT_loseLeadershipIfBelowMinNrOfMembers", test_LowestReachableMember_keepLeader_notEnoughMembers_DO_NOT_loseLeadershipIfBelowMinNrOfMembers),
             ("test_LowestReachableMember_keepLeader_notEnoughMembers_DO_loseLeadershipIfBelowMinNrOfMembers", test_LowestReachableMember_keepLeader_notEnoughMembers_DO_loseLeadershipIfBelowMinNrOfMembers),

--- a/Tests/DistributedActorsTests/Cluster/LeadershipTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/LeadershipTests.swift
@@ -34,7 +34,7 @@ final class LeadershipTests: XCTestCase {
     // MARK: LowestReachableMember
 
     func test_LowestReachableMember_selectLeader() throws {
-        var election = Leadership.LowestReachableMember(minimumNrOfMembers: 3)
+        var election = Leadership.LowestAddressMember(minimumNrOfMembers: 3)
 
         let membership = self.initialMembership
 
@@ -43,7 +43,7 @@ final class LeadershipTests: XCTestCase {
     }
 
     func test_LowestReachableMember_notEnoughMembersToDecide() throws {
-        var election = Leadership.LowestReachableMember(minimumNrOfMembers: 3)
+        var election = Leadership.LowestAddressMember(minimumNrOfMembers: 3)
 
         var membership = self.initialMembership
         _ = membership.remove(self.firstMember.node)
@@ -60,7 +60,7 @@ final class LeadershipTests: XCTestCase {
     }
 
     func test_LowestReachableMember_notEnoughMembersToDecide_fromWithToWithoutLeader() throws {
-        var election = Leadership.LowestReachableMember(minimumNrOfMembers: 3)
+        var election = Leadership.LowestAddressMember(minimumNrOfMembers: 3)
 
         var membership = self.initialMembership
         _ = try! membership.applyLeadershipChange(to: self.firstMember) // try! because `firstMember` is a member
@@ -78,7 +78,7 @@ final class LeadershipTests: XCTestCase {
     }
 
     func test_LowestReachableMember_whenCurrentLeaderDown() throws {
-        var election = Leadership.LowestReachableMember(minimumNrOfMembers: 3)
+        var election = Leadership.LowestAddressMember(minimumNrOfMembers: 3)
 
         var membership = self.initialMembership
         _ = membership.join(self.newMember.node)
@@ -91,8 +91,8 @@ final class LeadershipTests: XCTestCase {
             .shouldEqual(LeadershipChange(oldLeader: nil, newLeader: self.secondMember))
     }
 
-    func test_LowestReachableMember_whenCurrentLeaderUnreachable_enoughMembers() throws {
-        var election = Leadership.LowestReachableMember(minimumNrOfMembers: 3)
+    func test_LowestReachableMember_whenCurrentLeaderDown_enoughMembers() throws {
+        var election = Leadership.LowestAddressMember(minimumNrOfMembers: 3)
 
         var membership = self.initialMembership
         _ = membership.join(self.newMember.node)
@@ -100,13 +100,13 @@ final class LeadershipTests: XCTestCase {
         (try election.runElection(context: self.fakeContext, membership: membership).future.wait())
             .shouldEqual(LeadershipChange(oldLeader: nil, newLeader: self.firstMember))
 
-        _ = membership.mark(self.firstMember.node, reachability: .unreachable)
+        _ = membership.mark(self.firstMember.node, as: .down)
         (try election.runElection(context: self.fakeContext, membership: membership).future.wait())
             .shouldEqual(LeadershipChange(oldLeader: nil, newLeader: self.secondMember))
     }
 
     func test_LowestReachableMember_whenCurrentLeaderUnreachable_notEnoughMinMembers() throws {
-        var election = Leadership.LowestReachableMember(minimumNrOfMembers: 3)
+        var election = Leadership.LowestAddressMember(minimumNrOfMembers: 3)
 
         var membership = self.initialMembership
         let applyToMembership: (LeadershipChange?) throws -> (LeadershipChange?) = { change in
@@ -134,7 +134,7 @@ final class LeadershipTests: XCTestCase {
         // - third leaves
         // - second leaves
         // ! no need to drop the leadership from the first node, it shall remain the leader;
-        var election = Leadership.LowestReachableMember(minimumNrOfMembers: 3) // loseLeadershipIfBelowMinNrOfMembers: false by default
+        var election = Leadership.LowestAddressMember(minimumNrOfMembers: 3) // loseLeadershipIfBelowMinNrOfMembers: false by default
 
         var membership: Membership = self.initialMembership
         let applyToMembership: (LeadershipChange?) throws -> (LeadershipChange?) = { change in
@@ -170,7 +170,7 @@ final class LeadershipTests: XCTestCase {
         // - first becomes leader
         // - third leaves
         // ! not enough members to sustain leader, it should not be trusted anymore
-        var election = Leadership.LowestReachableMember(minimumNrOfMembers: 3, loseLeadershipIfBelowMinNrOfMembers: true)
+        var election = Leadership.LowestAddressMember(minimumNrOfMembers: 3, loseLeadershipIfBelowMinNrOfMembers: true)
 
         var membership: Membership = self.initialMembership
         let applyToMembership: (LeadershipChange?) throws -> (LeadershipChange?) = { change in

--- a/Tests/DistributedActorsTests/SupervisionTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/SupervisionTests+XCTest.swift
@@ -24,9 +24,11 @@ extension SupervisionTests {
     static var allTests: [(String, (SupervisionTests) -> () throws -> Void)] {
         return [
             ("test_stopSupervised_throws_shouldStop", test_stopSupervised_throws_shouldStop),
+            ("test_stopSupervised_throwsInAwaitResult_shouldStop", test_stopSupervised_throwsInAwaitResult_shouldStop),
             ("test_restartSupervised_throws_shouldRestart", test_restartSupervised_throws_shouldRestart),
             ("test_restartAtMostWithin_throws_shouldRestartNoMoreThanAllowedWithinPeriod", test_restartAtMostWithin_throws_shouldRestartNoMoreThanAllowedWithinPeriod),
             ("test_restartSupervised_throws_shouldRestart_andCreateNewInstanceOfClassBehavior", test_restartSupervised_throws_shouldRestart_andCreateNewInstanceOfClassBehavior),
+            ("test_restartSupervised_throwsInAwaitResult_shouldRestart", test_restartSupervised_throwsInAwaitResult_shouldRestart),
             ("test_escalateSupervised_throws_shouldKeepEscalatingThrough_watchingParents", test_escalateSupervised_throws_shouldKeepEscalatingThrough_watchingParents),
             ("test_escalateSupervised_throws_shouldKeepEscalatingThrough_nonWatchingParents", test_escalateSupervised_throws_shouldKeepEscalatingThrough_nonWatchingParents),
             ("test_escalateSupervised_throws_shouldKeepEscalatingUntilNonEscalatingParent", test_escalateSupervised_throws_shouldKeepEscalatingUntilNonEscalatingParent),


### PR DESCRIPTION
### Motivation:

Supervision did not trigger properly with failures in suspend/resume dances -- specifically in `context.awaitResult` on a failed future it would not escalate the failure.

We currently set the supervision of the /system/cluster to be .escalate
which is great as it can escalate to /system and there it will trigger a
termination of the actor system. E.g. one case where we want to do this
is when we fail to bind() -- which should have been happening but wasnt,
and was uncovered during #336.

With this change, the failure of bind() properly escalates to the
guardian, and the system then terminates itself.

The issue was that some of the handling is copy-pasted (yea...) into a
few places rather than be shared in one place. So some messages, like
system and normal ones are supervised correctly, but the .resume is
"special" and was not handled properly.

This PR also cleans up how much code is duplicated for this handling.

### Modifications:

- ensure that we always do the correct "dance" 💃 🕺  after performing an supervised interpretation in the Actor shell.
- add more tests
- reduce duplication of this code in the Shell

### Result:

- working supervision for `awaitResult`