### PR TITLE
!act #186 Rename .perpetual actor types to .wellKnown, as it suits them more

### DIFF
--- a/Sources/ActorSingletonPlugin/ActorSingleton.swift
+++ b/Sources/ActorSingletonPlugin/ActorSingleton.swift
@@ -59,7 +59,7 @@ public final class ActorSingleton<Message> {
         self.proxy = try system._spawnSystemActor(
             "singletonProxy-\(self.settings.name)",
             ActorSingletonProxy(settings: self.settings, allocationStrategy: allocationStrategy, props: self.props, self.behavior).behavior,
-            perpetual: true
+            wellKnown: true
         )
     }
 }

--- a/Sources/ActorSingletonPlugin/ActorSingletonManager.swift
+++ b/Sources/ActorSingletonPlugin/ActorSingletonManager.swift
@@ -100,11 +100,11 @@ extension ActorSingletonManager {
 
 extension ActorAddress {
     internal static func _singletonManager(name: String, on node: UniqueNode) -> ActorAddress {
-        .init(node: node, path: ._singletonManager(name: name), incarnation: .perpetual)
+        .init(node: node, path: ._singletonManager(name: name), incarnation: .wellKnown)
     }
 
     internal static func _singletonManager(name: String) -> ActorAddress {
-        .init(path: ._singletonManager(name: name), incarnation: .perpetual)
+        .init(path: ._singletonManager(name: name), incarnation: .wellKnown)
     }
 }
 

--- a/Sources/ActorSingletonPlugin/ActorSingletonProxy.swift
+++ b/Sources/ActorSingletonPlugin/ActorSingletonProxy.swift
@@ -124,7 +124,7 @@ internal class ActorSingletonProxy<Message> {
         self.managerRef = try context.system._spawnSystemActor(
             "singletonManager-\(self.settings.name)",
             ActorSingletonManager(settings: self.settings, props: self.singletonProps, self.singletonBehavior).behavior,
-            perpetual: true
+            wellKnown: true
         )
         // Need the manager to tell us the ref because we can't resolve it due to random incarnation
         let refSubReceive = context.subReceive(SubReceiveId(id: "ref-\(context.name)"), ActorRef<Message>?.self) {
@@ -221,7 +221,7 @@ extension ActorSingletonProxy {
 
 extension ActorAddress {
     internal static func _singletonProxy(name: String, on node: UniqueNode) -> ActorAddress {
-        .init(node: node, path: ._singletonProxy(name: name), incarnation: .perpetual)
+        .init(node: node, path: ._singletonProxy(name: name), incarnation: .wellKnown)
     }
 }
 

--- a/Sources/DistributedActors/ActorAddress.swift
+++ b/Sources/DistributedActors/ActorAddress.swift
@@ -129,7 +129,7 @@ extension ActorAddress: CustomStringConvertible, CustomDebugStringConvertible {
 
         res += "\(self.path)"
 
-        if self.incarnation == ActorIncarnation.perpetual {
+        if self.incarnation == ActorIncarnation.wellKnown {
             return res
         } else {
             return "\(res)#\(self.incarnation.value)"
@@ -140,16 +140,16 @@ extension ActorAddress: CustomStringConvertible, CustomDebugStringConvertible {
 extension ActorAddress {
     /// Local root (also known as: "/") actor address.
     /// Only to be used by the "/" root "actor"
-    internal static let _localRoot: ActorAddress = ActorPath._root.makeLocalAddress(incarnation: .perpetual)
-    internal static let _deadLetters: ActorAddress = ActorPath._deadLetters.makeLocalAddress(incarnation: .perpetual)
+    internal static let _localRoot: ActorAddress = ActorPath._root.makeLocalAddress(incarnation: .wellKnown)
+    internal static let _deadLetters: ActorAddress = ActorPath._deadLetters.makeLocalAddress(incarnation: .wellKnown)
 
-    internal static let _cluster: ActorAddress = ActorPath._cluster.makeLocalAddress(incarnation: .perpetual)
+    internal static let _cluster: ActorAddress = ActorPath._cluster.makeLocalAddress(incarnation: .wellKnown)
     internal static func _cluster(on node: UniqueNode? = nil) -> ActorAddress {
         switch node {
         case .none:
             return ._cluster
         case .some(let node):
-            return ActorPath._cluster.makeRemoteAddress(on: node, incarnation: .perpetual)
+            return ActorPath._cluster.makeRemoteAddress(on: node, incarnation: .wellKnown)
         }
     }
 }
@@ -507,9 +507,9 @@ public struct ActorIncarnation: Equatable, Hashable, ExpressibleByIntegerLiteral
 }
 
 public extension ActorIncarnation {
-    /// To be used ONLY by special actors whose existence is perpetual and identity never-changing.
+    /// To be used ONLY by special actors whose existence is wellKnown and identity never-changing.
     /// Examples: `/system/deadLetters` or `/system/cluster`.
-    static let perpetual: ActorIncarnation = ActorIncarnation(0)
+    static let wellKnown: ActorIncarnation = ActorIncarnation(0)
 
     static func random() -> ActorIncarnation {
         return ActorIncarnation(UInt32.random(in: UInt32(1) ... UInt32.max))

--- a/Sources/DistributedActors/ActorShell+Children.swift
+++ b/Sources/DistributedActors/ActorShell+Children.swift
@@ -315,14 +315,13 @@ extension Children {
 
 // TODO: Trying this style rather than the style done with DeathWatch to extend cell's capabilities
 extension ActorShell: ChildActorRefFactory {
-    // TODO: Maybe go back to "wellKnown" rather than perpetual, reads better to be honest and more true, since these do not have to live forever, they can come and go, but are "well known"
-    internal func _spawn<M>(_ naming: ActorNaming, props: Props, _ behavior: Behavior<M>, perpetual: Bool = false) throws -> ActorRef<M> {
+    internal func _spawn<M>(_ naming: ActorNaming, props: Props, _ behavior: Behavior<M>, wellKnown: Bool = false) throws -> ActorRef<M> {
         let name = naming.makeName(&self.namingContext)
 
         try behavior.validateAsInitial()
         try self.validateUniqueName(name) // FIXME: reserve name
 
-        let incarnation: ActorIncarnation = perpetual ? .perpetual : .random()
+        let incarnation: ActorIncarnation = wellKnown ? .wellKnown : .random()
         let address: ActorAddress = try self.address.makeChildAddress(name: name, incarnation: incarnation)
 
         let dispatcher: MessageDispatcher
@@ -394,7 +393,7 @@ public enum ActorContextError: Error {
     case attemptedStoppingMyselfUsingContext(ref: AddressableActorRef)
     /// Only the parent actor is allowed to stop its children. This is to avoid mistakes in which one part of the system
     /// can stop arbitrary actors of another part of the system which was programmed under the assumption such actor would
-    /// perpetually exist.
+    /// wellKnownly exist.
     case attemptedStoppingNonChildActor(ref: AddressableActorRef)
     /// It is not allowed to spawn
     case duplicateActorPath(path: ActorPath)

--- a/Sources/DistributedActors/ActorShell.swift
+++ b/Sources/DistributedActors/ActorShell.swift
@@ -639,7 +639,7 @@ public final class ActorShell<Message>: ActorContext<Message>, AbstractActor {
     // MARK: Spawn implementations
 
     public override func spawn<Message>(_ naming: ActorNaming, of type: Message.Type = Message.self, props: Props = Props(), _ behavior: Behavior<Message>) throws -> ActorRef<Message> {
-        return try self._spawn(naming, props: props, behavior, perpetual: false)
+        return try self._spawn(naming, props: props, behavior, wellKnown: false)
     }
 
     public override func spawnWatch<Message>(_ naming: ActorNaming, of type: Message.Type = Message.self, props: Props, _ behavior: Behavior<Message>) throws -> ActorRef<Message> {
@@ -745,7 +745,7 @@ public final class ActorShell<Message>: ActorContext<Message>, AbstractActor {
             self.messageAdapters.insert(MessageAdapterClosure(metaType: metaType, closure: anyAdapter), at: self.messageAdapters.startIndex)
 
             guard let adapterRef = self.messageAdapterRef else {
-                let adaptedAddress = try self.address.makeChildAddress(name: ActorNaming.adapter.makeName(&self.namingContext), incarnation: .perpetual)
+                let adaptedAddress = try self.address.makeChildAddress(name: ActorNaming.adapter.makeName(&self.namingContext), incarnation: .wellKnown)
                 let ref = ActorRefAdapter(self.myself, address: adaptedAddress)
                 self.messageAdapterRef = ref
 

--- a/Sources/DistributedActors/CRDT/CRDTReplicatorShell.swift
+++ b/Sources/DistributedActors/CRDT/CRDTReplicatorShell.swift
@@ -657,7 +657,7 @@ extension CRDT.Replicator.Shell {
 
 extension ActorAddress {
     internal static func _crdtReplicator(on node: UniqueNode) -> ActorAddress {
-        return .init(node: node, path: ._crdtReplicator, incarnation: .perpetual)
+        return .init(node: node, path: ._crdtReplicator, incarnation: .wellKnown)
     }
 }
 

--- a/Sources/DistributedActors/Cluster/ClusterReceptionist.swift
+++ b/Sources/DistributedActors/Cluster/ClusterReceptionist.swift
@@ -249,6 +249,6 @@ internal enum ClusterReceptionist {
     }
 
     private static func makeRemoteAddress(on node: UniqueNode) -> ActorAddress {
-        return try! .init(node: node, path: ActorPath([ActorPathSegment("system"), ActorPathSegment("receptionist")]), incarnation: .perpetual)
+        return try! .init(node: node, path: ActorPath([ActorPathSegment("system"), ActorPathSegment("receptionist")]), incarnation: .wellKnown)
     }
 }

--- a/Sources/DistributedActors/Cluster/ClusterShell.swift
+++ b/Sources/DistributedActors/Cluster/ClusterShell.swift
@@ -144,7 +144,7 @@ internal class ClusterShell {
             ClusterShell.naming,
             self.bind(),
             props: self.props,
-            perpetual: true
+            wellKnown: true
         )
 
         self._ref = delayed.ref
@@ -235,7 +235,7 @@ extension ClusterShell {
 
             // SWIM failure detector and gossiping
             let swimBehavior = SWIMShell(settings: clusterSettings.swim, clusterRef: context.myself).behavior
-            self._swimRef = try context._downcastUnsafe._spawn(SWIMShell.naming, props: Props(), swimBehavior, perpetual: true)
+            self._swimRef = try context._downcastUnsafe._spawn(SWIMShell.naming, props: Props(), swimBehavior, wellKnown: true)
 
             // automatic leader for .joining -> .up
             if let leaderElection = context.system.settings.cluster.autoLeaderElection.make(context.system.cluster.settings) {

--- a/Sources/DistributedActors/Cluster/SWIM/SWIMShell.swift
+++ b/Sources/DistributedActors/Cluster/SWIM/SWIMShell.swift
@@ -455,7 +455,7 @@ extension SWIMShell {
 
 extension ActorAddress {
     internal static func _swim(on node: UniqueNode) -> ActorAddress {
-        return .init(node: node, path: ActorPath._swim, incarnation: .perpetual)
+        return .init(node: node, path: ActorPath._swim, incarnation: .wellKnown)
     }
 }
 

--- a/Sources/DistributedActors/ProcessIsolated/ProcessCommander.swift
+++ b/Sources/DistributedActors/ProcessIsolated/ProcessCommander.swift
@@ -86,7 +86,7 @@ internal struct ProcessCommander {
 
 extension ActorAddress {
     static func ofProcessMaster(on node: UniqueNode) -> ActorAddress {
-        return try! .init(node: node, path: ActorPath._system.appending(ProcessCommander.name), incarnation: .perpetual)
+        return try! .init(node: node, path: ActorPath._system.appending(ProcessCommander.name), incarnation: .wellKnown)
     }
 }
 #endif

--- a/Sources/DistributedActors/ProcessIsolated/ProcessIsolated.swift
+++ b/Sources/DistributedActors/ProcessIsolated/ProcessIsolated.swift
@@ -127,7 +127,7 @@ public class ProcessIsolated {
                 funRespawnServantProcess: funRespawnServantProcess,
                 funKillServantProcess: funKillServantProcess
             )
-            self.processCommander = try! system._spawnSystemActor(ProcessCommander.naming, processCommander.behavior, perpetual: true)
+            self.processCommander = try! system._spawnSystemActor(ProcessCommander.naming, processCommander.behavior, wellKnown: true)
         } else {
             // on servant node
             guard let joinNodeString = KnownServantParameters.masterNode.extractFirst(arguments) else {

--- a/Sources/DistributedActors/Refs.swift
+++ b/Sources/DistributedActors/Refs.swift
@@ -464,7 +464,7 @@ public class Guardian {
         assert(parent.address == ActorAddress._localRoot, "A Guardian MUST live directly under the `/` path.")
 
         do {
-            self._address = try ActorPath(root: name).makeLocalAddress(incarnation: .perpetual)
+            self._address = try ActorPath(root: name).makeLocalAddress(incarnation: .wellKnown)
         } catch {
             fatalError("Illegal Guardian path, as those are only to be created by ActorSystem startup, considering this fatal.")
         }

--- a/Sources/DistributedActorsBenchmarks/ActorBenchmarkTools.swift
+++ b/Sources/DistributedActorsBenchmarks/ActorBenchmarkTools.swift
@@ -38,7 +38,7 @@ internal class BenchmarkLatchGuardian<Message>: Guardian { // This is an ugly ha
     override var address: ActorAddress {
         var fakePath: ActorPath = ._root
         try! fakePath.append(segment: .init("benchmarkLatch"))
-        return ActorAddress(path: fakePath, incarnation: .perpetual)
+        return ActorAddress(path: fakePath, incarnation: .wellKnown)
     }
 
     func blockUntilMessageReceived() -> Message {

--- a/Sources/DistributedActorsXPC/ActorCell/XPCServiceCellDelegate.swift
+++ b/Sources/DistributedActorsXPC/ActorCell/XPCServiceCellDelegate.swift
@@ -43,7 +43,7 @@ internal final class XPCServiceCellDelegate<Message>: CellDelegate<Message> {
         try! self.init(
             system: system, address: .init(
                 node: UniqueNode(protocol: "xpc", systemName: "", host: "localhost", port: 1, nid: NodeID(1)),
-                path: try! ActorPath(root: "xpc").appending(serviceName), incarnation: .perpetual
+                path: try! ActorPath(root: "xpc").appending(serviceName), incarnation: .wellKnown
             )
         )
     }

--- a/Sources/DistributedActorsXPC/Transport/XPCActorTransport.swift
+++ b/Sources/DistributedActorsXPC/Transport/XPCActorTransport.swift
@@ -48,7 +48,7 @@ public final class XPCActorTransport: ActorTransport {
 
     public override func onActorSystemStart(system: ActorSystem) {
         self.lock.synchronized {
-            self._master = try! system._spawnSystemActor("xpc", XPCMaster().behavior, perpetual: true)
+            self._master = try! system._spawnSystemActor("xpc", XPCMaster().behavior, wellKnown: true)
             self.system = system
         }
     }
@@ -143,7 +143,7 @@ extension XPCActorTransport: XPCControl {
         let targetAddress: ActorAddress = try ActorAddress(
             node: fakeNode,
             path: ActorPath([ActorPathSegment("xpc"), ActorPathSegment(serviceName)]),
-            incarnation: .perpetual
+            incarnation: .wellKnown
         )
 
         // TODO: passing such ref over the network would fail; where should we prevent this?

--- a/Tests/DistributedActorsTests/ActorAddressTests.swift
+++ b/Tests/DistributedActorsTests/ActorAddressTests.swift
@@ -152,9 +152,9 @@ final class ActorAddressTests: XCTestCase {
 
     func test_sortingOf_sameNode_ActorAddresses() throws {
         var addresses: [ActorAddress] = []
-        let a: ActorAddress = try ActorPath._user.appending("a").makeLocalAddress(incarnation: .perpetual)
-        let b: ActorAddress = try ActorPath._user.appending("b").makeLocalAddress(incarnation: .perpetual)
-        let c: ActorAddress = try ActorPath._user.appending("c").makeLocalAddress(incarnation: .perpetual)
+        let a: ActorAddress = try ActorPath._user.appending("a").makeLocalAddress(incarnation: .wellKnown)
+        let b: ActorAddress = try ActorPath._user.appending("b").makeLocalAddress(incarnation: .wellKnown)
+        let c: ActorAddress = try ActorPath._user.appending("c").makeLocalAddress(incarnation: .wellKnown)
         addresses.append(c)
         addresses.append(b)
         addresses.append(a)

--- a/Tests/DistributedActorsTests/CRDT/CRDTAnyTypesTests.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTAnyTypesTests.swift
@@ -17,8 +17,8 @@ import DistributedActorsTestKit
 import XCTest
 
 final class CRDTAnyTypesTests: XCTestCase {
-    let replicaA: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("a"), incarnation: .perpetual))
-    let replicaB: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("b"), incarnation: .perpetual))
+    let replicaA: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("a"), incarnation: .wellKnown))
+    let replicaB: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("b"), incarnation: .wellKnown))
 
     // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: AnyCvRDT tests

--- a/Tests/DistributedActorsTests/CRDT/CRDTGCounterTests.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTGCounterTests.swift
@@ -17,8 +17,8 @@ import DistributedActorsTestKit
 import XCTest
 
 final class CRDTGCounterTests: XCTestCase {
-    let replicaA: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("a"), incarnation: .perpetual))
-    let replicaB: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("b"), incarnation: .perpetual))
+    let replicaA: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("a"), incarnation: .wellKnown))
+    let replicaB: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("b"), incarnation: .wellKnown))
 
     func test_GCounter_increment_shouldUpdateDelta() throws {
         var g1 = CRDT.GCounter(replicaId: self.replicaA)

--- a/Tests/DistributedActorsTests/CRDT/CRDTLWWMapTests.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTLWWMapTests.swift
@@ -17,8 +17,8 @@ import DistributedActorsTestKit
 import XCTest
 
 final class CRDTLWWMapTests: XCTestCase {
-    let replicaA: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("a"), incarnation: .perpetual))
-    let replicaB: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("b"), incarnation: .perpetual))
+    let replicaA: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("a"), incarnation: .wellKnown))
+    let replicaB: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("b"), incarnation: .wellKnown))
 
     func test_LWWMap_basicOperations() throws {
         var m1 = CRDT.LWWMap<String, Int>(replicaId: self.replicaA, defaultValue: 0)

--- a/Tests/DistributedActorsTests/CRDT/CRDTLWWRegisterTests.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTLWWRegisterTests.swift
@@ -17,8 +17,8 @@ import DistributedActorsTestKit
 import XCTest
 
 final class CRDTLWWRegisterTests: XCTestCase {
-    let replicaA: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("a"), incarnation: .perpetual))
-    let replicaB: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("b"), incarnation: .perpetual))
+    let replicaA: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("a"), incarnation: .wellKnown))
+    let replicaB: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("b"), incarnation: .wellKnown))
 
     func test_LWWRegister_assign_shouldSetValueAndTimestamp() throws {
         var r1 = CRDT.LWWRegister<Int>(replicaId: self.replicaA, initialValue: 3)

--- a/Tests/DistributedActorsTests/CRDT/CRDTORMapTests.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTORMapTests.swift
@@ -17,8 +17,8 @@ import DistributedActorsTestKit
 import XCTest
 
 final class CRDTORMapTests: XCTestCase {
-    let replicaA: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("a"), incarnation: .perpetual))
-    let replicaB: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("b"), incarnation: .perpetual))
+    let replicaA: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("a"), incarnation: .wellKnown))
+    let replicaB: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("b"), incarnation: .wellKnown))
 
     // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: ORMap + GCounter tests

--- a/Tests/DistributedActorsTests/CRDT/CRDTORSetTests.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTORSetTests.swift
@@ -17,8 +17,8 @@ import DistributedActorsTestKit
 import XCTest
 
 final class CRDTORSetTests: XCTestCase {
-    let replicaA: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("a"), incarnation: .perpetual))
-    let replicaB: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("b"), incarnation: .perpetual))
+    let replicaA: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("a"), incarnation: .wellKnown))
+    let replicaB: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("b"), incarnation: .wellKnown))
 
     func test_ORSet_basicOperations() throws {
         var s1 = CRDT.ORSet<Int>(replicaId: self.replicaA)

--- a/Tests/DistributedActorsTests/CRDT/CRDTReplicatorInstanceTests.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTReplicatorInstanceTests.swift
@@ -29,8 +29,8 @@ final class CRDTReplicatorInstanceTests: XCTestCase {
         self.system.shutdown().wait()
     }
 
-    let replicaA: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("a"), incarnation: .perpetual))
-    let replicaB: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("b"), incarnation: .perpetual))
+    let replicaA: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("a"), incarnation: .wellKnown))
+    let replicaB: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("b"), incarnation: .wellKnown))
 
     func test_registerOwner_shouldAddActorRefToOwnersSetForCRDT() throws {
         let replicator = CRDT.Replicator.Instance(.default)

--- a/Tests/DistributedActorsTests/CRDT/CRDTReplicatorShellTests.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTReplicatorShellTests.swift
@@ -35,8 +35,8 @@ final class CRDTReplicatorShellTests: ClusteredNodesTestBase {
         self.remoteTestKit = super.testKit(self.remoteSystem)
     }
 
-    let ownerAlpha = try! ActorAddress(path: ActorPath._user.appending("alpha"), incarnation: .perpetual)
-    let ownerBeta = try! ActorAddress(path: ActorPath._user.appending("beta"), incarnation: .perpetual)
+    let ownerAlpha = try! ActorAddress(path: ActorPath._user.appending("alpha"), incarnation: .wellKnown)
+    let ownerBeta = try! ActorAddress(path: ActorPath._user.appending("beta"), incarnation: .wellKnown)
 
     let timeout = TimeAmount.seconds(1)
 

--- a/Tests/DistributedActorsTests/CRDT/CRDTVersioningTests.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTVersioningTests.swift
@@ -17,9 +17,9 @@ import DistributedActorsTestKit
 import XCTest
 
 final class CRDTVersioningTests: XCTestCase {
-    let replicaA: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("a"), incarnation: .perpetual))
-    let replicaB: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("b"), incarnation: .perpetual))
-    let replicaC: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("c"), incarnation: .perpetual))
+    let replicaA: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("a"), incarnation: .wellKnown))
+    let replicaB: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("b"), incarnation: .wellKnown))
+    let replicaC: ReplicaId = .actorAddress(try! ActorAddress(path: ActorPath._user.appending("c"), incarnation: .wellKnown))
 
     private typealias IntContainer = CRDT.VersionedContainer<Int>
 

--- a/Tests/DistributedActorsTests/CRDT/Protobuf/CRDT+SerializationTests.swift
+++ b/Tests/DistributedActorsTests/CRDT/Protobuf/CRDT+SerializationTests.swift
@@ -36,8 +36,8 @@ final class CRDTSerializationTests: XCTestCase {
         self.system.shutdown().wait()
     }
 
-    let ownerAlpha = try! ActorAddress(path: ActorPath._user.appending("alpha"), incarnation: .perpetual)
-    let ownerBeta = try! ActorAddress(path: ActorPath._user.appending("beta"), incarnation: .perpetual)
+    let ownerAlpha = try! ActorAddress(path: ActorPath._user.appending("alpha"), incarnation: .wellKnown)
+    let ownerBeta = try! ActorAddress(path: ActorPath._user.appending("beta"), incarnation: .wellKnown)
 
     // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: CRDT.Identity

--- a/Tests/DistributedActorsTests/CRDT/Protobuf/CRDTEnvelope+SerializationTests.swift
+++ b/Tests/DistributedActorsTests/CRDT/Protobuf/CRDTEnvelope+SerializationTests.swift
@@ -29,7 +29,7 @@ final class CRDTEnvelopeSerializationTests: XCTestCase {
         self.system.shutdown().wait()
     }
 
-    let ownerAlpha = try! ActorAddress(path: ActorPath._user.appending("alpha"), incarnation: .perpetual)
+    let ownerAlpha = try! ActorAddress(path: ActorPath._user.appending("alpha"), incarnation: .wellKnown)
 
     func test_serializationOf_CRDTEnvelope_AnyDeltaCRDT_GCounter() throws {
         try shouldNotThrow {

--- a/Tests/DistributedActorsTests/CRDT/Protobuf/CRDTReplication+SerializationTests.swift
+++ b/Tests/DistributedActorsTests/CRDT/Protobuf/CRDTReplication+SerializationTests.swift
@@ -31,8 +31,8 @@ final class CRDTReplicationSerializationTests: XCTestCase {
         self.system.shutdown().wait()
     }
 
-    let ownerAlpha = try! ActorAddress(path: ActorPath._user.appending("alpha"), incarnation: .perpetual)
-    let ownerBeta = try! ActorAddress(path: ActorPath._user.appending("beta"), incarnation: .perpetual)
+    let ownerAlpha = try! ActorAddress(path: ActorPath._user.appending("alpha"), incarnation: .wellKnown)
+    let ownerBeta = try! ActorAddress(path: ActorPath._user.appending("beta"), incarnation: .wellKnown)
 
     typealias WriteResult = CRDT.Replicator.RemoteCommand.WriteResult
     typealias ReadResult = CRDT.Replicator.RemoteCommand.ReadResult

--- a/Tests/DistributedActorsTests/Clocks/Protobuf/VersionVector+SerializationTests.swift
+++ b/Tests/DistributedActorsTests/Clocks/Protobuf/VersionVector+SerializationTests.swift
@@ -33,8 +33,8 @@ final class VersionVectorSerializationTests: XCTestCase {
         self.system.shutdown().wait()
     }
 
-    let actorA = try! ActorAddress(path: ActorPath._user.appending("A"), incarnation: .perpetual)
-    let actorB = try! ActorAddress(path: ActorPath._user.appending("B"), incarnation: .perpetual)
+    let actorA = try! ActorAddress(path: ActorPath._user.appending("A"), incarnation: .wellKnown)
+    let actorB = try! ActorAddress(path: ActorPath._user.appending("B"), incarnation: .wellKnown)
 
     // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: ReplicaId

--- a/Tests/DistributedActorsTests/Cluster/ProtobufRoundTripTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/ProtobufRoundTripTests.swift
@@ -30,7 +30,7 @@ final class ProtobufRoundTripTests: XCTestCase {
     let node = UniqueNode(node: Node(systemName: "system", host: "127.0.0.1", port: 8888), nid: .random())
     let otherNode = UniqueNode(node: Node(systemName: "system", host: "888.0.0.1", port: 9999), nid: .random())
 
-    let localActorAddress = try! ActorPath._user.appending("hello").makeLocalAddress(incarnation: .perpetual)
+    let localActorAddress = try! ActorPath._user.appending("hello").makeLocalAddress(incarnation: .wellKnown)
 
     // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: Core actor types

--- a/Tests/DistributedActorsTests/Cluster/RemoteActorRefProviderTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/RemoteActorRefProviderTests.swift
@@ -103,7 +103,7 @@ class RemoteActorRefProviderTests: XCTestCase {
 
     func test_remoteActorRefProvider_shouldResolveRemoteAlreadyDeadRef_forTypeMismatchOfActorAndResolveContext() throws {
         let unknownNode = UniqueNode(node: .init(systemName: "something", host: "1.1.1.1", port: 1111), nid: NodeID(1211))
-        let address: ActorAddress = try .init(node: unknownNode, path: ActorPath._dead.appending("already"), incarnation: .perpetual)
+        let address: ActorAddress = try .init(node: unknownNode, path: ActorPath._dead.appending("already"), incarnation: .wellKnown)
 
         let resolveContext = ResolveContext<DeadLetter>(address: address, system: system)
         let resolvedRef = self.system._resolve(context: resolveContext)

--- a/Tests/DistributedActorsTests/ProtoEnvelopeTests.swift
+++ b/Tests/DistributedActorsTests/ProtoEnvelopeTests.swift
@@ -22,7 +22,7 @@ class ProtoEnvelopeTests: XCTestCase {
     func test_init_ProtoEnvelopeZeroCopy() throws {
         var proto = ProtoEnvelope()
         proto.payload = Data([1, 2, 3])
-        proto.recipient = ProtoActorAddress(ActorAddress(path: ._user, incarnation: .perpetual))
+        proto.recipient = ProtoActorAddress(ActorAddress(path: ._user, incarnation: .wellKnown))
         proto.serializerID = 5
         let allocator = ByteBufferAllocator()
 


### PR DESCRIPTION
Long discussion in the ticket.

This is not really a public facing API either, but let's rename earlier rather than later.

Resolves https://github.com/apple/swift-distributed-actors/issues/186