### PR TITLE
Split ActorSingletonPluginTests

### DIFF
--- a/Tests/ActorSingletonPluginTests/ActorSingletonPluginTests+XCTest.swift
+++ b/Tests/ActorSingletonPluginTests/ActorSingletonPluginTests+XCTest.swift
@@ -25,6 +25,8 @@ extension ActorSingletonPluginTests {
         return [
             ("test_nonCluster", test_nonCluster),
             ("test_singletonByClusterLeadership", test_singletonByClusterLeadership),
+            ("test_singletonByClusterLeadership_stashMessagesIfNoLeader", test_singletonByClusterLeadership_stashMessagesIfNoLeader),
+            ("test_singletonByClusterLeadership_withLeaderChange", test_singletonByClusterLeadership_withLeaderChange),
         ]
     }
 }

--- a/Tests/ActorSingletonPluginTests/ActorSingletonPluginTests.swift
+++ b/Tests/ActorSingletonPluginTests/ActorSingletonPluginTests.swift
@@ -39,13 +39,127 @@ final class ActorSingletonPluginTests: ClusteredNodesTestBase {
         // singleton.actor
         let actor = try system.singleton.actor(name: "\(GreeterSingleton.name)-other", GreeterSingleton.self)
         // TODO: https://github.com/apple/swift-distributed-actors/issues/344
-        //         let string = try probe.expectReply(actor.greet(name: "Charlie", _replyTo: replyProbe.ref))
+        // let string = try probe.expectReply(actor.greet(name: "Charlie", _replyTo: replyProbe.ref))
         actor.ref.tell(.greet(name: "Charlie", _replyTo: replyProbe.ref))
 
         try replyProbe.expectMessage("Hi Charlie!")
     }
 
     func test_singletonByClusterLeadership() throws {
+        try shouldNotThrow {
+            var singletonSettings = ActorSingletonSettings(name: GreeterSingleton.name)
+            singletonSettings.allocationStrategy = .leadership
+
+            let first = self.setUpNode("first") { settings in
+                settings.cluster.node.port = 7111
+                settings.cluster.autoLeaderElection = .lowestAddress(minNumberOfMembers: 3)
+
+                settings += ActorSingleton(settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-1")))
+
+                settings.serialization.registerCodable(for: GreeterSingleton.Message.self, underId: 10001)
+            }
+            let second = self.setUpNode("second") { settings in
+                settings.cluster.node.port = 8222
+                settings.cluster.autoLeaderElection = .lowestAddress(minNumberOfMembers: 3)
+
+                settings += ActorSingleton(settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-2")))
+
+                settings.serialization.registerCodable(for: GreeterSingleton.Message.self, underId: 10001)
+            }
+            let third = self.setUpNode("third") { settings in
+                settings.cluster.node.port = 9333
+                settings.cluster.autoLeaderElection = .lowestAddress(minNumberOfMembers: 3)
+
+                settings += ActorSingleton(settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-3")))
+
+                settings.serialization.registerCodable(for: GreeterSingleton.Message.self, underId: 10001)
+            }
+
+            first.cluster.join(node: second.cluster.node.node)
+            third.cluster.join(node: second.cluster.node.node)
+
+            // `first` will be the leader (lowest address) and runs the singleton
+            try self.ensureNodes(.up, within: .seconds(10), systems: first, second, third)
+
+            let replyProbe1 = self.testKit(first).spawnTestProbe(expecting: String.self)
+            let ref1 = try first.singleton.ref(name: GreeterSingleton.name, of: GreeterSingleton.Message.self)
+            ref1.tell(.greet(name: "Charlie", _replyTo: replyProbe1.ref))
+
+            let replyProbe2 = self.testKit(second).spawnTestProbe(expecting: String.self)
+            let ref2 = try second.singleton.ref(name: GreeterSingleton.name, of: GreeterSingleton.Message.self)
+            ref2.tell(.greet(name: "Charlie", _replyTo: replyProbe2.ref))
+
+            let replyProbe3 = self.testKit(third).spawnTestProbe(expecting: String.self)
+            let ref3 = try third.singleton.ref(name: GreeterSingleton.name, of: GreeterSingleton.Message.self)
+            ref3.tell(.greet(name: "Charlie", _replyTo: replyProbe3.ref))
+
+            try replyProbe1.expectMessage("Hello-1 Charlie!")
+            try replyProbe2.expectMessage("Hello-1 Charlie!")
+            try replyProbe3.expectMessage("Hello-1 Charlie!")
+        }
+    }
+
+    func test_singletonByClusterLeadership_stashMessagesIfNoLeader() throws {
+        try shouldNotThrow {
+            var singletonSettings = ActorSingletonSettings(name: GreeterSingleton.name)
+            singletonSettings.allocationStrategy = .leadership
+
+            let first = self.setUpNode("first") { settings in
+                settings.cluster.node.port = 7111
+                settings.cluster.autoLeaderElection = .lowestAddress(minNumberOfMembers: 3)
+
+                settings += ActorSingleton(settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-1")))
+
+                settings.serialization.registerCodable(for: GreeterSingleton.Message.self, underId: 10001)
+            }
+            let second = self.setUpNode("second") { settings in
+                settings.cluster.node.port = 8222
+                settings.cluster.autoLeaderElection = .lowestAddress(minNumberOfMembers: 3)
+
+                settings += ActorSingleton(settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-2")))
+
+                settings.serialization.registerCodable(for: GreeterSingleton.Message.self, underId: 10001)
+            }
+            let third = self.setUpNode("third") { settings in
+                settings.cluster.node.port = 9333
+                settings.cluster.autoLeaderElection = .lowestAddress(minNumberOfMembers: 3)
+
+                settings += ActorSingleton(settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-3")))
+
+                settings.serialization.registerCodable(for: GreeterSingleton.Message.self, underId: 10001)
+            }
+
+            // No leader so singleton is not available, messages sent should be stashed
+            let replyProbe1 = self.testKit(first).spawnTestProbe(expecting: String.self)
+            let ref1 = try first.singleton.ref(name: GreeterSingleton.name, of: GreeterSingleton.Message.self)
+            ref1.tell(.greet(name: "Charlie", _replyTo: replyProbe1.ref))
+
+            let replyProbe2 = self.testKit(second).spawnTestProbe(expecting: String.self)
+            let ref2 = try second.singleton.ref(name: GreeterSingleton.name, of: GreeterSingleton.Message.self)
+            ref2.tell(.greet(name: "Charlie", _replyTo: replyProbe2.ref))
+
+            let replyProbe3 = self.testKit(third).spawnTestProbe(expecting: String.self)
+            let ref3 = try third.singleton.ref(name: GreeterSingleton.name, of: GreeterSingleton.Message.self)
+            ref3.tell(.greet(name: "Charlie", _replyTo: replyProbe3.ref))
+
+            try replyProbe1.expectNoMessage(for: .milliseconds(200))
+            try replyProbe2.expectNoMessage(for: .milliseconds(200))
+            try replyProbe3.expectNoMessage(for: .milliseconds(200))
+
+            first.cluster.join(node: second.cluster.node.node)
+            third.cluster.join(node: second.cluster.node.node)
+
+            // `first` becomes the leader (lowest address) and runs the singleton
+            try self.ensureNodes(.up, within: .seconds(10), systems: first, second, third)
+
+            try replyProbe1.expectMessage("Hello-1 Charlie!")
+            try replyProbe2.expectMessage("Hello-1 Charlie!")
+            try replyProbe3.expectMessage("Hello-1 Charlie!")
+        }
+    }
+
+    // FIXME: flaky test (https://github.com/apple/swift-distributed-actors/issues/346)
+    func test_singletonByClusterLeadership_withLeaderChange() throws {
         try shouldNotThrow {
             var singletonSettings = ActorSingletonSettings(name: GreeterSingleton.name)
             singletonSettings.allocationStrategy = .leadership


### PR DESCRIPTION
Motivation:
The original `ActorSingletonPluginTests.test_singletonByClusterLeadership` is flaky (see https://github.com/apple/swift-distributed-actors/issues/346).

Modifications:
Split the test into smaller, more focused tests. Rename `test_singletonByClusterLeadership` to `test_singletonByClusterLeadership_withLeaderChange`.

Result:
N/A
