### PR TITLE
=tests bump year in generate_linux_tests to 2020

### DIFF
--- a/Tests/ActorSingletonPluginTests/ActorSingletonPluginTests+XCTest.swift
+++ b/Tests/ActorSingletonPluginTests/ActorSingletonPluginTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/CDistributedActorsMailboxTests/CMPSCLinkedQueueTests+XCTest.swift
+++ b/Tests/CDistributedActorsMailboxTests/CMPSCLinkedQueueTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsConcurrencyHelpersTests/ConcurrencyHelpersTests+XCTest.swift
+++ b/Tests/DistributedActorsConcurrencyHelpersTests/ConcurrencyHelpersTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTestKitTests/ActorTestKitTests+XCTest.swift
+++ b/Tests/DistributedActorsTestKitTests/ActorTestKitTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTestKitTests/ActorTestProbeTests+XCTest.swift
+++ b/Tests/DistributedActorsTestKitTests/ActorTestProbeTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTestKitTests/DeadlineTests+XCTest.swift
+++ b/Tests/DistributedActorsTestKitTests/DeadlineTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTestKitTests/TimeAmountTests+XCTest.swift
+++ b/Tests/DistributedActorsTestKitTests/TimeAmountTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/ActorAddressTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/ActorAddressTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/ActorAskTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/ActorAskTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/ActorDeferTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/ActorDeferTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/ActorIsolationFailureHandlingTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/ActorIsolationFailureHandlingTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/ActorLeakingTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/ActorLeakingTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/ActorLifecycleTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/ActorLifecycleTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/ActorLoggingTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/ActorLoggingTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/ActorMemoryTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/ActorMemoryTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/ActorNamingTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/ActorNamingTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/ActorRefAdapterTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/ActorRefAdapterTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/ActorSubReceiveTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/ActorSubReceiveTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/ActorSystemTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/ActorSystemTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Actorable/ActorContextReceptionistTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Actorable/ActorContextReceptionistTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Actorable/ActorableOwnedMembershipTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Actorable/ActorableOwnedMembershipTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/BackoffStrategyTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/BackoffStrategyTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/BehaviorCanonicalizeTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/BehaviorCanonicalizeTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/BehaviorTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/BehaviorTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/BlockingReceptacleTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/BlockingReceptacleTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/CRDT/CRDTActorOwnedTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTActorOwnedTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/CRDT/CRDTAnyTypesTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTAnyTypesTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/CRDT/CRDTGCounterTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTGCounterTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/CRDT/CRDTLWWMapTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTLWWMapTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/CRDT/CRDTLWWRegisterTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTLWWRegisterTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/CRDT/CRDTORMapTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTORMapTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/CRDT/CRDTORSetTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTORSetTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/CRDT/CRDTReplicatorInstanceTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTReplicatorInstanceTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/CRDT/CRDTReplicatorShellTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTReplicatorShellTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/CRDT/CRDTVersioningTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTVersioningTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/CRDT/Protobuf/CRDT+SerializationTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/CRDT/Protobuf/CRDT+SerializationTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/CRDT/Protobuf/CRDTEnvelope+SerializationTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/CRDT/Protobuf/CRDTEnvelope+SerializationTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/CRDT/Protobuf/CRDTReplication+SerializationTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/CRDT/Protobuf/CRDTReplication+SerializationTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Clocks/LamportClockTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Clocks/LamportClockTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Clocks/Protobuf/VersionVector+SerializationTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Clocks/Protobuf/VersionVector+SerializationTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Clocks/VersionVectorTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Clocks/VersionVectorTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Cluster/AssociationClusteredTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Cluster/AssociationClusteredTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Cluster/ClusterEventStreamTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Cluster/ClusterEventStreamTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Cluster/ClusterLeaderActionsTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Cluster/ClusterLeaderActionsTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Cluster/ClusterMembershipGossipTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Cluster/ClusterMembershipGossipTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Cluster/ClusterReceptionistClusteredTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Cluster/ClusterReceptionistClusteredTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Cluster/DowningStrategy/TimeoutBasedDowningInstanceTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Cluster/DowningStrategy/TimeoutBasedDowningInstanceTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Cluster/LeadershipTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Cluster/LeadershipTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Cluster/Protobuf/ClusterEvents+SerializationTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Cluster/Protobuf/ClusterEvents+SerializationTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Cluster/Protobuf/Membership+SerializationTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Cluster/Protobuf/Membership+SerializationTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Cluster/ProtobufRoundTripTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Cluster/ProtobufRoundTripTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Cluster/RemoteActorRefProviderTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Cluster/RemoteActorRefProviderTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Cluster/RemoteMessagingClusteredTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Cluster/RemoteMessagingClusteredTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Cluster/RemotingHandshakeStateMachineTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Cluster/RemotingHandshakeStateMachineTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Cluster/RemotingTLSClusteredTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Cluster/RemotingTLSClusteredTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Cluster/SWIM/Protobuf/SWIM+SerializationTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Cluster/SWIM/Protobuf/SWIM+SerializationTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Cluster/SWIM/SWIMInstance+ClusterTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Cluster/SWIM/SWIMInstance+ClusterTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Cluster/SWIM/SWIMInstanceTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Cluster/SWIM/SWIMInstanceTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Cluster/SWIM/SWIMShellTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Cluster/SWIM/SWIMShellTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Cluster/SystemMessageRedeliveryHandlerTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Cluster/SystemMessageRedeliveryHandlerTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Cluster/SystemMessagesRedeliveryTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Cluster/SystemMessagesRedeliveryTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/CustomStringInterpolationTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/CustomStringInterpolationTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/DeadLetterTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/DeadLetterTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/DeathWatchTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/DeathWatchTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/DispatcherTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/DispatcherTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/EventStreamTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/EventStreamTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/FixedThreadPoolTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/FixedThreadPoolTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/HeapTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/HeapTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/InterceptorTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/InterceptorTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/MPSCLinkedQueueTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/MPSCLinkedQueueTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/MailboxTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/MailboxTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/MembershipTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/MembershipTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/NIOExtensionsTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/NIOExtensionsTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/NodeDeathWatcherTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/NodeDeathWatcherTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/NodeTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/NodeTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/ParentChildActorTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/ParentChildActorTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Pattern/PeriodicBroadcastTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Pattern/PeriodicBroadcastTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/Pattern/WorkerPoolTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Pattern/WorkerPoolTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/ProtoEnvelopeTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/ProtoEnvelopeTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/ReceptionistTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/ReceptionistTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/RingBufferTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/RingBufferTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/SerializationPoolTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/SerializationPoolTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/SerializationTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/SerializationTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/StashBufferTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/StashBufferTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/SupervisionTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/SupervisionTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/TimeSpecTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/TimeSpecTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/TimersTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/TimersTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/DistributedActorsTests/TraversalTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/TraversalTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/GenActorsTests/GenCodableTests+XCTest.swift
+++ b/Tests/GenActorsTests/GenCodableTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/GenActorsTests/GenerateActorsTests+XCTest.swift
+++ b/Tests/GenActorsTests/GenerateActorsTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/scripts/generate_linux_tests.rb
+++ b/scripts/generate_linux_tests.rb
@@ -36,7 +36,7 @@ def header(fileName)
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information


### PR DESCRIPTION

### Motivation:

Bump year in source gen license 

### Modifications:

- bump year and regenerate tests

### Result:
