### PR TITLE
=versionVector fix happensBefore ordering, add tests

### DIFF
--- a/Sources/DistributedActors/Clocks/VersionVector.swift
+++ b/Sources/DistributedActors/Clocks/VersionVector.swift
@@ -103,15 +103,15 @@ public struct VersionVector {
     /// - Parameter version: The version of interest
     /// - Returns: True if the replica's version in the `VersionVector` is greater than or equal to `version`. False otherwise.
     public func contains(_ replicaId: ReplicaId, _ version: Int) -> Bool {
-        return self[replicaId] >= version
+        self[replicaId] >= version
     }
 
-    /// Compare this `VersionVector` with another and determine causality between the two. They can be ordered (i.e.,
-    /// one happened before or after another), same, or concurrent.
+    /// Compare this `VersionVector` with another and determine causality between the two.
+    /// They can be ordered (i.e., one happened before or after another), same, or concurrent.
     ///
     /// - Parameter that: The `VersionVector` to compare this `VersionVector` to.
     /// - Returns: The causal relation between this and the given `VersionVector`.
-    public func compareTo(that: VersionVector) -> CausalRelation {
+    public func compareTo(_ that: VersionVector) -> CausalRelation {
         if self < that {
             return .happenedBefore
         }
@@ -146,17 +146,17 @@ extension VersionVector: Comparable {
 
         // If every entry in version vector X is less than or equal to the corresponding entry in
         // version vector Y, and at least one entry is strictly smaller, then X < Y.
-        var hasEqual = false
+        var hasAtLeastOneStrictlyLessThan = false
         for (replicaId, lVersion) in lhs.state {
             let rVersion = rhs[replicaId]
             if lVersion > rVersion {
                 return false
             }
-            if lVersion == rVersion {
-                hasEqual = true
+            if lVersion < rVersion {
+                hasAtLeastOneStrictlyLessThan = true
             }
         }
-        return !hasEqual
+        return hasAtLeastOneStrictlyLessThan
     }
 
     public static func == (lhs: VersionVector, rhs: VersionVector) -> Bool {

--- a/Sources/DistributedActors/Cluster/Cluster+Gossip.swift
+++ b/Sources/DistributedActors/Cluster/Cluster+Gossip.swift
@@ -130,7 +130,7 @@ extension Cluster.Gossip {
                 return .happenedBefore
             }
 
-            return versionOnNode.compareTo(that: incomingVersion) // FIXME: tests
+            return versionOnNode.compareTo(incomingVersion)
         }
 
         // FIXME: This could be too many layers;

--- a/Tests/DistributedActorsTests/Clocks/VersionVectorTests.swift
+++ b/Tests/DistributedActorsTests/Clocks/VersionVectorTests.swift
@@ -122,7 +122,7 @@ final class VersionVectorTests: XCTestCase {
         // Not every entry in lhs is <= rhs
         (VV([(replicaA, 1), (replicaB, 3)]) < VV([(replicaA, 2), (replicaB, 2)])).shouldBeFalse()
         // At least one entry in lhs must be strictly less than
-        (VV([(replicaA, 1), (replicaB, 2)]) < VV([(replicaA, 2), (replicaB, 2)])).shouldBeFalse()
+        (VV([(replicaA, 1), (replicaB, 2)]) < VV([(replicaA, 2), (replicaB, 2)])).shouldBeTrue()
 
         // Two empty version vectors should be considered equal instead of greater than
         (VV() > VV()).shouldBeFalse()
@@ -133,7 +133,7 @@ final class VersionVectorTests: XCTestCase {
         // Not every entry in lhs is >= rhs
         (VV([(replicaA, 2), (replicaB, 2)]) > VV([(replicaA, 1), (replicaB, 3)])).shouldBeFalse()
         // At least one entry in lhs must be strictly greater than
-        (VV([(replicaA, 2), (replicaB, 2)]) > VV([(replicaA, 1), (replicaB, 2)])).shouldBeFalse()
+        (VV([(replicaA, 2), (replicaB, 2)]) > VV([(replicaA, 1), (replicaB, 2)])).shouldBeTrue()
 
         // Two empty version vectors are considered equal
         (VV() == VV()).shouldBeTrue()
@@ -154,28 +154,34 @@ final class VersionVectorTests: XCTestCase {
     }
 
     func test_VersionVector_compareTo() throws {
-        guard case .happenedBefore = VV().compareTo(that: VV([(replicaA, 2)])) else {
+        guard case .happenedBefore = VV().compareTo(VV([(replicaA, 2)])) else {
             throw shouldNotHappen("An empty version vector is always before a non-empty one")
         }
-        guard case .happenedBefore = VV([(replicaA, 1), (replicaB, 2)]).compareTo(that: VV([(replicaA, 2), (replicaB, 3)])) else {
+        guard case .happenedBefore = VV([(replicaA, 1), (replicaB, 2)]).compareTo(VV([(replicaA, 2), (replicaB, 3)])) else {
             throw shouldNotHappen("Should be .happenedBefore relation since all entries in LHS are strictly less than RHS")
         }
+        guard case .happenedBefore = VV([(replicaA, 1), (replicaB, 1), (replicaC, 1)]).compareTo(VV([(replicaA, 1), (replicaB, 1), (replicaC, 2)])) else {
+            throw shouldNotHappen("Should be .happenedBefore relation since 2 entries in LHS are equal, and at least one is strictly less than RHS")
+        }
 
-        guard case .happenedAfter = VV([(replicaA, 2)]).compareTo(that: VV()) else {
+        guard case .happenedAfter = VV([(replicaA, 2)]).compareTo(VV()) else {
             throw shouldNotHappen("A non-empty version vector is always after an empty one")
         }
-        guard case .happenedAfter = VV([(replicaA, 2), (replicaB, 3)]).compareTo(that: VV([(replicaA, 1), (replicaB, 2)])) else {
+        guard case .happenedAfter = VV([(replicaA, 2), (replicaB, 3)]).compareTo(VV([(replicaA, 1), (replicaB, 2)])) else {
+            throw shouldNotHappen("Should be .happenedAfter relation since all entries in LHS are strictly greater than RHS")
+        }
+        guard case .happenedAfter = VV([(replicaA, 1), (replicaB, 1), (replicaC, 2)]).compareTo(VV([(replicaA, 1), (replicaB, 1), (replicaC, 1)])) else {
             throw shouldNotHappen("Should be .happenedAfter relation since all entries in LHS are strictly greater than RHS")
         }
 
-        guard case .same = VV().compareTo(that: VV()) else {
+        guard case .same = VV().compareTo(VV()) else {
             throw shouldNotHappen("Two empty version vectors should be considered the same")
         }
-        guard case .same = VV([(replicaA, 2), (replicaB, 1)]).compareTo(that: VV([(replicaB, 1), (replicaA, 2)])) else {
+        guard case .same = VV([(replicaA, 2), (replicaB, 1)]).compareTo(VV([(replicaB, 1), (replicaA, 2)])) else {
             throw shouldNotHappen("Two version vectors should be considered the same if elements are equal")
         }
 
-        guard case .concurrent = VV([(replicaA, 1), (replicaB, 4), (replicaC, 6)]).compareTo(that: VV([(replicaA, 2), (replicaB, 7), (replicaC, 2)])) else {
+        guard case .concurrent = VV([(replicaA, 1), (replicaB, 4), (replicaC, 6)]).compareTo(VV([(replicaA, 2), (replicaB, 7), (replicaC, 2)])) else {
             throw shouldNotHappen("Must be .concurrent relation if the two version vectors are not ordered or the same")
         }
     }


### PR DESCRIPTION
### Motivation:

I _think_ the happens before ordering of the VersionVectors has a slight mistake.

`[1 1 1]` should be happensBefore `[1 1 2]`

> The ordered relation is defined as:  Vector <math>a < b</math> if and only if every element of <math>V_a</math> is less than or equal to its corresponding element in <math>V_b</math>, and at least one of the elements is strictly less than. 

Please sanity check @yim-lee 🙇 

### Modifications:

The change is slight: we track if there was any element that was `<`, and we require that, rather than tracking the `==` and then negating it.

### Result:

- Correct ordering of VVs
