### PR TITLE
=actorable,reception #408 subscribe() must not crash in actorable context

### DIFF
--- a/IntegrationTests/run-tests.sh
+++ b/IntegrationTests/run-tests.sh
@@ -88,9 +88,7 @@ while getopts "f:vid" opt; do
 done
 
 function run_test() {
-    if $no_io_redirect; then
-        "$@"
-    elif $verbose; then
+    if $verbose; then
         "$@" 2>&1 | tee -a "$out"
         # we need to return the return value of the first command
         return ${PIPESTATUS[0]}

--- a/Tests/DistributedActorsTests/Actorable/ActorContextReceptionistTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/Actorable/ActorContextReceptionistTests+XCTest.swift
@@ -26,6 +26,7 @@ extension ActorContextReceptionTests {
             ("test_autoUpdatedListing_updatesAutomatically", test_autoUpdatedListing_updatesAutomatically),
             ("test_autoUpdatedListing_invokesOnUpdate", test_autoUpdatedListing_invokesOnUpdate),
             ("test_lookup_ofGenericType", test_lookup_ofGenericType),
+            ("test_subscribe_genericType", test_subscribe_genericType),
             ("test_autoUpdatedListing_shouldQuicklyUpdateFromThousandsOfUpdates", test_autoUpdatedListing_shouldQuicklyUpdateFromThousandsOfUpdates),
         ]
     }

--- a/Tests/DistributedActorsTests/Actorable/GenActors/OwnerOfThings+GenActor.swift
+++ b/Tests/DistributedActorsTests/Actorable/GenActors/OwnerOfThings+GenActor.swift
@@ -28,6 +28,7 @@ extension OwnerOfThings {
     public enum Message { 
         case readLastObservedValue(_replyTo: ActorRef<Reception.Listing<OwnerOfThings>?>) 
         case performLookup(_replyTo: ActorRef<Result<Reception.Listing<OwnerOfThings>, Error>>) 
+        case performSubscribe(p: ActorRef<Reception.Listing<OwnerOfThings>>) 
     }
     
 }
@@ -53,6 +54,9 @@ extension OwnerOfThings {
                 case .performLookup(let _replyTo):
                     instance.performLookup()
                                     .whenComplete { res in _replyTo.tell(res) } 
+                case .performSubscribe(let p):
+                    instance.performSubscribe(p: p)
+ 
                 
                 }
                 return .same
@@ -105,6 +109,11 @@ extension Actor where A.Message == OwnerOfThings.Message {
                 }
             }
         )
+    }
+ 
+
+     func performSubscribe(p: ActorRef<Reception.Listing<OwnerOfThings>>) {
+        self.ref.tell(.performSubscribe(p: p))
     }
  
 

--- a/Tests/DistributedActorsTests/Actorable/GenActors/OwnerOfThings+GenCodable.swift
+++ b/Tests/DistributedActorsTests/Actorable/GenActors/OwnerOfThings+GenCodable.swift
@@ -28,6 +28,7 @@ extension OwnerOfThings.Message: Codable {
     public enum DiscriminatorKeys: String, Decodable {
         case readLastObservedValue
         case performLookup
+        case performSubscribe
 
     }
 
@@ -35,6 +36,7 @@ extension OwnerOfThings.Message: Codable {
         case _case
         case readLastObservedValue__replyTo
         case performLookup__replyTo
+        case performSubscribe_p
 
     }
 
@@ -47,6 +49,9 @@ extension OwnerOfThings.Message: Codable {
         case .performLookup:
             let _replyTo = try container.decode(ActorRef<Result<Reception.Listing<OwnerOfThings>, Error>>.self, forKey: CodingKeys.performLookup__replyTo)
             self = .performLookup(_replyTo: _replyTo)
+        case .performSubscribe:
+            let p = try container.decode(ActorRef<Reception.Listing<OwnerOfThings>>.self, forKey: CodingKeys.performSubscribe_p)
+            self = .performSubscribe(p: p)
 
         }
     }
@@ -60,6 +65,9 @@ extension OwnerOfThings.Message: Codable {
         case .performLookup(let _replyTo):
             try container.encode(DiscriminatorKeys.performLookup.rawValue, forKey: CodingKeys._case)
             try container.encode(_replyTo, forKey: CodingKeys.performLookup__replyTo)
+        case .performSubscribe(let p):
+            try container.encode(DiscriminatorKeys.performSubscribe.rawValue, forKey: CodingKeys._case)
+            try container.encode(p, forKey: CodingKeys.performSubscribe_p)
 
         }
     }

--- a/Tests/DistributedActorsTests/Actorable/OwnerOfThings.swift
+++ b/Tests/DistributedActorsTests/Actorable/OwnerOfThings.swift
@@ -42,6 +42,12 @@ struct OwnerOfThings: Actorable {
         let reply = self.context.receptionist.lookup(.init(OwnerOfThings.self, id: "all/owners"), timeout: .effectivelyInfinite)
         return reply._nioFuture
     }
+
+    func performSubscribe(p: ActorRef<Reception.Listing<OwnerOfThings>>) {
+        self.context.receptionist.subscribe(.init(OwnerOfThings.self, id: "all/owners")) {
+            p.tell($0)
+        }
+    }
 }
 
 extension OwnerOfThings {


### PR DESCRIPTION
### Motivation:

The subscribe() API of receptionist was not test covered in the Actorable version of the API. We assumed "it's the same so it'll obviously work", well, we were wrong 🙃 


### Modifications:

- The ID of the subreceive is now correctly type it subscribes to, this is pretty good IMHO
  - rather the .description of the key, which includes illegal chars (`(`)
- this means that a new subscribe overrides the old one... To be fair, for the same type that's pretty valid, as they'd all return the same listings anyway.
  - we can follow up on this later though


### Result:

- Resolves #408 Actorable + Receptionist: blows up on subreceive naming when subscribe() is used 