### PR TITLE
=log Allow silencing some logs even at trace level

### DIFF
--- a/Sources/DistributedActors/ActorLogging.swift
+++ b/Sources/DistributedActors/ActorLogging.swift
@@ -63,9 +63,13 @@ public class LoggingContext {
     }
 }
 
+/// Specialized `Logger` factory, populating the logger with metadata about its "owner" actor (or system),
+/// such as it's path or node on which it resides.
+///
+/// The preferred way of obtaining a logger for an actor or system is `context.log` or `system.log`, rather than creating new ones.
 public struct ActorLogger {
     public static func make<T>(context: ActorContext<T>) -> Logger {
-        if let overriddenLoggerFactory = context.system.settings.overrideLoggerFactory {
+        if let overriddenLoggerFactory = context.system.settings.logging.overrideLoggerFactory {
             return overriddenLoggerFactory("\(context.path)")
         }
 
@@ -83,7 +87,7 @@ public struct ActorLogger {
     }
 
     public static func make(system: ActorSystem, identifier: String? = nil) -> Logger {
-        if let overriddenLoggerFactory = system.settings.overrideLoggerFactory {
+        if let overriddenLoggerFactory = system.settings.logging.overrideLoggerFactory {
             return overriddenLoggerFactory(identifier ?? system.name)
         }
 
@@ -128,7 +132,7 @@ public struct ActorOriginLogHandler: LogHandler {
     public init<T>(_ context: ActorContext<T>) {
         self.init(LoggingContext(
             identifier: context.path.description,
-            useBuiltInFormatter: context.system.settings.useBuiltInFormatter,
+            useBuiltInFormatter: context.system.settings.logging.useBuiltInFormatter,
             dispatcher: { [weak context = context] in context?.dispatcher.name ?? "unknown" }
         ))
     }
@@ -136,7 +140,7 @@ public struct ActorOriginLogHandler: LogHandler {
     public init(_ system: ActorSystem, identifier: String? = nil) {
         self.init(LoggingContext(
             identifier: identifier ?? system.name,
-            useBuiltInFormatter: system.settings.useBuiltInFormatter,
+            useBuiltInFormatter: system.settings.logging.useBuiltInFormatter,
             dispatcher: { () in _hackyPThreadThreadId() }
         ))
     }

--- a/Sources/DistributedActors/ActorShell+Children.swift
+++ b/Sources/DistributedActors/ActorShell+Children.swift
@@ -342,7 +342,9 @@ extension ActorShell: ChildActorRefFactory {
         )
         let mailbox = Mailbox(shell: actor, capacity: props.mailbox.capacity)
 
-        log.debug("Spawning [\(behavior)], on path: [\(address.path)]")
+        if self.system.settings.logging.verboseSpawning {
+            log.trace("Spawning [\(behavior)], on path: [\(address.path)]")
+        }
 
         let cell = ActorCell(
             address: address,

--- a/Sources/DistributedActors/ActorSystem.swift
+++ b/Sources/DistributedActors/ActorSystem.swift
@@ -173,9 +173,9 @@ public final class ActorSystem {
         let theOne = self._root
 
         // dead letters init
-        let overrideLogger: Logger? = settings.overrideLoggerFactory.map { f in f("\(ActorPath._deadLetters)") }
+        let overrideLogger: Logger? = settings.logging.overrideLoggerFactory.map { f in f("\(ActorPath._deadLetters)") }
         var deadLogger = overrideLogger ?? Logger(label: "\(ActorPath._deadLetters)", factory: {
-            let context = LoggingContext(identifier: $0, useBuiltInFormatter: settings.useBuiltInFormatter, dispatcher: nil)
+            let context = LoggingContext(identifier: $0, useBuiltInFormatter: settings.logging.useBuiltInFormatter, dispatcher: nil)
             if settings.cluster.enabled {
                 context[metadataKey: "node"] = .stringConvertible(settings.cluster.uniqueBindNode)
             }

--- a/Sources/DistributedActors/ActorSystemSettings.swift
+++ b/Sources/DistributedActors/ActorSystemSettings.swift
@@ -21,24 +21,12 @@ public struct ActorSystemSettings {
         .init()
     }
 
-    // TODO: LoggingSettings
-
-    /// Configure default log level for all `Logger` instances created by the library.
-    public var defaultLogLevel: Logger.Level = .info // TODO: maybe remove this? should be up to logging library to configure for us as well
-
-    /// Optionally override Logger that shall be offered to actors and the system.
-    /// This is used instead of globally configured `Logging.Logger()` factories by the actor system.
-    public var overrideLoggerFactory: ((String) -> Logger)?
-
-    // TODO: hope to remove this once a StdOutLogHandler lands that has formatting support;
-    // logs are hard to follow with not consistent order of metadata etc (like system address etc).
-    public var useBuiltInFormatter: Bool = true
-
     public var actor: ActorSettings = .default
     public var serialization: SerializationSettings = .default
     public var plugins: PluginsSettings = .default
     public var metrics: MetricsSettings = .default(rootName: nil)
     public var failure: FailureSettings = .default
+    public var logging: LoggingSettings = .default
     public var instrumentation: InstrumentationSettings = .default
 
     public typealias ProtocolName = String
@@ -46,6 +34,16 @@ public struct ActorSystemSettings {
     public var cluster: ClusterSettings = .default {
         didSet {
             self.serialization.localNode = self.cluster.uniqueBindNode
+        }
+    }
+
+    /// See `logging.defaultLevel`
+    public var defaultLogLevel: Logger.Level {
+        get {
+            logging.defaultLevel
+        }
+        set {
+            logging.defaultLevel = newValue
         }
     }
 
@@ -60,6 +58,36 @@ extension Array where Element == ActorTransport {
     public static func += <T: ActorTransport>(transports: inout Self, transport: T) {
         transports.append(transport)
     }
+}
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: Logging Settings
+
+/// Note that some of these settings would be obsolete if we had a nice configurable LogHandler which could selectively
+/// log some labelled loggers and some not. Until we land such log handler we have to manually in-project opt-in/-out
+/// of logging some subsystems.
+public struct LoggingSettings {
+    public static let `default` = LoggingSettings()
+
+    /// At what level should the library actually log and print logs // TODO: We'd want to replace this by proper log handlers which allow config by labels
+    public var defaultLevel: Logger.Level = .info // TODO: maybe remove this? should be up to logging library to configure for us as well
+
+    /// Optionally override Logger that shall be offered to actors and the system.
+    /// This is used instead of globally configured `Logging.Logger()` factories by the actor system.
+    public var overrideLoggerFactory: ((String) -> Logger)?
+
+    // TODO: hope to remove this once a StdOutLogHandler lands that has formatting support;
+    // logs are hard to follow with not consistent order of metadata etc (like system address etc).
+    public var useBuiltInFormatter: Bool = true
+
+    // ==== ------------------------------------------------------------------------------------------------------------
+    // MARK: Verbose logging of sub-systems (again, would not be needed with configurable appenders)
+
+    /// Log all detailed timer start/cancel events
+    public var verboseTimers = false
+
+    /// Log all actor `spawn` events
+    public var verboseSpawning = false
 }
 
 // ==== ----------------------------------------------------------------------------------------------------------------

--- a/Sources/DistributedActors/Serialization.swift
+++ b/Sources/DistributedActors/Serialization.swift
@@ -47,11 +47,10 @@ public struct Serialization {
 
         self.allocator = self.settings.allocator
 
-        var log = systemSettings.overrideLoggerFactory.map { $0("/system/serialization") } ??
-            Logger(label: "/system/serialization", factory: { id in
-                let context = LoggingContext(identifier: id, useBuiltInFormatter: systemSettings.useBuiltInFormatter, dispatcher: nil)
-                return ActorOriginLogHandler(context)
-            })
+        var log = Logger(label: "serialization", factory: { id in
+            let context = LoggingContext(identifier: id, useBuiltInFormatter: system.settings.logging.useBuiltInFormatter, dispatcher: nil)
+            return ActorOriginLogHandler(context)
+        })
         // TODO: Dry up setting this metadata
         log[metadataKey: "node"] = .stringConvertible(systemSettings.cluster.uniqueBindNode)
         log.logLevel = systemSettings.defaultLogLevel

--- a/Sources/DistributedActors/Timers.swift
+++ b/Sources/DistributedActors/Timers.swift
@@ -115,7 +115,9 @@ public class Timers<Message> {
     @inlinable
     public func cancel(for key: TimerKey) {
         if let timer = self.installedTimers.removeValue(forKey: key) {
-            self.context.log.trace("Cancel timer [\(key)] with generation [\(timer.generation)]", metadata: self.metadata)
+            if context.system.settings.logging.verboseTimers {
+                self.context.log.trace("Cancel timer [\(key)] with generation [\(timer.generation)]", metadata: self.metadata)
+            }
             timer.handle.cancel()
         }
     }
@@ -160,7 +162,9 @@ public class Timers<Message> {
             }
         }
 
-        self.context.log.trace("Started timer [\(key)] with generation [\(generation)]", metadata: self.metadata)
+        if context.system.settings.logging.verboseTimers {
+            self.context.log.trace("Started timer [\(key)] with generation [\(generation)]", metadata: self.metadata)
+        }
         self.installedTimers[key] = Timer(key: key, message: message, repeated: repeated, generation: generation, handle: handle)
     }
 

--- a/Sources/DistributedActorsTestKit/Cluster/ClusteredNodesTestBase.swift
+++ b/Sources/DistributedActorsTestKit/Cluster/ClusteredNodesTestBase.swift
@@ -65,7 +65,7 @@ open class ClusteredNodesTestBase: XCTestCase {
             settings.cluster.node.port = self.nextPort()
 
             if self.captureLogs {
-                settings.overrideLoggerFactory = capture.loggerFactory(captureLabel: name)
+                settings.logging.overrideLoggerFactory = capture.loggerFactory(captureLabel: name)
             }
 
             settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 2)

--- a/Tests/DistributedActorsTests/ActorRefAdapterTests.swift
+++ b/Tests/DistributedActorsTests/ActorRefAdapterTests.swift
@@ -235,7 +235,7 @@ class ActorRefAdapterTests: ActorSystemTestBase {
     func test_adaptedRef_shouldDeadLetter_whenOwnerTerminated() throws {
         let logCaptureHandler = LogCapture()
         let system = ActorSystem("\(type(of: self))-2") { settings in
-            settings.overrideLoggerFactory = logCaptureHandler.loggerFactory(captureLabel: settings.cluster.node.systemName)
+            settings.logging.overrideLoggerFactory = logCaptureHandler.loggerFactory(captureLabel: settings.cluster.node.systemName)
         }
         defer { system.shutdown().wait() }
 

--- a/Tests/DistributedActorsTests/BehaviorTests.swift
+++ b/Tests/DistributedActorsTests/BehaviorTests.swift
@@ -425,7 +425,7 @@ final class BehaviorTests: ActorSystemTestBase {
     func test_makeAsynchronousCallback_shouldPrintNicelyIfThrewInsideClosure() throws {
         let capture = LogCapture(settings: .init())
         let system = ActorSystem("CallbackCrash") { settings in
-            settings.overrideLoggerFactory = .some(capture.loggerFactory(captureLabel: "mock"))
+            settings.logging.overrideLoggerFactory = .some(capture.loggerFactory(captureLabel: "mock"))
         }
         defer {
             system.shutdown().wait()


### PR DESCRIPTION
### Motivation:

Timer logs are a bit too noisy in normal operations, while we do want to see other logs at trace.

Just a minor thing really

### Modifications:

- introduce LoggingSettings which we wanted anyway
- allow disabling some verbose logs like timer's start/cancel

THE ACTUAL SOLUTION: would be to have a LogHandler that is configurable by labels and tags what it should log or not. But until we get that we have those flags I guess...

### Result:

- more control over logging
- better namespace