### PR TITLE
+swim it_Clustered_swim_suspension_reachability fix invalid timeout setup

### DIFF
--- a/IntegrationTests/tests_04_cluster/it_Clustered_swim_suspension_reachability/main.swift
+++ b/IntegrationTests/tests_04_cluster/it_Clustered_swim_suspension_reachability/main.swift
@@ -31,6 +31,7 @@ let system = ActorSystem("System") { settings in
     settings.cluster.enabled = true
     settings.cluster.bindPort = Int(args[0])!
 
+    settings.cluster.swim.failureDetector.suspicionTimeoutPeriodsMin = 3
     settings.cluster.swim.failureDetector.suspicionTimeoutPeriodsMax = 3
     settings.cluster.swim.failureDetector.pingTimeout = .milliseconds(100)
     settings.cluster.swim.failureDetector.probeInterval = .milliseconds(300)

--- a/Tests/DistributedActorsTests/Cluster/SWIM/SWIMShellClusteredTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/SWIM/SWIMShellClusteredTests.swift
@@ -233,6 +233,7 @@ final class SWIMShellClusteredTests: ClusteredNodesTestBase {
 
             let pingTimeout: TimeAmount = .milliseconds(100)
             let ref = try first.spawn("SWIM", self.swimBehavior(members: [remoteMemberRef], clusterRef: self.firstClusterProbe.ref, configuredWith: { settings in
+                settings.failureDetector.suspicionTimeoutPeriodsMin = 3
                 settings.failureDetector.suspicionTimeoutPeriodsMax = 3
                 settings.failureDetector.pingTimeout = pingTimeout
             }))


### PR DESCRIPTION
Clustered_swim_suspension_reachability_crash has an invalid timeout setup (timeoutMax < timeoutMin). 

- Resolves #455