### PR TITLE
+system allow parking() when clustering

### DIFF
--- a/IntegrationTests/tests_03_xpc_actorable/it_XPCActorable_echo_service/main.swift
+++ b/IntegrationTests/tests_03_xpc_actorable/it_XPCActorable_echo_service/main.swift
@@ -36,5 +36,5 @@ try! _file.append("service booted...\n")
 let service = try XPCActorableService(system, XPCEchoService.init)
 
 service.park()
-//system.park()
+system.park() // TODO system park should invoke the service park, we only need to park once for XPC to kickoff dispatch_main
 // unreachable, park never exits

--- a/Samples/Sources/SampleCluster/main.swift
+++ b/Samples/Sources/SampleCluster/main.swift
@@ -93,5 +93,4 @@ if system.cluster.node.port == 7337 { // <2>
 }
 // end::cluster-sample-actors-discover-and-chat[]
 
-system.park()
-Thread.sleep(.seconds(60)) // TODO: make park halt execution here
+system.park(atMost: .seconds(60))

--- a/Samples/Sources/SampleDiningPhilosophers/DiningPhilosophers.swift
+++ b/Samples/Sources/SampleDiningPhilosophers/DiningPhilosophers.swift
@@ -32,6 +32,6 @@ struct DiningPhilosophers {
         let _: Philosopher.Ref = try system.spawn("Cory", Philosopher(left: fork3, right: fork4).behavior)
         let _: Philosopher.Ref = try system.spawn("Norman", Philosopher(left: fork4, right: fork5).behavior)
 
-        Thread.sleep(time)
+        system.park(atMost: time)
     }
 }

--- a/Samples/Sources/SampleDiningPhilosophers/DistributedDiningPhilosophers.swift
+++ b/Samples/Sources/SampleDiningPhilosophers/DistributedDiningPhilosophers.swift
@@ -73,6 +73,6 @@ struct DistributedDiningPhilosophers {
         _ = try systemC.spawn("Cory", Philosopher(left: fork3, right: fork4).behavior)
         _ = try systemC.spawn("Norman", Philosopher(left: fork4, right: fork5).behavior)
 
-        Thread.sleep(time)
+        systemA.park(atMost: time)
     }
 }


### PR DESCRIPTION

### Motivation:

It is not clear to users how to "keep the main() alive while the system is not terminated".

We have park() for that, but it was not fully doing that.

Goal, avoid people writing "sleep for 10 minutes" in example apps etc: 

>                 try! self.client.run(for: .minutes(10)) // FIXME: How can I make this run indefinitely?

### Modifications:

- Make park do what people would expect.
- I'd like to eventually revisit the park design, but for now this is better