### PR TITLE
[Do not merge] SWIMMember equals should not take status into account

### DIFF
--- a/Sources/DistributedActors/Cluster/SWIM/SWIM.swift
+++ b/Sources/DistributedActors/Cluster/SWIM/SWIM.swift
@@ -252,7 +252,7 @@ extension SWIM.Status {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: SWIM Member
 
-internal struct SWIMMember: Hashable {
+internal struct SWIMMember {
     var node: UniqueNode {
         return self.ref.address.node ?? self.ref._system!.settings.cluster.uniqueBindNode
     }
@@ -285,6 +285,17 @@ internal struct SWIMMember: Hashable {
 
     var isDead: Bool {
         self.status.isDead
+    }
+}
+
+extension SWIMMember: Hashable, Equatable {
+    static func == (lhs: SWIMMember, rhs: SWIMMember) -> Bool {
+        return lhs.ref == rhs.ref && lhs.protocolPeriod == rhs.protocolPeriod
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(ref)
+        hasher.combine(protocolPeriod)
     }
 }
 


### PR DESCRIPTION
Introduction of individual suspicions broke SWIMMember's `equals`.

### Motivation:

Introduction of individual suspicions broke SWIMMember's `equals`. Now SWIMMember instances will differ if they have different `suspectedBy` lists in `.suspect` status. This breaks `Gossip` equatable and may lead to duplicate `SWIMMember` instances in `Gossip` heap.

### Modifications:

SWIMMember's equals will now ignore status. It's safe because SWIM can create only one instance of SWIMMember per actorRef per probe period.

### Result:

No duplicate SWIMMembers in Gossip. Will fix flakiness in `DowningClusteredTests`
