### PR TITLE
+actor,watch #433 Implements watch(:with)

### DIFF
--- a/Sources/DistributedActors/ActorContext.swift
+++ b/Sources/DistributedActors/ActorContext.swift
@@ -153,6 +153,18 @@ public class ActorContext<Message>: ActorRefFactory {
     /// If the `.terminated` signal is handled by returning `.unhandled` it is the same as if the signal was not handled at all,
     /// and the Death Pact will trigger as usual.
     ///
+    /// ### The watch(:with:) variant
+    /// Watch offers another variant of the API, which allows you to customize what message shall be received
+    /// when the watchee is terminated. The message may be optionally passed as `context.watch(ref, with: MyMessage(ref, ...))`,
+    /// allowing you to carry additional context "along with" the information about _which_ actor has terminated.
+    /// Note that the delivery semantics of when this message is delivered is the same as `Signals.Terminated` (i.e.
+    /// it's delivery is guaranteed, even in face of message loss across nodes), and the actual message is _local_ (meaning
+    /// that internally all signalling is still performed using `Terminated` and system messages, but when the time comes
+    /// to deliver it to this actor, instead the customized message is delivered).
+    ///
+    /// Invoking `watch()` multiple times with differing `with` arguments results in only the _latest_ invocation to take effect.
+    /// In other words, when an actor terminates, the customized termination message that was last provided "wins,"
+    /// and is delivered to the watcher (this actor).
     ///
     /// # Examples:
     ///
@@ -162,14 +174,17 @@ public class ActorContext<Message>: ActorRefFactory {
     ///     // watch a child actor immediately when spawning it, (entering a death pact with it)
     ///     let child = try context.watch(context.spawn("child", (behavior)))
     ///
+    ///     // watch(:with:)
+    ///     context.watch(ref, with: .customMessageOnTermination(ref, otherInformation))
+    ///
     /// #### Concurrency:
     ///  - MUST NOT be invoked concurrently to the actors execution, i.e. from the "outside" of the current actor.
     @discardableResult
-    public func watch<M>(_ watchee: ActorRef<M>, file: String = #file, line: UInt = #line) -> ActorRef<M> {
+    public func watch<M>(_ watchee: ActorRef<M>, with terminationMessage: Message? = nil, file: String = #file, line: UInt = #line) -> ActorRef<M> {
         return undefined()
     }
 
-    internal func watch(_ watchee: AddressableActorRef, file: String = #file, line: UInt = #line) {
+    internal func watch(_ watchee: AddressableActorRef, with terminationMessage: Message? = nil, file: String = #file, line: UInt = #line) {
         return undefined()
     }
 

--- a/Sources/DistributedActorsTestKit/ActorTestKit.swift
+++ b/Sources/DistributedActorsTestKit/ActorTestKit.swift
@@ -353,8 +353,8 @@ final class MockActorContext<Message>: ActorContext<Message> {
         fatalError("Failed: \(MockActorContextError())")
     }
 
-    override func watch<M>(_ watchee: ActorRef<M>, file: String = #file, line: UInt = #line) -> ActorRef<M> {
-        return super.watch(watchee, file: file, line: line)
+    override func watch<M>(_ watchee: ActorRef<M>, with terminationMessage: Message? = nil, file: String = #file, line: UInt = #line) -> ActorRef<M> {
+        return super.watch(watchee, with: terminationMessage, file: file, line: line)
     }
 
     override func unwatch<M>(_ watchee: ActorRef<M>, file: String = #file, line: UInt = #line) -> ActorRef<M> {

--- a/Sources/DistributedActorsTestKit/TestProbes.swift
+++ b/Sources/DistributedActorsTestKit/TestProbes.swift
@@ -113,7 +113,7 @@ public class ActorTestProbe<Message> {
 
             // probe commands:
             case .watchCommand(let who, let file, let line):
-                cell.deathWatch.watch(watchee: who, myself: context.myself, parent: cell._parent, file: file, line: line)
+                cell.deathWatch.watch(watchee: who, with: nil, myself: context.myself, parent: cell._parent, file: file, line: line)
                 return .same
 
             case .unwatchCommand(let who):

--- a/Tests/DistributedActorsTests/DeathWatchTests+XCTest.swift
+++ b/Tests/DistributedActorsTests/DeathWatchTests+XCTest.swift
@@ -24,6 +24,9 @@ extension DeathWatchTests {
     static var allTests: [(String, (DeathWatchTests) -> () throws -> Void)] {
         return [
             ("test_watch_shouldTriggerTerminatedWhenWatchedActorStops", test_watch_shouldTriggerTerminatedWhenWatchedActorStops),
+            ("test_watchWith_shouldTriggerCustomMessageWhenWatchedActorStops", test_watchWith_shouldTriggerCustomMessageWhenWatchedActorStops),
+            ("test_watchWith_calledMultipleTimesShouldCarryTheLatestMessage", test_watchWith_calledMultipleTimesShouldCarryTheLatestMessage),
+            ("test_watchWith_calledMultipleTimesShouldAllowGettingBackToSignalDelivery", test_watchWith_calledMultipleTimesShouldAllowGettingBackToSignalDelivery),
             ("test_watch_fromMultipleActors_shouldTriggerTerminatedWhenWatchedActorStops", test_watch_fromMultipleActors_shouldTriggerTerminatedWhenWatchedActorStops),
             ("test_watch_fromMultipleActors_shouldNotifyOfTerminationOnlyCurrentWatchers", test_watch_fromMultipleActors_shouldNotifyOfTerminationOnlyCurrentWatchers),
             ("test_minimized_deathPact_shouldTriggerForWatchedActor", test_minimized_deathPact_shouldTriggerForWatchedActor),


### PR DESCRIPTION
Which allows for efficient watching with "context" information for the watch -- is important for receptionist.

### Motivation:

Without this sometimes it has to become a manual dance or "create a closure to call later", like we do today in: 

```
      let terminatedCallback = ClusterReceptionist.makeRemoveRegistrationCallback(context: context, key: key, ref: ref, storage: storage)
            try ClusterReceptionist.startWatcher(ref: ref, context: context, terminatedCallback: terminatedCallback.invoke(()))

  // TODO: use context aware watch once implemented. See: issue #544
    private static func startWatcher<M>(ref: AddressableActorRef, context: ActorContext<M>, terminatedCallback: @autoclosure @escaping () -> Void) throws {
```

### Modifications:

- allow watching with custom message associated with the watch, this makes it much easier to react to terminations which need to carry some context -- in our case in receptionist we'll want to store not only the `ref` that has terminated, but also the `key(s)` it is associated with.

### Result:

- Resolves #433
- will simplify existing receptionist 
- will simplify and improve scalability of distributed receptionist (since we spawn way less actors, no need for the "watcher")
