### PR TITLE
=genactors adopt argument parser <3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,8 +35,6 @@ var targets: [PackageDescription.Target] = [
             "Logging", "Metrics",
             "Backtrace",
 
-            "Files", // TODO: remove, currently the codegen needs it 
-
             "DistributedActorsConcurrencyHelpers",
             "CDistributedActorsMailbox",
         ]
@@ -52,6 +50,7 @@ var targets: [PackageDescription.Target] = [
             "SwiftSyntax",
             "Stencil",
             "Files",
+            "ArgumentParser",
         ]
     ),
     
@@ -263,6 +262,7 @@ var dependencies: [Package.Dependency] = [
     // swift-syntax is Swift version dependent, and added  as such below
     .package(url: "https://github.com/stencilproject/Stencil.git", from: "0.13.1"), // BSD license
     .package(url: "https://github.com/JohnSundell/Files", from: "4.1.0"), // MIT license
+    .package(url: "https://github.com/apple/swift-argument-parser", .exact("0.0.1")), // not API stable, Apache v2
 ]
 
 #if swift(>=5.1)

--- a/Sources/GenActors/ActorableAnalysis.swift
+++ b/Sources/GenActors/ActorableAnalysis.swift
@@ -22,7 +22,7 @@ import SwiftSyntax
 
 struct GatherActorables: SyntaxVisitor {
     let path: File
-    let settings: GenerateActors.Settings
+    let settings: GenerateActorsCommand
 
     var imports: [String] = []
 
@@ -32,7 +32,7 @@ struct GatherActorables: SyntaxVisitor {
     // Stack of types a declaration is nested in. E.g. an actorable struct declared in an enum for namespacing.
     var nestingStack: [String] = []
 
-    init(_ path: File, _ settings: GenerateActors.Settings) {
+    init(_ path: File, _ settings: GenerateActorsCommand) {
         self.path = path
         self.settings = settings
     }

--- a/Sources/GenActors/Decls+GenActorRendering.swift
+++ b/Sources/GenActors/Decls+GenActorRendering.swift
@@ -17,7 +17,7 @@ import Stencil
 import SwiftSyntax
 
 protocol Renderable {
-    func render(_ settings: GenerateActors.Settings) throws -> String
+    func render(_ settings: GenerateActorsCommand) throws -> String
 }
 
 enum Rendering {
@@ -166,7 +166,7 @@ extension Rendering {
             """
         )
 
-        func render(_ settings: GenerateActors.Settings) throws -> String {
+        func render(_ settings: GenerateActorsCommand) throws -> String {
             let context: [String: Any] = [
                 "baseName": self.actorable.fullName,
                 "actorableProtocol": self.actorable.type == .protocol ? self.actorable.name : "",
@@ -259,7 +259,7 @@ extension Rendering {
             """
         )
 
-        func render(_ settings: GenerateActors.Settings) throws -> String {
+        func render(_ settings: GenerateActorsCommand) throws -> String {
             let context: [String: Any] = [
                 "baseName": self.actorable.fullName,
                 "funcTells": try self.actorable.funcs.map { funcDecl in

--- a/Sources/GenActors/Decls+GenCodableRendering.swift
+++ b/Sources/GenActors/Decls+GenCodableRendering.swift
@@ -56,7 +56,7 @@ extension Rendering {
             """
         )
 
-        func render(_: GenerateActors.Settings) throws -> String {
+        func render(_: GenerateActorsCommand) throws -> String {
             let printer = CodePrinter()
 
             let baseName = "\(self.actorable.messageFullyQualifiedName)"

--- a/Sources/GenActors/GenerateActorsCommand.swift
+++ b/Sources/GenActors/GenerateActorsCommand.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import DistributedActors
+
+struct GenerateActorsCommand: ParsableCommand {
+    @Flag(help: "Remove *all* +Gen... source files before generating a new batch of files")
+    var clean: Bool
+
+    @Flag(name: .shortAndLong, help: "Print verbose information while analyzing and generating sources")
+    var verbose: Bool
+
+    @Argument()
+    var scanTargets: [String]
+}
+
+extension GenerateActorsCommand {
+    public func run() throws {
+        let gen = GenerateActors(command: self)
+        _ = try gen.run()
+    }
+}

--- a/Sources/GenActors/main.swift
+++ b/Sources/GenActors/main.swift
@@ -12,9 +12,4 @@
 //
 //===----------------------------------------------------------------------===//
 
-do {
-    let gen = GenerateActors(args: CommandLine.arguments)
-    _ = try gen.run()
-} catch {
-    print("error: \(error)")
-}
+GenerateActorsCommand.main()


### PR DESCRIPTION
### Motivation:

The argument parsing in GenActors was a stop-gap until we could use the `ArgumentParser`

### Modifications:

- use argument parser!

### Result:

- No more hand rolled argument parsing <3 