### PR TITLE
!actor Slim down actor shell to 480 bytes again, after introducing instrumentation

### DIFF
--- a/Sources/DistributedActors/ActorContext.swift
+++ b/Sources/DistributedActors/ActorContext.swift
@@ -74,6 +74,11 @@ public class ActorContext<Message>: ActorRefFactory {
         return undefined()
     }
 
+    /// `Props` which were used when spawning this actor.
+    public var props: Props {
+        return undefined()
+    }
+
     // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: Timers
 

--- a/Sources/DistributedActors/ActorLogging.swift
+++ b/Sources/DistributedActors/ActorLogging.swift
@@ -133,7 +133,7 @@ public struct ActorOriginLogHandler: LogHandler {
         self.init(LoggingContext(
             identifier: context.path.description,
             useBuiltInFormatter: context.system.settings.logging.useBuiltInFormatter,
-            dispatcher: { [weak context = context] in context?.dispatcher.name ?? "unknown" }
+            dispatcher: { () in context.props.dispatcher.name }
         ))
     }
 

--- a/Sources/DistributedActors/ActorRefProvider.swift
+++ b/Sources/DistributedActors/ActorRefProvider.swift
@@ -145,8 +145,7 @@ internal struct LocalActorRefProvider: _ActorRefProvider {
                 parent: AddressableActorRef(root.ref),
                 behavior: behavior,
                 address: address,
-                props: props,
-                dispatcher: dispatcher
+                props: props
             )
 
             let cell = actor._myCell

--- a/Sources/DistributedActors/ActorShell+Children.swift
+++ b/Sources/DistributedActors/ActorShell+Children.swift
@@ -324,21 +324,12 @@ extension ActorShell: ChildActorRefFactory {
         let incarnation: ActorIncarnation = props._wellKnown ? .wellKnown : .random()
         let address: ActorAddress = try self.address.makeChildAddress(name: name, incarnation: incarnation)
 
-        let dispatcher: MessageDispatcher
-        switch props.dispatcher {
-        case .default: dispatcher = self.dispatcher // TODO: this is dispatcher inheritance, not sure about it
-        case .callingThread: dispatcher = CallingThreadDispatcher()
-        case .nio(let group): dispatcher = NIOEventLoopGroupDispatcher(group)
-        default: fatalError("not implemented yet, only default dispatcher and calling thread one work")
-        }
-
         let actor: ActorShell<M> = ActorShell<M>(
             system: self.system,
             parent: self.myself.asAddressable(),
             behavior: behavior,
             address: address,
-            props: props,
-            dispatcher: dispatcher
+            props: props
         )
         let mailbox = Mailbox(shell: actor, capacity: props.mailbox.capacity)
 

--- a/Sources/DistributedActors/ActorShell.swift
+++ b/Sources/DistributedActors/ActorShell.swift
@@ -50,12 +50,10 @@ public final class ActorShell<Message>: ActorContext<Message>, AbstractActor {
     // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: Basic ActorContext capabilities
 
-    private let _dispatcher: MessageDispatcher
-
     @usableFromInline
     var _system: ActorSystem
     public override var system: ActorSystem {
-        return self._system
+        self._system
     }
 
     /// Guaranteed to be set during ActorRef creation
@@ -137,7 +135,7 @@ public final class ActorShell<Message>: ActorContext<Message>, AbstractActor {
     internal init(
         system: ActorSystem, parent: AddressableActorRef,
         behavior: Behavior<Message>, address: ActorAddress,
-        props: Props, dispatcher: MessageDispatcher
+        props: Props
     ) {
         self._system = system
         self._parent = parent
@@ -145,7 +143,6 @@ public final class ActorShell<Message>: ActorContext<Message>, AbstractActor {
         self.behavior = behavior
         self._address = address
         self._props = props
-        self._dispatcher = dispatcher
 
         self.supervisor = Supervision.supervisorFor(system, initialBehavior: behavior, props: props.supervision)
 
@@ -226,37 +223,36 @@ public final class ActorShell<Message>: ActorContext<Message>, AbstractActor {
     ///
     /// Warning: Do not use after actor has terminated (!)
     public override var myself: ActorRef<Message> {
-        return .init(.cell(self._myCell))
+        .init(.cell(self._myCell))
     }
 
-    // Implementation note: Watch out when accessing from outside of an actor run, myself could have been unset (!)
+    public override var props: Props {
+        self._props
+    }
+
     public override var address: ActorAddress {
-        return self._address
+        self._address
     }
 
     // Implementation note: Watch out when accessing from outside of an actor run, myself could have been unset (!)
     public override var path: ActorPath {
-        return self._address.path
+        self._address.path
     }
 
     // Implementation note: Watch out when accessing from outside of an actor run, myself could have been unset (!)
     public override var name: String {
-        return self._address.name
+        self._address.name
     }
 
     // access only from within actor
     private lazy var _log = ActorLogger.make(context: self)
     public override var log: Logger {
         get {
-            return self._log
+            self._log
         }
         set {
             self._log = newValue
         }
-    }
-
-    public override var dispatcher: MessageDispatcher {
-        return self._dispatcher
     }
 
     // ==== ------------------------------------------------------------------------------------------------------------

--- a/Sources/DistributedActors/Props.swift
+++ b/Sources/DistributedActors/Props.swift
@@ -88,6 +88,7 @@ public enum DispatcherProps {
     /// This dispatcher will keep a real dedicated Thread for this actor. This is very rarely something you want,
     // unless designing an actor that is intended to spin without others interrupting it on some resource and may block on it etc.
     case pinnedThread // TODO: implement pinned thread dispatcher
+    // TODO: CPU Affinity when pinning
 
     /// WARNING: Use with Caution!
     ///
@@ -103,6 +104,15 @@ public enum DispatcherProps {
     ///
     /// Dispatcher which hijacks the calling thread to schedule execution.
     case callingThread
+
+    public var name: String {
+        switch self {
+        case .default: return "default"
+        case .pinnedThread: return "pinnedThread"
+        case .nio: return "nioEventLoopGroup"
+        case .callingThread: return "callingThread"
+        }
+    }
 }
 
 // ==== ----------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Slim down ActorShell after we had broken the ActorMemory test by growing it by the introduction of instrumentation

### Motivation:

Small shells == small actors == happy users.

- We retain the new instrumentation without growing the actors.
- Future: we'll remove a bunch of other things here making the shell even smaller when we tackle the tree changes

### Modifications:

- remove "dispatcher inheritance" which was never _really_ offered and could be debated if it's needed anyway or not.

### Result:

- Resolves #502