### PR TITLE
use swift-server/swift-backtrace

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -252,7 +252,7 @@ var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.7.0"),
 
     // ~~~ workaround for backtraces ~~~
-    .package(url: "https://github.com/ianpartridge/swift-backtrace.git", from: "1.1.1"),
+    .package(url: "https://github.com/swift-server/swift-backtrace.git", from: "1.1.1"),
 
     // ~~~ SSWG APIs ~~~
     .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),


### PR DESCRIPTION
motivation: repository moved in the swift-server org

changes: update the url to the new location
