### PR TITLE
#523 Don't expose AskResponse/Reply wait()

### DIFF
--- a/Docs/behaviors.adoc
+++ b/Docs/behaviors.adoc
@@ -164,7 +164,7 @@ include::{dir_sact_doc_tests}/ActorDocExamples.swift[tag=ask_outside]
 ----
 <1> `replyTo` is an actor ref of the type specified with the `for` parameter of ask and is used to receive the response
 <2> Create the message that will be sent to the ref that `ask` is called on
-<3> Retrieve the result from the `api:AskResponse[struct]`. *In production code the blocking `wait` should be avoided and asynchronous callbacks should be used instead.
+<3> Retrieve the result from the `api:AskResponse[struct]`.
 
 WARNING: _Never_ invoke any kind of blocking operation such as `future.wait()` inside of an actor!
          Same as blocking an event loop, blocking inside actors will cause starvation for other actors sharing the same dispatcher.

--- a/Sources/DistributedActors/ActorRef+Ask.swift
+++ b/Sources/DistributedActors/ActorRef+Ask.swift
@@ -198,18 +198,6 @@ extension AskResponse {
             return .nioFuture(nioFuture.map { callback($0) })
         }
     }
-
-    /// Blocks and waits until there is a response or fails with an error.
-    ///
-    /// - Warning: This is blocking and should be avoided in production code. Use asynchronous callbacks instead.
-    public func wait() throws -> Value {
-        switch self {
-        case .completed(let result):
-            return try result.get()
-        case .nioFuture(let nioFuture):
-            return try nioFuture.wait()
-        }
-    }
 }
 
 // ==== ----------------------------------------------------------------------------------------------------------------

--- a/Sources/DistributedActors/GenActors/Actorable.swift
+++ b/Sources/DistributedActors/GenActors/Actorable.swift
@@ -137,18 +137,6 @@ extension ResultReply {
             fatalError(errorMessage)
         }
     }
-
-    /// Blocks and waits until there is a reply or fails with an error.
-    ///
-    /// - Warning: This is blocking and should be avoided in production code. Use asynchronous callbacks instead.
-    public func wait() throws -> Value {
-        switch self {
-        case .completed(let result):
-            return try result.get()
-        case .nioFuture(let nioFuture):
-            return try nioFuture.wait()
-        }
-    }
 }
 
 extension ResultReply: AsyncResult {

--- a/Sources/DistributedActorsTestKit/ActorTestKit.swift
+++ b/Sources/DistributedActorsTestKit/ActorTestKit.swift
@@ -494,3 +494,33 @@ extension ActorTestKit {
         }
     }
 }
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: AskResponse
+
+extension AskResponse {
+    /// Blocks and waits until there is a response or fails with an error.
+    public func wait() throws -> Value {
+        switch self {
+        case .completed(let result):
+            return try result.get()
+        case .nioFuture(let nioFuture):
+            return try nioFuture.wait()
+        }
+    }
+}
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: ResultReply
+
+extension ResultReply {
+    /// Blocks and waits until there is a reply or fails with an error.
+    public func wait() throws -> Value {
+        switch self {
+        case .completed(let result):
+            return try result.get()
+        case .nioFuture(let nioFuture):
+            return try nioFuture.wait()
+        }
+    }
+}

--- a/Tests/DistributedActorsDocumentationTests/ActorDocExamples.swift
+++ b/Tests/DistributedActorsDocumentationTests/ActorDocExamples.swift
@@ -284,9 +284,8 @@ class ActorDocExamples: XCTestCase {
             Hello(name: "Anne", replyTo: replyTo) // <2>
         }
 
-        let result = try response.wait() // <3>
+        response._onComplete { result in _ = result } // <3>
         // end::ask_outside[]
-        _ = result
     }
 
     func example_ask_inside() throws {


### PR DESCRIPTION
Motivation:
Follow up discussions on https://github.com/apple/swift-distributed-actors/pull/517.

`wait` is unsafe and we don't want users calling it without understanding the risks.

Modifications:
- Move `AskResponse.wait` and `ResultReply.wait` to test kit.
- Update example in doc to use `_onComplete`, not the best but we'll go with it for now.

Result:
`wait` can only be used in tests.

This resolves https://github.com/apple/swift-distributed-actors/issues/523.