### PR TITLE
=serialization #537 clear reference cycle system/serialization on shu…

### DIFF
--- a/Sources/DistributedActors/Serialization/Serialization+SerializerID.swift
+++ b/Sources/DistributedActors/Serialization/Serialization+SerializerID.swift
@@ -91,14 +91,6 @@ extension Serialization {
         internal static let SystemMessageNACK: SerializerID = .checkProtobufRepresentable(_SystemMessage.NACK.self)
         internal static let SystemMessageEnvelope: SerializerID = .checkProtobufRepresentable(DistributedActors.SystemMessageEnvelope.self)
 
-        internal static let Int: SerializerID = 100
-        internal static let UInt: SerializerID = 101
-        internal static let Int32: SerializerID = 102
-        internal static let UInt32: SerializerID = 103
-        internal static let Int64: SerializerID = 104
-        internal static let UInt64: SerializerID = 105
-        internal static let String: SerializerID = 106
-
         internal static let ActorAddress: SerializerID = .checkProtobufRepresentable(DistributedActors.ActorAddress.self)
 
         internal static let ClusterShellMessage: SerializerID = .checkProtobufRepresentable(ClusterShell.Message.self)

--- a/Sources/DistributedActors/Serialization/SerializationPool.swift
+++ b/Sources/DistributedActors/Serialization/SerializationPool.swift
@@ -108,25 +108,8 @@ public final class SerializationPool {
                 // do the work, this may be "heavy"
                 let deserialized = try self.serialization.deserializeAny(from: &bytes, using: manifest)
 
-//                // The order of the below if/if-else/else is quite important:
-//                if let wellTyped = deserialized as? Message {
-                // 1) we usually have the right Message type, as we resolved an alive actor and are delivering to it,
-                //    the cast will be successful and we can safely deliver the message
                 self.instrumentation.remoteActorMessageDeserializeEnd(id: callback, message: deserialized)
-//                    return .message(wellTyped)
                 return .message(deserialized)
-
-//                } else if messageType == Never.self {
-//                    // 2) we may have resolved an already-dead actor ref, in which case the type of its message would be Never;
-//                    //    Since such Never message can never be fulfilled, it also makes no sense that such message was even sent(!),
-//                    //    thus we treat this simply as a dead letter and deliver it as such
-//                    self.instrumentation.remoteActorMessageDeserializeEnd(id: callback, message: deserialized)
-//                    pprint("DEAD LETTER; \n    \(messageType)\n    \(Message.self)\n    Deserialized: \(deserialized)")
-//                    return .deadLetter(deserialized)
-//                } else {
-//                    // 3) the message was neither the right type, nor was the recipient a `Never` expecting ref, thus something went quite wrong and we should throw.
-//                    throw SerializationError.unableToDeserialize(hint: "Unable to deserialize payload (manifest: \(manifest)) as [\(String(reflecting: messageType))]")
-//                }
             } catch {
                 self.instrumentation.remoteActorMessageDeserializeEnd(id: callback, message: nil)
                 throw error


### PR DESCRIPTION
Solves the leak https://github.com/apple/swift-distributed-actors/issues/537

Was due to removal of the clearing of the serialization / system reference cycle that exists and we break it when we shutdown a system.

Usage of locks around this made more proper as well.