### PR TITLE
Follow-up for #564

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -5,6 +5,7 @@
 --exclude "**/*.pb.swift"
 --exclude "**/*+GenActor.swift"
 --exclude "**/*+GenCodable.swift"
+--exclude "**/*+XPCProtocolStub.swift"
 
 # format options
 

--- a/Tests/DistributedActorsDocumentationTests/Actorable/GenActors/AllInOneMachine+GenActor.swift
+++ b/Tests/DistributedActorsDocumentationTests/Actorable/GenActors/AllInOneMachine+GenActor.swift
@@ -33,18 +33,18 @@ extension AllInOneMachine {
 
     public enum Message: ActorMessage { 
         case clean 
-        case diagnostics(/*TODO: MODULE.*/GeneratedActor.Messages.Diagnostics) 
         case coffeeMachine(/*TODO: MODULE.*/GeneratedActor.Messages.CoffeeMachine) 
+        case diagnostics(/*TODO: MODULE.*/GeneratedActor.Messages.Diagnostics) 
     }
-    
-    /// Performs boxing of GeneratedActor.Messages.Diagnostics messages such that they can be received by Actor<AllInOneMachine>
-    public static func _boxDiagnostics(_ message: GeneratedActor.Messages.Diagnostics) -> AllInOneMachine.Message {
-        .diagnostics(message)
-    } 
     
     /// Performs boxing of GeneratedActor.Messages.CoffeeMachine messages such that they can be received by Actor<AllInOneMachine>
     public static func _boxCoffeeMachine(_ message: GeneratedActor.Messages.CoffeeMachine) -> AllInOneMachine.Message {
         .coffeeMachine(message)
+    } 
+    
+    /// Performs boxing of GeneratedActor.Messages.Diagnostics messages such that they can be received by Actor<AllInOneMachine>
+    public static func _boxDiagnostics(_ message: GeneratedActor.Messages.Diagnostics) -> AllInOneMachine.Message {
+        .diagnostics(message)
     } 
     
 }
@@ -67,12 +67,12 @@ extension AllInOneMachine {
                     instance.clean()
  
                 
-                case .diagnostics(.printDiagnostics):
-                    instance.printDiagnostics()
- 
                 case .coffeeMachine(.makeCoffee(let _replyTo)):
                     let result = instance.makeCoffee()
                     _replyTo.tell(result)
+ 
+                case .diagnostics(.printDiagnostics):
+                    instance.printDiagnostics()
  
                 }
                 return .same

--- a/Tests/DistributedActorsDocumentationTests/Actorable/GenActors/AllInOneMachine+GenCodable.swift
+++ b/Tests/DistributedActorsDocumentationTests/Actorable/GenActors/AllInOneMachine+GenCodable.swift
@@ -33,15 +33,15 @@ extension AllInOneMachine.Message {
     // TODO: Check with Swift team which style of discriminator to aim for
     public enum DiscriminatorKeys: String, Decodable {
         case clean
-        case _boxDiagnostics
         case _boxCoffeeMachine
+        case _boxDiagnostics
 
     }
 
     public enum CodingKeys: CodingKey {
         case _case
-        case _boxDiagnostics
         case _boxCoffeeMachine
+        case _boxDiagnostics
 
     }
 
@@ -50,12 +50,12 @@ extension AllInOneMachine.Message {
         switch try container.decode(DiscriminatorKeys.self, forKey: CodingKeys._case) {
         case .clean:
             self = .clean
-        case ._boxDiagnostics:
-            let boxed = try container.decode(GeneratedActor.Messages.Diagnostics.self, forKey: CodingKeys._boxDiagnostics)
-            self = .diagnostics(boxed)
         case ._boxCoffeeMachine:
             let boxed = try container.decode(GeneratedActor.Messages.CoffeeMachine.self, forKey: CodingKeys._boxCoffeeMachine)
             self = .coffeeMachine(boxed)
+        case ._boxDiagnostics:
+            let boxed = try container.decode(GeneratedActor.Messages.Diagnostics.self, forKey: CodingKeys._boxDiagnostics)
+            self = .diagnostics(boxed)
 
         }
     }
@@ -65,12 +65,12 @@ extension AllInOneMachine.Message {
         switch self {
         case .clean:
             try container.encode(DiscriminatorKeys.clean.rawValue, forKey: CodingKeys._case)
-        case .diagnostics(let boxed):
-            try container.encode(DiscriminatorKeys._boxDiagnostics.rawValue, forKey: CodingKeys._case)
-            try container.encode(boxed, forKey: CodingKeys._boxDiagnostics)
         case .coffeeMachine(let boxed):
             try container.encode(DiscriminatorKeys._boxCoffeeMachine.rawValue, forKey: CodingKeys._case)
             try container.encode(boxed, forKey: CodingKeys._boxCoffeeMachine)
+        case .diagnostics(let boxed):
+            try container.encode(DiscriminatorKeys._boxDiagnostics.rawValue, forKey: CodingKeys._case)
+            try container.encode(boxed, forKey: CodingKeys._boxDiagnostics)
 
         }
     }

--- a/Tests/GenActorsTests/AwaitingActorable/AwaitingActorable.swift
+++ b/Tests/GenActorsTests/AwaitingActorable/AwaitingActorable.swift
@@ -25,15 +25,15 @@ public struct AwaitingActorable: Actorable {
         false
     }
 
-    func awaitOnAFuture(f: EventLoopFuture<String>, replyTo: ActorRef<Result<String, ErrorEnvelope>>) -> Behavior<Myself.Message> {
+    func awaitOnAFuture(f: EventLoopFuture<String>, replyTo: ActorRef<Result<String, AwaitingActorableError>>) -> Behavior<Myself.Message> {
         context.awaitResult(of: f, timeout: .effectivelyInfinite) { result in
-            replyTo.tell(result.mapError { error in ErrorEnvelope(error) })
+            replyTo.tell(result.mapError { error in AwaitingActorableError.error(error) })
         }
     }
 
-    func onResultAsyncExample(f: EventLoopFuture<String>, replyTo: ActorRef<Result<String, ErrorEnvelope>>) {
+    func onResultAsyncExample(f: EventLoopFuture<String>, replyTo: ActorRef<Result<String, AwaitingActorableError>>) {
         context.onResultAsync(of: f, timeout: .effectivelyInfinite) { result in
-            replyTo.tell(result.mapError { error in ErrorEnvelope(error) })
+            replyTo.tell(result.mapError { error in AwaitingActorableError.error(error) })
         }
     }
 }
@@ -41,4 +41,8 @@ public struct AwaitingActorable: Actorable {
 // should not accidentally try to make this actorable
 public struct ExampleModel {
     public struct ExampleData {}
+}
+
+public enum AwaitingActorableError: Error, NonTransportableActorMessage {
+    case error(Error)
 }

--- a/Tests/GenActorsTests/AwaitingActorable/GenActors/AwaitingActorable+GenActor.swift
+++ b/Tests/GenActorsTests/AwaitingActorable/GenActors/AwaitingActorable+GenActor.swift
@@ -26,8 +26,8 @@ import class NIO.EventLoopFuture
 extension AwaitingActorable {
 
     public enum Message: ActorMessage { 
-        case awaitOnAFuture(f: EventLoopFuture<String>, replyTo: ActorRef<Result<String, ErrorEnvelope>>) 
-        case onResultAsyncExample(f: EventLoopFuture<String>, replyTo: ActorRef<Result<String, ErrorEnvelope>>) 
+        case awaitOnAFuture(f: EventLoopFuture<String>, replyTo: ActorRef<Result<String, AwaitingActorableError>>) 
+        case onResultAsyncExample(f: EventLoopFuture<String>, replyTo: ActorRef<Result<String, AwaitingActorableError>>) 
     }
     
 }
@@ -84,12 +84,12 @@ extension AwaitingActorable {
 
 extension Actor where A.Message == AwaitingActorable.Message {
 
-     func awaitOnAFuture(f: EventLoopFuture<String>, replyTo: ActorRef<Result<String, ErrorEnvelope>>) {
+     func awaitOnAFuture(f: EventLoopFuture<String>, replyTo: ActorRef<Result<String, AwaitingActorableError>>) {
         self.ref.tell(Self.Message.awaitOnAFuture(f: f, replyTo: replyTo))
     }
  
 
-     func onResultAsyncExample(f: EventLoopFuture<String>, replyTo: ActorRef<Result<String, ErrorEnvelope>>) {
+     func onResultAsyncExample(f: EventLoopFuture<String>, replyTo: ActorRef<Result<String, AwaitingActorableError>>) {
         self.ref.tell(Self.Message.onResultAsyncExample(f: f, replyTo: replyTo))
     }
  

--- a/Tests/GenActorsTests/GenerateActorsTests.swift
+++ b/Tests/GenActorsTests/GenerateActorsTests.swift
@@ -333,7 +333,7 @@ final class GenerateActorsTests: XCTestCase {
     // MARK: Awaiting on a result (context.awaitResult)
 
     func test_AwaitingActorable_awaitOnAResult() throws {
-        let p = self.testKit.spawnTestProbe(expecting: Result<String, ErrorEnvelope>.self)
+        let p = self.testKit.spawnTestProbe(expecting: Result<String, AwaitingActorableError>.self)
 
         let actor = try self.system.spawn("testActor") { AwaitingActorable(context: $0) }
         let promise = self.system._eventLoopGroup.next().makePromise(of: String.self)
@@ -351,7 +351,7 @@ final class GenerateActorsTests: XCTestCase {
     }
 
     func test_AwaitingActorable_onResultAsync() throws {
-        let p = self.testKit.spawnTestProbe(expecting: Result<String, ErrorEnvelope>.self)
+        let p = self.testKit.spawnTestProbe(expecting: Result<String, AwaitingActorableError>.self)
 
         let actor = try self.system.spawn("testActor") { AwaitingActorable(context: $0) }
         let promise = self.system._eventLoopGroup.next().makePromise(of: String.self)


### PR DESCRIPTION
Motivation:
Some follow-ups that came out of https://github.com/apple/swift-distributed-actors/pull/564

Modifications:
The most significant change is we relax the conformance `Result: ActorMessage` from `Failure == ErrorEnvelop` to `Failure: ActorMessage`.

