### PR TITLE
=test #529 harden test_down_beGossipedToOtherNodes

### DIFF
--- a/Sources/DistributedActorsTestKit/ActorTestKit.swift
+++ b/Sources/DistributedActorsTestKit/ActorTestKit.swift
@@ -131,8 +131,12 @@ extension ActorTestKit {
     /// Spawns an `ActorTestProbe` and immediately subscribes it to the passed in event stream.
     ///
     /// - Hint: Use `fishForMessages` and `fishFor` to filter expectations for specific events.
-    public func spawnEventStreamTestProbe<Event: ActorMessage>(subscribedTo eventStream: EventStream<Event>, file: String = #file, line: UInt = #line, column: UInt = #column) -> ActorTestProbe<Event> {
-        let p = self.spawnTestProbe(.prefixed(with: "\(eventStream.ref.path.name)-subscriberProbe"), expecting: Event.self)
+    public func spawnEventStreamTestProbe<Event: ActorMessage>(
+        _ naming: ActorNaming? = nil,
+        subscribedTo eventStream: EventStream<Event>,
+        file: String = #file, line: UInt = #line, column: UInt = #column
+    ) -> ActorTestProbe<Event> {
+        let p = self.spawnTestProbe(naming ?? ActorNaming.prefixed(with: "\(eventStream.ref.path.name)-subscriberProbe"), expecting: Event.self)
         eventStream.subscribe(p.ref)
         return p
     }

--- a/Tests/DistributedActorsTests/Cluster/MembershipGossipClusteredTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/MembershipGossipClusteredTests.swift
@@ -66,17 +66,15 @@ final class MembershipGossipClusteredTests: ClusteredNodesTestBase {
                 try self.assertMemberStatus(on: second, node: third.cluster.node, is: .up)
             }
 
+            let firstEvents = testKit(first).spawnEventStreamTestProbe(subscribedTo: first.cluster.events)
+            let secondEvents = testKit(second).spawnEventStreamTestProbe(subscribedTo: second.cluster.events)
+            let thirdEvents = testKit(third).spawnEventStreamTestProbe(subscribedTo: third.cluster.events)
+
             second.cluster.down(node: third.cluster.node.node)
 
-            try self.testKit(first).eventually(within: .seconds(5)) {
-                try self.assertMemberStatus(on: first, node: third.cluster.node, is: .down)
-            }
-            try self.testKit(second).eventually(within: .seconds(5)) {
-                try self.assertMemberStatus(on: second, node: third.cluster.node, is: .down)
-            }
-            try self.testKit(third).eventually(within: .seconds(5)) {
-                try self.assertMemberStatus(on: third, node: third.cluster.node, is: .down)
-            }
+            try self.assertMemberDown(firstEvents, node: third.cluster.node)
+            try self.assertMemberDown(secondEvents, node: third.cluster.node)
+            try self.assertMemberDown(thirdEvents, node: third.cluster.node)
         }
     }
 


### PR DESCRIPTION
### Motivation:

- flaky test

### Modifications:

- it was flaky because it was racing trying to see the node as .down in a snapshot observation which may or may not happen
- because down -> removed would happen sometimes fast enough
- the solution is as always if one cares about every "edge" to use events to observe things

### Result:

- Resolves #529