### PR TITLE
#528 Use CodePrinter everywhere in GenActors

### DIFF
--- a/Samples/Sources/XPCActorServiceProvider/GenActors/GreetingsServiceImpl+GenActor.swift
+++ b/Samples/Sources/XPCActorServiceProvider/GenActors/GreetingsServiceImpl+GenActor.swift
@@ -45,8 +45,8 @@ extension GreetingsServiceImpl {
  
                 case .greetingsService(.greet(let name, let _replyTo)):
                     do {
-                    let result = try instance.greet(name: name)
-                    _replyTo.tell(.success(result))
+                        let result = try instance.greet(name: name)
+                        _replyTo.tell(.success(result))
                     } catch {
                         context.log.warning("Error thrown while handling [\(message)], error: \(error)")
                         _replyTo.tell(.failure(ErrorEnvelope(error)))
@@ -67,7 +67,8 @@ extension GreetingsServiceImpl {
                             case .failure(let error):
                                 _replyTo.tell(.failure(ErrorEnvelope(error)))
                             }
-                        } 
+                        }
+ 
                 }
                 return .same
             }.receiveSignal { _context, signal in 

--- a/Sources/GenActors/CodePrinter.swift
+++ b/Sources/GenActors/CodePrinter.swift
@@ -53,6 +53,10 @@ struct CodePrinter {
         self.indentation += 1
     }
 
+    mutating func indent(by amount: Int) {
+        self.indentation += amount
+    }
+
     mutating func outdent() {
         guard self.indentation > 0 else {
             return

--- a/Tests/DistributedActorsDocumentationTests/Actorable/GenActors/InvokeFuncs+GenActor.swift
+++ b/Tests/DistributedActorsDocumentationTests/Actorable/GenActors/InvokeFuncs+GenActor.swift
@@ -66,7 +66,8 @@ extension InvokeFuncs {
                             case .failure(let error):
                                 _replyTo.tell(.failure(ErrorEnvelope(error)))
                             }
-                        } 
+                        }
+ 
                 case .internalTask(let _replyTo):
                     let result = instance.internalTask()
                     _replyTo.tell(result)

--- a/Tests/DistributedActorsTests/Actorable/GenActors/OwnerOfThings+GenActor.swift
+++ b/Tests/DistributedActorsTests/Actorable/GenActors/OwnerOfThings+GenActor.swift
@@ -60,7 +60,8 @@ extension OwnerOfThings {
                             case .failure(let error):
                                 _replyTo.tell(.failure(ErrorEnvelope(error)))
                             }
-                        } 
+                        }
+ 
                 case .performAskLookup(let _replyTo):
                     instance.performAskLookup()
                         ._onComplete { res in
@@ -70,7 +71,8 @@ extension OwnerOfThings {
                             case .failure(let error):
                                 _replyTo.tell(.failure(ErrorEnvelope(error)))
                             }
-                        } 
+                        }
+ 
                 case .performSubscribe(let p):
                     instance.performSubscribe(p: p)
  

--- a/Tests/GenActorsTests/TestActorable/GenActors/TestActorable+GenActor.swift
+++ b/Tests/GenActorsTests/TestActorable/GenActors/TestActorable+GenActor.swift
@@ -97,8 +97,8 @@ extension TestActorable {
  
                 case .greetReplyToReturnStrictThrowing(let name, let _replyTo):
                     do {
-                    let result = try instance.greetReplyToReturnStrictThrowing(name: name)
-                    _replyTo.tell(.success(result))
+                        let result = try instance.greetReplyToReturnStrictThrowing(name: name)
+                        _replyTo.tell(.success(result))
                     } catch {
                         context.log.warning("Error thrown while handling [\(message)], error: \(error)")
                         _replyTo.tell(.failure(ErrorEnvelope(error)))
@@ -117,7 +117,8 @@ extension TestActorable {
                             case .failure(let error):
                                 _replyTo.tell(.failure(ErrorEnvelope(error)))
                             }
-                        } 
+                        }
+ 
                 case .becomeStopped:
                     return /*become*/ instance.becomeStopped()
  


### PR DESCRIPTION
Motivation: 
See https://github.com/apple/swift-distributed-actors/issues/528

Modifications:
Use `CodePrinter` everywhere and remove FIXMEs

Result:
Resolves https://github.com/apple/swift-distributed-actors/issues/528
