### PR TITLE
=mac,test Fix ActorShell memory usage test (went down by the defer re…

### DIFF
--- a/Tests/DistributedActorsTests/ActorMemoryTests.swift
+++ b/Tests/DistributedActorsTests/ActorMemoryTests.swift
@@ -24,8 +24,8 @@ final class ActorMemoryTests: XCTestCase {
 
     func test_osx_actorShell_instanceSize() {
         #if os(OSX)
-        class_getInstanceSize(ActorShell<Int>.self).shouldEqual(520) // FIXME: make it back to 480 or smaller
-        class_getInstanceSize(ActorShell<String>.self).shouldEqual(520) // FIXME: make it back to 480 or smaller
+        class_getInstanceSize(ActorShell<Int>.self).shouldEqual(512) // FIXME: make it back to 480 or smaller
+        class_getInstanceSize(ActorShell<String>.self).shouldEqual(512) // FIXME: make it back to 480 or smaller
         #else
         print("Skipping test_osx_actorShell_instanceSize as requires Objective-C runtime")
         #endif


### PR DESCRIPTION
Forgot to amend the test during https://github.com/apple/swift-distributed-actors/pull/582 since the test only runs on Mac.

Fixes the actor shell size to adjust for the removal for the deferred functions container.