### PR TITLE
Fix integer deserialization

### DIFF
--- a/Sources/DistributedActors/Serialization/Serialization+PrimitiveSerializers.swift
+++ b/Sources/DistributedActors/Serialization/Serialization+PrimitiveSerializers.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2018-2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2018-2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -39,7 +39,6 @@ internal class StringSerializer: Serializer<String> {
     override func deserialize(from buffer: Serialization.Buffer) throws -> String {
         switch buffer {
         case .data(let data):
-            // FIXME: required? or just throw error?
             guard let s = String(data: data, encoding: .utf8) else {
                 throw SerializationError.notAbleToDeserialize(hint: String(reflecting: String.self))
             }
@@ -73,8 +72,7 @@ internal class IntegerSerializer<Number: FixedWidthInteger>: Serializer<Number> 
     override func deserialize(from buffer: Serialization.Buffer) throws -> Number {
         switch buffer {
         case .data(let data):
-            // FIXME: required? or just throw error?
-            return data.withUnsafeBytes { $0.load(as: Number.self) }
+            return Number(bigEndian: data.withUnsafeBytes { $0.load(as: Number.self) })
         case .nioByteBuffer(let buffer):
             guard let i = buffer.getInteger(at: 0, endianness: .big, as: Number.self) else {
                 throw SerializationError.notAbleToDeserialize(hint: "\(buffer) as \(Number.self)")
@@ -102,7 +100,6 @@ internal class BoolSerializer: Serializer<Bool> {
     override func deserialize(from buffer: Serialization.Buffer) throws -> Bool {
         switch buffer {
         case .data(let data):
-            // FIXME: required? or just throw error?
             let i = data.withUnsafeBytes { $0.load(as: Int8.self) }
             return i == 1
         case .nioByteBuffer(let buffer):

--- a/Tests/DistributedActorsTests/SerializationTests.swift
+++ b/Tests/DistributedActorsTests/SerializationTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Distributed Actors open source project
 //
-// Copyright (c) 2018-2019 Apple Inc. and the Swift Distributed Actors project authors
+// Copyright (c) 2018-2020 Apple Inc. and the Swift Distributed Actors project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -48,6 +48,26 @@ class SerializationTests: ActorSystemTestBase {
         }
 
         buf.shouldEqual(out)
+    }
+
+    func test_serialize_Int_withData() throws {
+        let value: Int = 6
+
+        let serialized = try system.serialization.serialize(value)
+        // Deserialize from `Data`
+        let deserialized = try system.serialization.deserialize(as: Int.self, from: .data(serialized.buffer.readData()), using: serialized.manifest)
+
+        deserialized.shouldEqual(value)
+    }
+
+    func test_serialize_Bool_withData() throws {
+        let value: Bool = true
+
+        let serialized = try system.serialization.serialize(value)
+        // Deserialize from `Data`
+        let deserialized = try system.serialization.deserialize(as: Bool.self, from: .data(serialized.buffer.readData()), using: serialized.manifest)
+
+        deserialized.shouldEqual(value)
     }
 
     // ==== ------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Motivation:
https://github.com/apple/swift-distributed-actors/issues/588

Modification:
Ensure to use big endian as well when deserialing from `Data`

Result:
Resolves https://github.com/apple/swift-distributed-actors/issues/588
