### PR TITLE
=test #615 Less intense test_interceptor_shouldSurviveDeeplyNestedInt…

### DIFF
--- a/Tests/DistributedActorsTests/InterceptorTests.swift
+++ b/Tests/DistributedActorsTests/InterceptorTests.swift
@@ -99,15 +99,16 @@ final class InterceptorTests: ActorSystemTestBase {
             return .intercept(behavior: behavior, with: makeStringsLouderInterceptor)
         }
 
+        let depth = 50
         let ref: ActorRef<String> = try system.spawn(
             "theWallsHaveEars",
-            interceptionInceptionBehavior(currentDepth: 0, stopAt: 100)
+            interceptionInceptionBehavior(currentDepth: 0, stopAt: depth)
         )
 
         ref.tell("hello")
 
-        try p.expectMessage("received:hello!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-        for j in 0 ... 100 {
+        try p.expectMessage("received:hello!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+        for j in 0 ... depth {
             let m = "from-interceptor:hello\(String(repeating: "!", count: j))"
             try i.expectMessage(m)
         }


### PR DESCRIPTION
…erceptors to keep happy under ASAN

### Motivation:

Test is a bit over the top with it's nesting. Surviving 50 nestings is plenty.

(failing at 255 depth)

For reference, the nesting (in debug mode):


```

    #5 0x1113d500e in ActorRef.tell(_:file:line:) Refs.swift:73
    #6 0x1117809f3 in ActorTestProbe.tell(_:file:line:) TestProbes.swift:481
    #7 0x1122f556d in ShoutingInterceptor.interceptMessage(target:context:message:) InterceptorTests.swift:28
    #8 0x1122f6961 in vtable thunk for Interceptor.interceptMessage(target:context:message:) dispatching to ShoutingInterceptor.interceptMessage(target:context:message:) <compiler-generated>
    #9 0x11091415f in static Interceptor.handleMessage(context:behavior:interceptor:message:) Behaviors.swift:420
    #10 0x11090dedd in Behavior.interpretMessage(context:message:file:line:) Behaviors.swift:468
    #11 0x1122f56df in ShoutingInterceptor.interceptMessage(target:context:message:) InterceptorTests.swift:29
    #12 0x1122f6961 in vtable thunk for Interceptor.interceptMessage(target:context:message:) dispatching to ShoutingInterceptor.interceptMessage(target:context:message:) <compiler-generated>
    #13 0x11091415f in static Interceptor.handleMessage(context:behavior:interceptor:message:) Behaviors.swift:420
    #14 0x11090dedd in Behavior.interpretMessage(context:message:file:line:) Behaviors.swift:468
    #15 0x1122f56df in ShoutingInterceptor.interceptMessage(target:context:message:) InterceptorTests.swift:29
    #16 0x1122f6961 in vtable thunk for Interceptor.interceptMessage(target:context:message:) dispatching to ShoutingInterceptor.interceptMessage(target:context:message:) <compiler-generated>
    #17 0x11091415f in static Interceptor.handleMessage(context:behavior:interceptor:message:) Behaviors.swift:420
    #18 0x11090dedd in Behavior.interpretMessage(context:message:file:line:) Behaviors.swift:468
    #19 0x1122f56df in ShoutingInterceptor.interceptMessage(target:context:message:) InterceptorTests.swift:29
```

it does not fail in debug or release (which likely cuts some frames as well).

If we really needed to we could make it survive arbitrary depth, but I'd delay until there's actual reason to support insane nesting here. I'd argue it's programmer error if we ever end up with such deep nesting.

### Modifications:

- modify test, no need to push it so hard in the test

### Result:

- Resolves #615 FAILED: stack overflow with ASan in DistributedActorsTests.InterceptorTests test_interceptor_shouldSurviveDeeplyNestedInterceptors 
