### PR TITLE
=actorable,gen #404 nested type before funcs would break GenActors

### DIFF
--- a/Docs/actorables.adoc
+++ b/Docs/actorables.adoc
@@ -216,7 +216,7 @@ In other words, we have to define a special boxing methods in the protocols. If 
 asking us to provide the function declaration (without implementing it, as that is generated) to our protocol(s):
 
 ----
-[gen-actors] Actorable protocol [CoffeeMachine] MUST define a boxing function, in order to be adopted by other Actorables!
+Actorable protocol [CoffeeMachine] MUST define a boxing function, in order to be adopted by other Actorables!
 Please define a static boxing function in [CoffeeMachine]:
 
     static func _boxCoffeeMachine(_ message: GeneratedActor.Messages.CoffeeMachine) -> Self.Message

--- a/Package.swift
+++ b/Package.swift
@@ -46,9 +46,11 @@ var targets: [PackageDescription.Target] = [
         dependencies: [
             "DistributedActors",
             .product(name: "SwiftSyntax", package: "SwiftSyntax"),
-            .product(name: "Stencil", package: "Stencil"),
-            .product(name: "Files", package: "Files"),
+            .product(name: "Logging", package: "swift-log"),
             .product(name: "ArgumentParser", package: "swift-argument-parser"),
+
+            .product(name: "Stencil", package: "Stencil"), // TODO: remove this dependency
+            .product(name: "Files", package: "Files"), // TODO: remove this dependency
         ]
     ),
 

--- a/Tests/DistributedActorsTests/Actorable/OwnerOfThings.swift
+++ b/Tests/DistributedActorsTests/Actorable/OwnerOfThings.swift
@@ -15,6 +15,10 @@
 import DistributedActors
 
 struct OwnerOfThings: Actorable {
+    enum Hello {
+        case breaksCodeGen
+    }
+
     let context: Myself.Context
     let ownedListing: ActorableOwned<Reception.Listing<OwnerOfThings>>!
 


### PR DESCRIPTION
### Motivation:

Codegen did not handle well if there was another type declared in an Actorable _before_ functions were. We'd nil out the currently built wipActorable and this way the functions ended up in limbo and not rendered at all.

This adds no test, but compilation itself "is" the test -- with such enum the codegen would be wrong and the existing sources using this type would not compile anymore.

### Modifications:

- be more smart when to "reset and store" a completed actorable after visiting it

### Result:

- Resolves #404

