### PR TITLE
=actor,init Receptionist may have gotten deadLetters rather than NodeDeathWatcher

### DIFF
--- a/Sources/DistributedActors/ActorShell.swift
+++ b/Sources/DistributedActors/ActorShell.swift
@@ -149,13 +149,7 @@ public final class ActorShell<Message: ActorMessage>: ActorContext<Message>, Abs
         self._props = props
 
         self.supervisor = Supervision.supervisorFor(system, initialBehavior: behavior, props: props.supervision)
-
-        if let nodeDeathWatcher = system._nodeDeathWatcher {
-            self._deathWatch = DeathWatch(nodeDeathWatcher: nodeDeathWatcher)
-        } else {
-            // FIXME; we could see if `myself` is the right one actually... rather than dead letters; if we know the FIRST actor ever is the failure detector one?
-            self._deathWatch = DeathWatch(nodeDeathWatcher: system.deadLetters.adapted())
-        }
+        self._deathWatch = DeathWatch(nodeDeathWatcher: system._nodeDeathWatcher ?? system.deadLetters.adapted())
 
         self.namingContext = ActorNamingContext()
 

--- a/Sources/DistributedActors/Cluster/ClusterShellState.swift
+++ b/Sources/DistributedActors/Cluster/ClusterShellState.swift
@@ -214,7 +214,13 @@ extension ClusterShellState {
         self.log.trace("Aborting INBOUND handshake channel: \(channel)")
 
         channel.close().whenFailure { [log = self.log, metadata = self.metadata] error in
-            log.warning("Failed to abortIncomingHandshake (close) channel [\(channel)], error: \(error)", metadata: metadata)
+            switch error {
+            case ChannelError.alreadyClosed:
+                // this is less severe and we should not warn about it; most often it's just a race of closes when we're racing both sides connecting.
+                log.debug("Channel already closed [\(channel)], error: \(error)", metadata: metadata)
+            default:
+                log.warning("Failed to close channel [\(channel)], error: \(error)", metadata: metadata)
+            }
         }
     }
 

--- a/Sources/DistributedActors/Cluster/SWIM/SWIMShell.swift
+++ b/Sources/DistributedActors/Cluster/SWIM/SWIMShell.swift
@@ -245,7 +245,11 @@ internal struct SWIMShell {
                     ]
                 )
             } else {
-                context.log.warning("\(err) Did not receive ack from \(reflecting: pingedMember.address) within configured timeout. Sending ping requests to other members.")
+                context.log.debug(
+                    """
+                    Did not receive ack from \(reflecting: pingedMember.address) within configured timeout. \
+                    Sending ping requests to other members. Error: \(err)
+                    """)
             }
             if let pingReqOrigin = pingReqOrigin {
                 self.swim.adjustLHMultiplier(.probeWithMissedNack)

--- a/Sources/DistributedActors/DeadLetters.swift
+++ b/Sources/DistributedActors/DeadLetters.swift
@@ -42,7 +42,6 @@ public struct DeadLetter: NonTransportableActorMessage { // TODO: make it also r
     let sentAtFile: String?
     let sentAtLine: UInt?
 
-    // TODO: could be under a flag if we do carry the file/line or not?
     public init(_ message: Any, recipient: ActorAddress?, sentAtFile: String? = nil, sentAtLine: UInt? = nil) {
         self.message = message
         self.recipient = recipient


### PR DESCRIPTION
### Motivation:

We had a wrong initialization order here, resulting in the receptionist starting and needing to use the clustered node death watcher -- yet that one was started _after_ the receptionist.

This could result in the deathwatcher not performing its duties, for the receptionist as well as dead letters on system init.

### Modifications:

- the initialization order of system actors is very important and this fixes it
 - first node death watcher, then anything that follows
- some logging lessening

### Result:

- more correct receptionist and in general actors watching remote actors