### PR TITLE
=test #575 harden test_clusterReceptionist_shouldRemoveActorsOfTerminatedN…

### DIFF
--- a/Sources/DistributedActors/Cluster/ClusterShell.swift
+++ b/Sources/DistributedActors/Cluster/ClusterShell.swift
@@ -154,7 +154,7 @@ internal class ClusterShell {
         }
 
         guard let removedAssociation = removedAssociationOption else {
-            system.log.warning("Attempted to terminate non-existing association [\(reflecting: remoteNode)].")
+            system.log.debug("Attempted to terminate non-existing association [\(reflecting: remoteNode)].")
             return
         }
 

--- a/Sources/DistributedActorsTestKit/TestProbes+Receptionist.swift
+++ b/Sources/DistributedActorsTestKit/TestProbes+Receptionist.swift
@@ -26,12 +26,16 @@ extension ActorTestProbe where Message == Receptionist.Listing<String> {
         expected: Set<ActorRef<String>>, within timeout: TimeAmount,
         file: StaticString = #file, line: UInt = #line, column: UInt = #column
     ) throws {
-        let listing = try self.fishForMessages(within: timeout, file: file, line: line) {
-            if $0.refs.count == expected.count { return .catchComplete }
-            else { return .ignore }
-        }.first!
+        do {
+            let listing = try self.fishForMessages(within: timeout, file: file, line: line) {
+                if $0.refs.count == expected.count { return .catchComplete }
+                else { return .ignore }
+            }.first!
 
-        // TODO: not super efficient, rework eventually
-        listing.refs.map { $0.path }.sorted().shouldEqual(expected.map { $0.address.path }.sorted(), file: file, line: line, column: column)
+            // TODO: not super efficient, rework eventually
+            listing.refs.map { $0.path }.sorted().shouldEqual(expected.map { $0.address.path }.sorted(), file: file, line: line, column: column)
+        } catch {
+            throw self.error("Expected \(expected), error: \(error)", file: file, line: line)
+        }
     }
 }

--- a/Tests/DistributedActorsTests/Cluster/Reception/OpLogClusterReceptionistClusteredTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/Reception/OpLogClusterReceptionistClusteredTests.swift
@@ -302,7 +302,7 @@ final class OpLogClusterReceptionistClusteredTests: ClusteredNodesTestBase {
             try p2.eventuallyExpectListing(expected: [firstRef, secondRef], within: .seconds(3))
 
             // crash the second node
-            second.shutdown()
+            second.shutdown().wait()
 
             // it should be removed from all listings; on both nodes, for all keys
             try p1.eventuallyExpectListing(expected: [firstRef], within: .seconds(5))


### PR DESCRIPTION
Seems like only a timing issue, could not spot anything very wrong in logs, esp after the latest reworks in cluster.

Let's see tho.

Resolves https://github.com/apple/swift-distributed-actors/issues/575