### PR TITLE
=test #435 hardening test_singletonByClusterLeadership_withLeaderChange

### DIFF
--- a/Sources/DistributedActors/ActorSystem.swift
+++ b/Sources/DistributedActors/ActorSystem.swift
@@ -97,6 +97,11 @@ public final class ActorSystem {
         self._metrics
     }
 
+    // TODO: become the system's uptime
+    internal func uptimeNanoseconds() -> Int64 {
+        Deadline.now().uptimeNanoseconds
+    }
+
     // ==== ----------------------------------------------------------------------------------------------------------------
     // MARK: Cluster
 

--- a/Sources/DistributedActorsTestKit/Cluster/ClusteredActorSystemsXCTestCase.swift
+++ b/Sources/DistributedActorsTestKit/Cluster/ClusteredActorSystemsXCTestCase.swift
@@ -141,14 +141,14 @@ open class ClusteredActorSystemsXCTestCase: XCTestCase {
     }
 
     public func ensureNodes(
-        _ status: Cluster.MemberStatus, on system: ActorSystem? = nil, within: TimeAmount = .seconds(15), nodes: UniqueNode...,
+        _ status: Cluster.MemberStatus, on system: ActorSystem? = nil, within: TimeAmount = .seconds(20), nodes: UniqueNode...,
         file: StaticString = #file, line: UInt = #line
     ) throws {
         try self.ensureNodes(status, on: system, within: within, nodes: nodes, file: file, line: line)
     }
 
     public func ensureNodes(
-        _ status: Cluster.MemberStatus, on system: ActorSystem? = nil, within: TimeAmount = .seconds(15), nodes: [UniqueNode],
+        _ status: Cluster.MemberStatus, on system: ActorSystem? = nil, within: TimeAmount = .seconds(20), nodes: [UniqueNode],
         file: StaticString = #file, line: UInt = #line
     ) throws {
         guard let onSystem = system ?? self._nodes.first(where: { !$0.isShuttingDown }) else {


### PR DESCRIPTION
It seems the failures are nit really failures of the singleton impl, but hitting slowness on the joining:

```
00:08:24.039 error: No result within 15s for block at /code/Tests/ActorSingletonPluginTests/ActorSingletonPluginClusteredTests.swift:207. Queried 147 times, within 15s. Last error: 
00:08:24.039             try self.ensureNodes(.up, on: second, nodes: fourth.cluster.node, second.cluster.node, third.cluster.node)
00:08:24.039                          ^~~~~~
00:08:24.039 error: Expected sact://fourth:1412707459@127.0.0.1:7444 on sact://second:4182240610@127.0.0.1:8222 to be seen as: [up], but was [joining]
```

Adding more logging to test_singletonByClusterLeadership_withLeaderChange.
Also measuring if we're actually dropping messages or not, that's quite good to know (in my testing so far we never dropped (a drop _is_ legal here in some situations)).

Having that said, there will be more testing and optimizing the join speed which would also harden and speed up these.

- Resolves #435