### PR TITLE
=log No more dead letters on system init when local only mode

### DIFF
--- a/Sources/DistributedActors/ActorSystemSettings.swift
+++ b/Sources/DistributedActors/ActorSystemSettings.swift
@@ -78,6 +78,8 @@ public struct LoggingSettings {
         }
     }
 
+    /// "Base" logger that will be used as template for all loggers created by the system (e.g. for `context.log` offered to actors).
+    /// This may be used to configure specific systems to log to specific files, or to carry system-wide metadata throughout all loggers the actor system will use.
     public var logger: Logger = LoggingSettings.makeDefaultLogger()
 
     static func makeDefaultLogger() -> Logger {

--- a/Sources/DistributedActors/DeadLetters.swift
+++ b/Sources/DistributedActors/DeadLetters.swift
@@ -42,12 +42,22 @@ public struct DeadLetter: NonTransportableActorMessage { // TODO: make it also r
     let sentAtFile: String?
     let sentAtLine: UInt?
 
+    #if DEBUG
+    public init(_ message: Any, recipient: ActorAddress?, sentAtFile: String? = #file, sentAtLine: UInt? = #line) {
+        self.message = message
+        self.recipient = recipient
+        self.sentAtFile = sentAtFile
+        self.sentAtLine = sentAtLine
+    }
+
+    #else
     public init(_ message: Any, recipient: ActorAddress?, sentAtFile: String? = nil, sentAtLine: UInt? = nil) {
         self.message = message
         self.recipient = recipient
         self.sentAtFile = sentAtFile
         self.sentAtLine = sentAtLine
     }
+    #endif
 }
 
 /// // Marker protocol used as `Message` type when a resolve fails to locate an actor given an address.
@@ -212,16 +222,16 @@ public final class DeadLetterOffice {
             return
         }
 
+        // TODO: more metadata (from Envelope) (e.g. sender)
+        metadata["deadLetter/location"] = "\(file):\(line)"
+
         // in all other cases, we want to log the dead letter:
-        // TODO: more metadata (from Envelope)
         self.log.info(
             """
             Dead letter: [\(deadLetter.message)]:\(String(reflecting: type(of: deadLetter.message))) was not delivered \
             \(recipientString).
             """,
-            metadata: metadata,
-            file: file,
-            line: line
+            metadata: metadata
         )
     }
 

--- a/Sources/DistributedActors/EventStream.swift
+++ b/Sources/DistributedActors/EventStream.swift
@@ -30,7 +30,9 @@ public struct EventStream<Event: ActorMessage> {
     }
 
     internal init(
-        _ system: ActorSystem, name: String, of type: Event.Type = Event.self,
+        _ system: ActorSystem,
+        name: String,
+        of type: Event.Type = Event.self,
         systemStream: Bool,
         customBehavior: Behavior<EventStreamShell.Message<Event>>? = nil
     ) throws {
@@ -42,16 +44,16 @@ public struct EventStream<Event: ActorMessage> {
         }
     }
 
-    public func subscribe(_ ref: ActorRef<Event>) {
-        self.ref.tell(.subscribe(ref))
+    public func subscribe(_ ref: ActorRef<Event>, file: String = #file, line: UInt = #line) {
+        self.ref.tell(.subscribe(ref), file: file, line: line)
     }
 
-    public func unsubscribe(_ ref: ActorRef<Event>) {
-        self.ref.tell(.unsubscribe(ref))
+    public func unsubscribe(_ ref: ActorRef<Event>, file: String = #file, line: UInt = #line) {
+        self.ref.tell(.unsubscribe(ref), file: file, line: line)
     }
 
     public func publish(_ event: Event, file: String = #file, line: UInt = #line) {
-        self.ref.tell(.publish(event))
+        self.ref.tell(.publish(event), file: file, line: line)
     }
 }
 


### PR DESCRIPTION
### Motivation:

We used to get 

`Captured log [ClusterEventStreamTests][2020-06-18 12:43:46.4680] [DeadLetters.swift:228][/dead/letters] [info] Dead letter: [subscribe(ActorRef<Cluster.Event>(/system/receptionist/$sub-DistributedActors.Cluster.Event-y))]:DistributedActors.EventStreamShell.Message<DistributedActors.Cluster.Event> was not delivered to ["/dead/letters"].`

on system startup when in local mode I just realized.

### Modifications:

- always spawn the event stream; it still makes sense even if 1 node. We'd get the joining snapshot and that's it.

### Result:

- no more dead letters for no reason