### PR TITLE
!testkit make testkit more consistent in "pretty" printing

### DIFF
--- a/Sources/DistributedActorsTestKit/LogCapture.swift
+++ b/Sources/DistributedActorsTestKit/LogCapture.swift
@@ -110,6 +110,8 @@ extension LogCapture {
                 }
 
                 metadata.removeValue(forKey: "label")
+                metadata.removeValue(forKey: "actor/node")
+                metadata.removeValue(forKey: "actor/nodeName")
                 if !metadata.isEmpty {
                     metadataString = "\n// metadata:\n"
                     for key in metadata.keys.sorted() {
@@ -315,7 +317,7 @@ extension LogCapture {
             """
             let callSiteError = callSite.error(message)
             if failTest {
-                XCTAssert(false, message, file: callSite.file, line: callSite.line)
+                XCTFail(message, file: callSite.file, line: callSite.line)
             }
             throw callSiteError
         }

--- a/Sources/DistributedActorsTestKit/ShouldMatchers.swift
+++ b/Sources/DistributedActorsTestKit/ShouldMatchers.swift
@@ -35,27 +35,33 @@ public struct TestMatchers<T> {
 
     func toBe<T>(_ expected: T.Type) {
         if !(self.it is T) {
-            let msg = self.callSite.detailedMessage(got: self.it, expected: expected)
-            XCTAssert(false, msg, file: self.callSite.file, line: self.callSite.line)
+            let error = self.callSite.notEqualError(got: self.it, expected: expected)
+            XCTFail("\(error)", file: self.callSite.file, line: self.callSite.line)
         }
     }
 }
 
 public extension TestMatchers where T: Equatable {
     func toEqual(_ expected: T) {
-        let msg = self.callSite.detailedMessage(got: self.it, expected: expected)
-        XCTAssertEqual(self.it, expected, msg, file: self.callSite.file, line: self.callSite.line)
+        if self.it != expected {
+            let error = self.callSite.notEqualError(got: self.it, expected: expected)
+            XCTAssertEqual(self.it, expected, "\(error)", file: self.callSite.file, line: self.callSite.line)
+            XCTFail("\(error)", file: self.callSite.file, line: self.callSite.line)
+        }
     }
 
     func toNotEqual(_ unexpectedEqual: T) {
-        let msg = self.callSite.detailedMessage(got: self.it, unexpectedEqual: unexpectedEqual)
-        XCTAssertNotEqual(self.it, unexpectedEqual, msg, file: self.callSite.file, line: self.callSite.line)
+        if self.it == unexpectedEqual {
+            let error = self.callSite.equalError(got: self.it, unexpectedEqual: unexpectedEqual)
+            XCTAssertNotEqual(self.it, unexpectedEqual, "\(error)", file: self.callSite.file, line: self.callSite.line)
+            XCTFail("\(error)", file: self.callSite.file, line: self.callSite.line)
+        }
     }
 
     func toBe<Other>(_ expected: Other.Type) {
         if !(self.it is Other) {
-            let msg = self.callSite.detailedMessage(got: self.it, expected: expected)
-            XCTAssert(false, msg, file: self.callSite.file, line: self.callSite.line)
+            let error = self.callSite.notEqualError(got: self.it, expected: expected)
+            XCTFail("\(error)", file: self.callSite.file, line: self.callSite.line)
         }
     }
 }
@@ -70,7 +76,7 @@ public extension TestMatchers where T: Collection, T.Element: Equatable {
             let partialMatch = self.it.commonPrefix(with: prefix)
 
             // classic printout without prefix matching:
-            // let msg = self.callSite.detailedMessage("Expected [\(it)] to start with prefix: [\(prefix)]. " + partialMatchMessage)
+            // let error = self.callSite.error("Expected [\(it)] to start with prefix: [\(prefix)]. " + partialMatchMessage)
 
             // fancy printout:
             var m = "Expected "
@@ -88,8 +94,8 @@ public extension TestMatchers where T: Collection, T.Element: Equatable {
             m += "\(prefix.dropFirst(partialMatch.underestimatedCount))]."
             if isTty { m += " (Matching sub-prefix marked in \(ANSIColors.bold.rawValue)bold\(ANSIColors.reset.rawValue)\(ANSIColors.red.rawValue))" }
 
-            let msg = self.callSite.detailedMessage(m)
-            XCTAssert(false, msg, file: self.callSite.file, line: self.callSite.line)
+            let error = self.callSite.error(m)
+            XCTFail("\(error)", file: self.callSite.file, line: self.callSite.line)
         }
     }
 
@@ -106,8 +112,8 @@ public extension TestMatchers where T: Collection, T.Element: Equatable {
             if isTty { m += "\(ANSIColors.reset.rawValue)\(ANSIColors.red.rawValue)" }
             m += "]"
 
-            let msg = self.callSite.detailedMessage(m)
-            XCTAssert(false, msg, file: self.callSite.file, line: self.callSite.line)
+            let error = self.callSite.error(m)
+            XCTFail("\(error)", file: self.callSite.file, line: self.callSite.line)
         }
     }
 
@@ -123,8 +129,8 @@ public extension TestMatchers where T: Collection, T.Element: Equatable {
             if isTty { m += "\(ANSIColors.reset.rawValue)\(ANSIColors.red.rawValue)" }
             m += "]"
 
-            let msg = self.callSite.detailedMessage(m)
-            XCTAssert(false, msg, file: self.callSite.file, line: self.callSite.line)
+            let error = self.callSite.error(m)
+            XCTFail("\(error)", file: self.callSite.file, line: self.callSite.line)
         }
     }
 
@@ -134,8 +140,8 @@ public extension TestMatchers where T: Collection, T.Element: Equatable {
             // fancy printout:
             let m = "Expected [\(it)] to contain element matching predicate"
 
-            let msg = self.callSite.detailedMessage(m)
-            XCTAssert(false, msg, file: self.callSite.file, line: self.callSite.line)
+            let error = self.callSite.error(m)
+            XCTFail("\(error)", file: self.callSite.file, line: self.callSite.line)
         }
     }
 }
@@ -153,8 +159,8 @@ public extension TestMatchers where T == String {
             if isTty { m += "\(ANSIColors.reset.rawValue)\(ANSIColors.red.rawValue)" }
             m += "]"
 
-            let msg = self.callSite.detailedMessage(m)
-            XCTAssert(false, msg, file: self.callSite.file, line: self.callSite.line)
+            let error = self.callSite.error(m)
+            XCTFail("\(error)", file: self.callSite.file, line: self.callSite.line)
         }
     }
 
@@ -166,23 +172,35 @@ public extension TestMatchers where T == String {
 
 public extension TestMatchers where T: Comparable {
     func toBeLessThan(_ expected: T) {
-        let msg = self.callSite.detailedMessage("\(self.it) is not less than \(expected)")
-        XCTAssertLessThan(self.it, expected, msg, file: self.callSite.file, line: self.callSite.line)
+        if !(self.it < expected) {
+            let error = self.callSite.error("\(self.it) is not less than \(expected)")
+            XCTAssertLessThan(self.it, expected, "\(error)", file: self.callSite.file, line: self.callSite.line)
+            XCTFail("\(error)", file: self.callSite.file, line: self.callSite.line)
+        }
     }
 
     func toBeLessThanOrEqual(_ expected: T) {
-        let msg = self.callSite.detailedMessage("\(self.it) is not less than or equal \(expected)")
-        XCTAssertLessThanOrEqual(self.it, expected, msg, file: self.callSite.file, line: self.callSite.line)
+        if !(self.it <= expected) {
+            let error = self.callSite.error("\(self.it) is not less than or equal \(expected)")
+            XCTAssertLessThanOrEqual(self.it, expected, "\(error)", file: self.callSite.file, line: self.callSite.line)
+            XCTFail("\(error)", file: self.callSite.file, line: self.callSite.line)
+        }
     }
 
     func toBeGreaterThan(_ expected: T) {
-        let msg = self.callSite.detailedMessage("\(self.it) is not greater than \(expected)")
-        XCTAssertGreaterThan(self.it, expected, msg, file: self.callSite.file, line: self.callSite.line)
+        if !(self.it > expected) {
+            let error = self.callSite.error("\(self.it) is not greater than \(expected)")
+            XCTAssertGreaterThan(self.it, expected, "\(error)", file: self.callSite.file, line: self.callSite.line)
+            XCTFail("\(error)", file: self.callSite.file, line: self.callSite.line)
+        }
     }
 
     func toBeGreaterThanOrEqual(_ expected: T) {
-        let msg = self.callSite.detailedMessage("\(self.it) is not greater than or equal \(expected)")
-        XCTAssertGreaterThanOrEqual(self.it, expected, msg, file: self.callSite.file, line: self.callSite.line)
+        if !(self.it >= expected) {
+            let error = self.callSite.error("\(self.it) is not greater than or equal \(expected)")
+            XCTAssertGreaterThanOrEqual(self.it, expected, "\(error)", file: self.callSite.file, line: self.callSite.line)
+            XCTFail("\(error)", file: self.callSite.file, line: self.callSite.line)
+        }
     }
 }
 
@@ -192,8 +210,8 @@ public extension TestMatchers where T: Collection {
         if !self.it.isEmpty {
             let m = "Expected [\(it)] to be empty"
 
-            let msg = self.callSite.detailedMessage(m)
-            XCTAssert(false, msg, file: self.callSite.file, line: self.callSite.line)
+            let error = self.callSite.error(m)
+            XCTFail("\(error)", file: self.callSite.file, line: self.callSite.line)
         }
     }
 
@@ -202,8 +220,8 @@ public extension TestMatchers where T: Collection {
         if self.it.isEmpty {
             let m = "Expected [\(it)] to to be non-empty"
 
-            let msg = self.callSite.detailedMessage(m)
-            XCTAssert(false, msg, file: self.callSite.file, line: self.callSite.line)
+            let error = self.callSite.error(m)
+            XCTFail("\(error)", file: self.callSite.file, line: self.callSite.line)
         }
     }
 }
@@ -219,15 +237,21 @@ private extension Collection where Element: Equatable {
 
 extension Optional {
     public func shouldBeNil(file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
-        let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
-        let msg = callSite.detailedMessage("Expected nil, got [\(String(describing: self))]")
-        XCTAssertNil(self, msg, file: callSite.file, line: callSite.line)
+        if self != nil {
+            let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
+            let error = callSite.error("Expected nil, got [\(String(describing: self))]")
+            XCTAssertNil(self, "\(error)", file: callSite.file, line: callSite.line)
+            XCTFail("\(error)", file: callSite.file, line: callSite.line)
+        }
     }
 
     public func shouldNotBeNil(file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
-        let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
-        let msg = callSite.detailedMessage("Expected not nil, got [\(String(describing: self))]")
-        XCTAssertNotNil(self, msg, file: callSite.file, line: callSite.line)
+        if self == nil {
+            let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
+            let error = callSite.error("Expected not nil, got [\(String(describing: self))]")
+            XCTAssertNotNil(self, "\(error)", file: callSite.file, line: callSite.line)
+            XCTFail("\(error)", file: callSite.file, line: callSite.line)
+        }
     }
 }
 
@@ -253,8 +277,7 @@ extension Set {
             }
 
             XCTFail(
-                callSiteInfo.detailedMessage(
-                    message),
+                "\(callSiteInfo.error(message))",
                 file: callSiteInfo.file,
                 line: callSiteInfo.line
             )
@@ -372,19 +395,20 @@ extension String {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Free `should*` functions
 
-public func shouldThrow<E: Error, T>(expected: E.Type, file: StaticString = #file, line: UInt = #line, column: UInt = #column, _ block: () throws -> T) {
+public func shouldThrow<E: Error, T>(expected: E.Type, file: StaticString = #file, line: UInt = #line, column: UInt = #column, _ block: () throws -> T) throws {
     let callSiteInfo = CallSiteInfo(file: file, line: line, column: column, function: #function)
-    let error = shouldThrow(file: file, line: line, column: column, block)
+    let error = try shouldThrow(file: file, line: line, column: column, block)
 
     guard error is E else {
-        let msg = callSiteInfo.detailedMessage("Expected block to throw [\(expected)], but threw: [\(error)]")
-        XCTFail(msg, file: callSiteInfo.file, line: callSiteInfo.line)
-        fatalError("Failed: \(ShouldMatcherError.expectedErrorToBeThrown)")
+        let error = callSiteInfo.error("Expected block to throw [\(expected)], but threw: [\(error)]")
+        XCTFail("\(error)", file: callSiteInfo.file, line: callSiteInfo.line)
+        throw error
     }
 }
 
+/// If this function throws, the wrapped block did NOT throw.
 @discardableResult
-public func shouldThrow<T>(file: StaticString = #file, line: UInt = #line, column: UInt = #column, _ block: () throws -> T) -> Error {
+public func shouldThrow<T>(file: StaticString = #file, line: UInt = #line, column: UInt = #column, _ block: () throws -> T) throws -> Error {
     let callSiteInfo = CallSiteInfo(file: file, line: line, column: column, function: #function)
     var it: T?
     do {
@@ -393,9 +417,9 @@ public func shouldThrow<T>(file: StaticString = #file, line: UInt = #line, colum
         return error
     }
 
-    let msg = callSiteInfo.detailedMessage("Expected block to throw, but returned: [\(it!)]")
-    XCTFail(msg, file: callSiteInfo.file, line: callSiteInfo.line)
-    fatalError("Failed: \(ShouldMatcherError.expectedErrorToBeThrown)")
+    let error = callSiteInfo.error("Expected block to throw, but returned: [\(it!)]")
+    XCTFail("\(error)", file: callSiteInfo.file, line: callSiteInfo.line)
+    throw error
 }
 
 /// Provides improved error logging in case of an unexpected throw.
@@ -417,29 +441,19 @@ public func shouldThrow<T>(file: StaticString = #file, line: UInt = #line, colum
 /// ```
 ///
 /// Mostly used for debugging what was thrown in a test in a more command line friendly way, e.g. on CI.
-public func shouldNotThrow<T>(file: StaticString = #file, line: UInt = #line, column: UInt = #column, _ block: () throws -> T) rethrows -> T {
+public func shouldNotThrow<T>(file: StaticString = #file, line: UInt = #line, column: UInt = #column, _ block: () throws -> T) throws -> T {
     let callSiteInfo = CallSiteInfo(file: file, line: line, column: column, function: #function)
     do {
         return try block()
     } catch {
-        let msg: String
-        switch error {
-        case let eventuallyError as EventuallyError:
-            msg = callSiteInfo.detailedMessage("Unexpected throw captured") + "\(eventuallyError.message)"
-        case CallSiteError.error(let message):
-            msg = callSiteInfo.detailedMessage("Unexpected throw captured") + "\(message)"
-        default:
-            msg = callSiteInfo.detailedMessage("Unexpected throw captured: [\(error)]")
-        }
-        XCTFail(msg, file: callSiteInfo.file, line: callSiteInfo.line)
-        throw ShouldMatcherError.unexpectedErrorWasThrown
+        XCTFail("\(error)", file: callSiteInfo.file, line: callSiteInfo.line)
+        throw callSiteInfo.error("Should not have thrown, but did:\n" + "\(error)")
     }
 }
 
 public func shouldNotHappen(_ message: String, file: StaticString = #file, line: UInt = #line, column: UInt = #column) -> Error {
     let callSiteInfo = CallSiteInfo(file: file, line: line, column: column, function: #function)
-
-    return callSiteInfo.error("Should not happen! [\(message)]")
+    return callSiteInfo.error("Should not happen: \(message)")
 }
 
 // ==== ----------------------------------------------------------------------------------------------------------------
@@ -450,7 +464,7 @@ public enum ShouldMatcherError: Error {
     case unexpectedErrorWasThrown
 }
 
-struct CallSiteInfo {
+public struct CallSiteInfo {
     let file: StaticString
     let line: UInt
     let column: UInt
@@ -462,65 +476,70 @@ struct CallSiteInfo {
         self.column = column
         self.appliedAssertionName = String(function[function.startIndex ... function.firstIndex(of: "(")!])
     }
+}
 
-    /// Prepares a detailed error information, specialized for two values being equal
-    /// // TODO: DRY this all up
+extension CallSiteInfo {
+    /// Prepares a detailed error, specialized for two values being equal
+    ///
     /// - Warning: Performs file IO in order to read source location line where failure happened
-    func detailedMessage(got it: Any, expected: Any) -> String {
-        let msg = "[\(it)] does not equal expected: [\(expected)]\n"
-        return self.detailedMessage(msg)
+    func notEqualError(got it: Any, expected: Any, failTest: Bool = true) -> CallSiteError {
+        self.error("[\(it)] does not equal expected: [\(expected)]\n", failTest: failTest)
     }
 
-    func detailedMessage(got it: Any, unexpectedEqual: Any) -> String {
-        let msg = "[\(it)] does equal: [\(unexpectedEqual)]\n"
-        return self.detailedMessage(msg)
+    /// - Warning: Performs file IO in order to read source location line where failure happened
+    func equalError(got it: Any, unexpectedEqual: Any, failTest: Bool = true) -> CallSiteError {
+        self.error("[\(it)] does equal: [\(unexpectedEqual)]\n", failTest: failTest)
+    }
+
+    /// Returns an Error that should be thrown by the called.
+    /// The failure contains the passed in message as well as source location of the call site, for easier locating of the issue.
+    public func error(_ message: String, failTest: Bool = true) -> CallSiteError {
+        if failTest, !ActorTestKit.isInRepeatableContext() {
+            XCTFail(message, file: self.file, line: self.line)
+        }
+
+        return CallSiteError(callSite: self, explained: message)
+    }
+}
+
+public struct CallSiteError: Error, CustomStringConvertible {
+    let callSite: CallSiteInfo
+    let explained: String
+
+    public init(callSite: CallSiteInfo, explained: String) {
+        self.callSite = callSite
+
+        self.explained = explained
     }
 
     /// Prepares a detailed error information
     ///
     /// - Warning: Performs file IO in order to read source location line where failure happened
-    func detailedMessage(_ explained: String) -> String {
-        let lines = try! String(contentsOfFile: "\(self.file)")
-            .components(separatedBy: .newlines)
-        let failingLine = lines
-            .dropFirst(Int(self.line - 1))
-            .first!
+    public var description: String {
+        guard isTty else {
+            return self.explained
+        }
 
         var s = ""
+        let lines = try! String(contentsOfFile: "\(self.callSite.file)")
+            .components(separatedBy: .newlines)
+        let failingLine = lines
+            .dropFirst(Int(self.callSite.line - 1))
+            .first!
 
+        s += "\n"
+        s += "\(failingLine)\n"
+        s += "\(String(repeating: " ", count: Int(self.callSite.column) - 1 - self.callSite.appliedAssertionName.count))"
         if isTty {
-            s += "\n"
-            s += "\(failingLine)\n"
-            s += "\(String(repeating: " ", count: Int(self.column) - 1 - self.appliedAssertionName.count))"
-            if isTty {
-                s += ANSIColors.red.rawValue
-            }
-            s += "^\(String(repeating: "~", count: self.appliedAssertionName.count - 1))\n"
-            s += "error: "
-            s += explained
-            s += ANSIColors.reset.rawValue
-        } else {
-            s += explained
+            s += ANSIColors.red.rawValue
         }
+        s += "^\(String(repeating: "~", count: self.callSite.appliedAssertionName.count - 1))\n"
+        s += "error: "
+        s += self.explained
+        s += ANSIColors.reset.rawValue
+
         return s
     }
-}
-
-extension CallSiteInfo {
-    /// Returns an Error that should be thrown by the called.
-    /// The failure contains the passed in message as well as source location of the call site, for easier locating of the issue.
-    public func error(_ message: String, failTest: Bool = true) -> Error {
-        let details = self.detailedMessage(message)
-        if failTest, !ActorTestKit.isInRepeatableContext() {
-            XCTFail(details, file: self.file, line: self.line)
-        }
-
-        return CallSiteError.error(message: details)
-    }
-}
-
-public enum CallSiteError: Error {
-    case error(message: String)
 }
 
 enum ANSIColors: String {

--- a/Sources/DistributedActorsTestKit/TestProbes.swift
+++ b/Sources/DistributedActorsTestKit/TestProbes.swift
@@ -349,7 +349,7 @@ extension ActorTestProbe where Message: Equatable {
             let receivedMessage = try self.receiveMessage(within: timeout)
             self.lastMessage = receivedMessage
             guard receivedMessage == message else {
-                throw callSite.error(callSite.detailedMessage(got: receivedMessage, expected: message))
+                throw callSite.notEqualError(got: receivedMessage, expected: message)
             }
         } catch {
             let message = "Did not receive expected [\(message)]:\(type(of: message)) within [\(timeout.prettyDescription)], error: \(error)"
@@ -367,7 +367,7 @@ extension ActorTestProbe where Message: Equatable {
         let receivedMessage = try self.receiveMessage(within: timeout)
         self.lastMessage = receivedMessage
         guard receivedMessage is T else {
-            throw callSite.error(callSite.detailedMessage(got: receivedMessage, expected: type))
+            throw callSite.notEqualError(got: receivedMessage, expected: type)
         }
     }
 }
@@ -632,7 +632,7 @@ extension ActorTestProbe {
 
         let got: _SystemMessage = try self.expectSignal(file: file, line: line, column: column)
         if got != expected {
-            throw callSite.error(callSite.detailedMessage(got: got, expected: expected))
+            throw callSite.notEqualError(got: got, expected: expected)
         }
     }
 }

--- a/Tests/ActorSingletonPluginTests/ActorSingletonPluginClusteredTests.swift
+++ b/Tests/ActorSingletonPluginTests/ActorSingletonPluginClusteredTests.swift
@@ -27,233 +27,227 @@ final class ActorSingletonPluginClusteredTests: ClusteredActorSystemsXCTestCase 
     }
 
     func test_singletonByClusterLeadership_happyPath() throws {
-        try shouldNotThrow {
-            var singletonSettings = ActorSingletonSettings(name: GreeterSingleton.name)
-            singletonSettings.allocationStrategy = .byLeadership
+        var singletonSettings = ActorSingletonSettings(name: GreeterSingleton.name)
+        singletonSettings.allocationStrategy = .byLeadership
 
-            let first = self.setUpNode("first") { settings in
-                settings += ActorSingletonPlugin()
+        let first = self.setUpNode("first") { settings in
+            settings += ActorSingletonPlugin()
 
-                settings.cluster.node.port = 7111
-                settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
-                settings.serialization.register(GreeterSingleton.Message.self)
-            }
-            let second = self.setUpNode("second") { settings in
-                settings += ActorSingletonPlugin()
-
-                settings.cluster.node.port = 8222
-                settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
-                settings.serialization.register(GreeterSingleton.Message.self)
-            }
-            let third = self.setUpNode("third") { settings in
-                settings += ActorSingletonPlugin()
-
-                settings.cluster.node.port = 9333
-                settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
-                settings.serialization.register(GreeterSingleton.Message.self)
-            }
-
-            // Bring up `ActorSingletonProxy` before setting up cluster (https://github.com/apple/swift-distributed-actors/issues/463)
-            let ref1 = try first.singleton.host(GreeterSingleton.Message.self, settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-1")))
-            let ref2 = try second.singleton.host(GreeterSingleton.Message.self, settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-2")))
-            let ref3 = try third.singleton.host(GreeterSingleton.Message.self, settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-3")))
-
-            first.cluster.join(node: second.cluster.node.node)
-            third.cluster.join(node: first.cluster.node.node)
-
-            // `first` will be the leader (lowest address) and runs the singleton
-            try self.ensureNodes(.up, nodes: first.cluster.node, second.cluster.node, third.cluster.node)
-
-            try self.assertSingletonRequestReply(first, singletonRef: ref1, message: "Alice", expect: "Hello-1 Alice!")
-            try self.assertSingletonRequestReply(second, singletonRef: ref2, message: "Bob", expect: "Hello-1 Bob!")
-            try self.assertSingletonRequestReply(third, singletonRef: ref3, message: "Charlie", expect: "Hello-1 Charlie!")
+            settings.cluster.node.port = 7111
+            settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
+            settings.serialization.register(GreeterSingleton.Message.self)
         }
+        let second = self.setUpNode("second") { settings in
+            settings += ActorSingletonPlugin()
+
+            settings.cluster.node.port = 8222
+            settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
+            settings.serialization.register(GreeterSingleton.Message.self)
+        }
+        let third = self.setUpNode("third") { settings in
+            settings += ActorSingletonPlugin()
+
+            settings.cluster.node.port = 9333
+            settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
+            settings.serialization.register(GreeterSingleton.Message.self)
+        }
+
+        // Bring up `ActorSingletonProxy` before setting up cluster (https://github.com/apple/swift-distributed-actors/issues/463)
+        let ref1 = try first.singleton.host(GreeterSingleton.Message.self, settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-1")))
+        let ref2 = try second.singleton.host(GreeterSingleton.Message.self, settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-2")))
+        let ref3 = try third.singleton.host(GreeterSingleton.Message.self, settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-3")))
+
+        first.cluster.join(node: second.cluster.node.node)
+        third.cluster.join(node: first.cluster.node.node)
+
+        // `first` will be the leader (lowest address) and runs the singleton
+        try self.ensureNodes(.up, nodes: first.cluster.node, second.cluster.node, third.cluster.node)
+
+        try self.assertSingletonRequestReply(first, singletonRef: ref1, message: "Alice", expect: "Hello-1 Alice!")
+        try self.assertSingletonRequestReply(second, singletonRef: ref2, message: "Bob", expect: "Hello-1 Bob!")
+        try self.assertSingletonRequestReply(third, singletonRef: ref3, message: "Charlie", expect: "Hello-1 Charlie!")
     }
 
     func test_singletonByClusterLeadership_stashMessagesIfNoLeader() throws {
-        try shouldNotThrow {
-            var singletonSettings = ActorSingletonSettings(name: GreeterSingleton.name)
-            singletonSettings.allocationStrategy = .byLeadership
+        var singletonSettings = ActorSingletonSettings(name: GreeterSingleton.name)
+        singletonSettings.allocationStrategy = .byLeadership
 
-            let first = self.setUpNode("first") { settings in
-                settings += ActorSingletonPlugin()
+        let first = self.setUpNode("first") { settings in
+            settings += ActorSingletonPlugin()
 
-                settings.cluster.node.port = 7111
-                settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
-                settings.serialization.register(GreeterSingleton.Message.self)
-            }
-            let second = self.setUpNode("second") { settings in
-                settings += ActorSingletonPlugin()
-
-                settings.cluster.node.port = 8222
-                settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
-                settings.serialization.register(GreeterSingleton.Message.self)
-            }
-            let third = self.setUpNode("third") { settings in
-                settings += ActorSingletonPlugin()
-
-                settings.cluster.node.port = 9333
-                settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
-                settings.serialization.register(GreeterSingleton.Message.self)
-            }
-
-            // No leader so singleton is not available, messages sent should be stashed
-            let replyProbe1 = self.testKit(first).spawnTestProbe(expecting: String.self)
-            let ref1 = try first.singleton.host(GreeterSingleton.Message.self, settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-1")))
-            ref1.tell(.greet(name: "Alice-1", _replyTo: replyProbe1.ref))
-
-            let replyProbe2 = self.testKit(second).spawnTestProbe(expecting: String.self)
-            let ref2 = try second.singleton.host(GreeterSingleton.Message.self, settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-2")))
-            ref2.tell(.greet(name: "Bob-2", _replyTo: replyProbe2.ref))
-
-            let replyProbe3 = self.testKit(third).spawnTestProbe(expecting: String.self)
-            let ref3 = try third.singleton.host(GreeterSingleton.Message.self, settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-3")))
-            ref3.tell(.greet(name: "Charlie-3", _replyTo: replyProbe3.ref))
-
-            try replyProbe1.expectNoMessage(for: .milliseconds(200))
-            try replyProbe2.expectNoMessage(for: .milliseconds(200))
-            try replyProbe3.expectNoMessage(for: .milliseconds(200))
-
-            first.cluster.join(node: second.cluster.node.node)
-            third.cluster.join(node: second.cluster.node.node)
-
-            // `first` becomes the leader (lowest address) and runs the singleton
-            try self.ensureNodes(.up, nodes: first.cluster.node, second.cluster.node, third.cluster.node)
-
-            try replyProbe1.expectMessage("Hello-1 Alice-1!")
-            try replyProbe2.expectMessage("Hello-1 Bob-2!")
-            try replyProbe3.expectMessage("Hello-1 Charlie-3!")
+            settings.cluster.node.port = 7111
+            settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
+            settings.serialization.register(GreeterSingleton.Message.self)
         }
+        let second = self.setUpNode("second") { settings in
+            settings += ActorSingletonPlugin()
+
+            settings.cluster.node.port = 8222
+            settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
+            settings.serialization.register(GreeterSingleton.Message.self)
+        }
+        let third = self.setUpNode("third") { settings in
+            settings += ActorSingletonPlugin()
+
+            settings.cluster.node.port = 9333
+            settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
+            settings.serialization.register(GreeterSingleton.Message.self)
+        }
+
+        // No leader so singleton is not available, messages sent should be stashed
+        let replyProbe1 = self.testKit(first).spawnTestProbe(expecting: String.self)
+        let ref1 = try first.singleton.host(GreeterSingleton.Message.self, settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-1")))
+        ref1.tell(.greet(name: "Alice-1", _replyTo: replyProbe1.ref))
+
+        let replyProbe2 = self.testKit(second).spawnTestProbe(expecting: String.self)
+        let ref2 = try second.singleton.host(GreeterSingleton.Message.self, settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-2")))
+        ref2.tell(.greet(name: "Bob-2", _replyTo: replyProbe2.ref))
+
+        let replyProbe3 = self.testKit(third).spawnTestProbe(expecting: String.self)
+        let ref3 = try third.singleton.host(GreeterSingleton.Message.self, settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-3")))
+        ref3.tell(.greet(name: "Charlie-3", _replyTo: replyProbe3.ref))
+
+        try replyProbe1.expectNoMessage(for: .milliseconds(200))
+        try replyProbe2.expectNoMessage(for: .milliseconds(200))
+        try replyProbe3.expectNoMessage(for: .milliseconds(200))
+
+        first.cluster.join(node: second.cluster.node.node)
+        third.cluster.join(node: second.cluster.node.node)
+
+        // `first` becomes the leader (lowest address) and runs the singleton
+        try self.ensureNodes(.up, nodes: first.cluster.node, second.cluster.node, third.cluster.node)
+
+        try replyProbe1.expectMessage("Hello-1 Alice-1!")
+        try replyProbe2.expectMessage("Hello-1 Bob-2!")
+        try replyProbe3.expectMessage("Hello-1 Charlie-3!")
     }
 
     func test_singletonByClusterLeadership_withLeaderChange() throws {
-        try shouldNotThrow {
-            var singletonSettings = ActorSingletonSettings(name: GreeterSingleton.name)
-            singletonSettings.allocationStrategy = .byLeadership
+        var singletonSettings = ActorSingletonSettings(name: GreeterSingleton.name)
+        singletonSettings.allocationStrategy = .byLeadership
 
-            let first = self.setUpNode("first") { settings in
-                settings += ActorSingletonPlugin()
+        let first = self.setUpNode("first") { settings in
+            settings += ActorSingletonPlugin()
 
-                settings.cluster.node.port = 7111
-                settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
-                settings.serialization.register(GreeterSingleton.Message.self)
-            }
-            let second = self.setUpNode("second") { settings in
-                settings += ActorSingletonPlugin()
-
-                settings.cluster.node.port = 8222
-                settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
-                settings.serialization.register(GreeterSingleton.Message.self)
-            }
-            let third = self.setUpNode("third") { settings in
-                settings += ActorSingletonPlugin()
-
-                settings.cluster.node.port = 9333
-                settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
-                settings.serialization.register(GreeterSingleton.Message.self)
-            }
-            let fourth = self.setUpNode("fourth") { settings in
-                settings += ActorSingletonPlugin()
-
-                settings.cluster.node.port = 7444
-                settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
-                settings.serialization.register(GreeterSingleton.Message.self)
-            }
-
-            // Bring up `ActorSingletonProxy` before setting up cluster (https://github.com/apple/swift-distributed-actors/issues/463)
-            let ref1 = try first.singleton.host(GreeterSingleton.Message.self, settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-1")))
-            let ref2 = try second.singleton.host(GreeterSingleton.Message.self, settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-2")))
-            let ref3 = try third.singleton.host(GreeterSingleton.Message.self, settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-3")))
-            _ = try fourth.singleton.host(GreeterSingleton.Message.self, settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-4")))
-
-            first.cluster.join(node: second.cluster.node.node)
-            third.cluster.join(node: second.cluster.node.node)
-
-            try self.ensureNodes(.up, nodes: first.cluster.node, second.cluster.node, third.cluster.node)
-            pinfo("Nodes up: \([first.cluster.node, second.cluster.node, third.cluster.node])")
-
-            let replyProbe2 = self.testKit(second).spawnTestProbe(expecting: String.self)
-            let replyProbe3 = self.testKit(third).spawnTestProbe(expecting: String.self)
-
-            // `first` has the lowest address so it should be the leader and singleton
-            try self.assertSingletonRequestReply(first, singletonRef: ref1, message: "Alice", expect: "Hello-1 Alice!")
-            try self.assertSingletonRequestReply(second, singletonRef: ref2, message: "Bob", expect: "Hello-1 Bob!")
-            try self.assertSingletonRequestReply(third, singletonRef: ref3, message: "Charlie", expect: "Hello-1 Charlie!")
-            pinfo("All three nodes communicated with singleton")
-
-            let firstNode = first.cluster.node
-            first.cluster.leave()
-
-            // Make sure that `second` and `third` see `first` as down and become leader-less
-            try self.testKit(second).eventually(within: .seconds(10)) {
-                try self.assertMemberStatus(on: second, node: firstNode, is: .down)
-                try self.assertLeaderNode(on: second, is: nil)
-            }
-            try self.testKit(third).eventually(within: .seconds(10)) {
-                try self.assertMemberStatus(on: third, node: firstNode, is: .down)
-                try self.assertLeaderNode(on: third, is: nil)
-            }
-            pinfo("Node \(first.cluster.node) left cluster...")
-
-            // `fourth` will become the new leader and singleton
-            pinfo("Node \(fourth.cluster.node) joining cluster...")
-            fourth.cluster.join(node: second.cluster.node.node)
-            let start = fourth.uptimeNanoseconds()
-
-            // No leader so singleton is not available, messages sent should be stashed
-            _ = try second.spawn("teller", of: String.self, .setup { context in
-                context.timers.startPeriodic(key: "periodic-try-send", message: "tick", interval: .seconds(1))
-                var attempt = 0
-
-                return .receiveMessage { _ in
-                    attempt += 1
-                    // No leader so singleton is not available, messages sent should be stashed
-                    let m2 = "Bob-2 (\(attempt))"
-                    pnote("  Sending: \(m2) -> \(ref2) (it may be terminated/not-re-pointed yet)")
-                    ref2.tell(.greet(name: m2, _replyTo: replyProbe2.ref))
-
-                    let m3 = "Charlie-3 (\(attempt))"
-                    pnote("  Sending: \(m3) -> \(ref3) (it may be terminated/not-re-pointed yet)")
-                    ref3.tell(.greet(name: m3, _replyTo: replyProbe3.ref))
-                    return .same
-                }
-            })
-
-            try self.ensureNodes(.up, on: second, nodes: second.cluster.node, third.cluster.node, fourth.cluster.node)
-            pinfo("Fourth node joined, will become leader; Members now: \([fourth.cluster.node, second.cluster.node, third.cluster.node])")
-
-            // The stashed messages get routed to new singleton running on `fourth`
-            let got2 = try replyProbe2.expectMessage()
-            got2.shouldStartWith(prefix: "Hello-4 Bob-2")
-            pinfo("Received reply (by \(replyProbe2.address.path)) from singleton: \(got2)")
-            if got2 == "Hello-4 Bob-2 (1)!" {
-                var counter = 0
-                while try replyProbe2.maybeExpectMessage(within: .milliseconds(100)) != nil {
-                    counter += 1
-                }
-                pinfo("  No messages were lost! Including \(counter) more, following the previous delivery.")
-            } else {
-                pinfo("  Initial messages may have been lost, delivered message: \(got2)")
-            }
-
-            let got3 = try replyProbe3.expectMessage()
-            got3.shouldStartWith(prefix: "Hello-4 Charlie-3")
-            pinfo("Received reply (by \(replyProbe3.address.path)) from singleton: \(got3)")
-            if got3 == "Hello-4 Charlie-3 (1)!" {
-                var counter = 0
-                while try replyProbe3.maybeExpectMessage(within: .milliseconds(100)) != nil {
-                    counter += 1
-                }
-                pinfo("  No messages were lost! Including \(counter) more, following the previous delivery.")
-            } else {
-                pinfo("  Initial messages may have been lost, delivered message: \(got3)")
-            }
-
-            let stop = fourth.uptimeNanoseconds()
-            pinfo("Singleton re-pointing took: \(TimeAmount.nanoseconds(stop - start).prettyDescription)")
-
-            pinfo("Nodes communicated successfully with singleton on [fourth]")
+            settings.cluster.node.port = 7111
+            settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
+            settings.serialization.register(GreeterSingleton.Message.self)
         }
+        let second = self.setUpNode("second") { settings in
+            settings += ActorSingletonPlugin()
+
+            settings.cluster.node.port = 8222
+            settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
+            settings.serialization.register(GreeterSingleton.Message.self)
+        }
+        let third = self.setUpNode("third") { settings in
+            settings += ActorSingletonPlugin()
+
+            settings.cluster.node.port = 9333
+            settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
+            settings.serialization.register(GreeterSingleton.Message.self)
+        }
+        let fourth = self.setUpNode("fourth") { settings in
+            settings += ActorSingletonPlugin()
+
+            settings.cluster.node.port = 7444
+            settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
+            settings.serialization.register(GreeterSingleton.Message.self)
+        }
+
+        // Bring up `ActorSingletonProxy` before setting up cluster (https://github.com/apple/swift-distributed-actors/issues/463)
+        let ref1 = try first.singleton.host(GreeterSingleton.Message.self, settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-1")))
+        let ref2 = try second.singleton.host(GreeterSingleton.Message.self, settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-2")))
+        let ref3 = try third.singleton.host(GreeterSingleton.Message.self, settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-3")))
+        _ = try fourth.singleton.host(GreeterSingleton.Message.self, settings: singletonSettings, GreeterSingleton.makeBehavior(instance: GreeterSingleton("Hello-4")))
+
+        first.cluster.join(node: second.cluster.node.node)
+        third.cluster.join(node: second.cluster.node.node)
+
+        try self.ensureNodes(.up, nodes: first.cluster.node, second.cluster.node, third.cluster.node)
+        pinfo("Nodes up: \([first.cluster.node, second.cluster.node, third.cluster.node])")
+
+        let replyProbe2 = self.testKit(second).spawnTestProbe(expecting: String.self)
+        let replyProbe3 = self.testKit(third).spawnTestProbe(expecting: String.self)
+
+        // `first` has the lowest address so it should be the leader and singleton
+        try self.assertSingletonRequestReply(first, singletonRef: ref1, message: "Alice", expect: "Hello-1 Alice!")
+        try self.assertSingletonRequestReply(second, singletonRef: ref2, message: "Bob", expect: "Hello-1 Bob!")
+        try self.assertSingletonRequestReply(third, singletonRef: ref3, message: "Charlie", expect: "Hello-1 Charlie!")
+        pinfo("All three nodes communicated with singleton")
+
+        let firstNode = first.cluster.node
+        first.cluster.leave()
+
+        // Make sure that `second` and `third` see `first` as down and become leader-less
+        try self.testKit(second).eventually(within: .seconds(10)) {
+            try self.assertMemberStatus(on: second, node: firstNode, is: .down)
+            try self.assertLeaderNode(on: second, is: nil)
+        }
+        try self.testKit(third).eventually(within: .seconds(10)) {
+            try self.assertMemberStatus(on: third, node: firstNode, is: .down)
+            try self.assertLeaderNode(on: third, is: nil)
+        }
+        pinfo("Node \(first.cluster.node) left cluster...")
+
+        // `fourth` will become the new leader and singleton
+        pinfo("Node \(fourth.cluster.node) joining cluster...")
+        fourth.cluster.join(node: second.cluster.node.node)
+        let start = fourth.uptimeNanoseconds()
+
+        // No leader so singleton is not available, messages sent should be stashed
+        _ = try second.spawn("teller", of: String.self, .setup { context in
+            context.timers.startPeriodic(key: "periodic-try-send", message: "tick", interval: .seconds(1))
+            var attempt = 0
+
+            return .receiveMessage { _ in
+                attempt += 1
+                // No leader so singleton is not available, messages sent should be stashed
+                let m2 = "Bob-2 (\(attempt))"
+                pnote("  Sending: \(m2) -> \(ref2) (it may be terminated/not-re-pointed yet)")
+                ref2.tell(.greet(name: m2, _replyTo: replyProbe2.ref))
+
+                let m3 = "Charlie-3 (\(attempt))"
+                pnote("  Sending: \(m3) -> \(ref3) (it may be terminated/not-re-pointed yet)")
+                ref3.tell(.greet(name: m3, _replyTo: replyProbe3.ref))
+                return .same
+            }
+        })
+
+        try self.ensureNodes(.up, on: second, nodes: second.cluster.node, third.cluster.node, fourth.cluster.node)
+        pinfo("Fourth node joined, will become leader; Members now: \([fourth.cluster.node, second.cluster.node, third.cluster.node])")
+
+        // The stashed messages get routed to new singleton running on `fourth`
+        let got2 = try replyProbe2.expectMessage()
+        got2.shouldStartWith(prefix: "Hello-4 Bob-2")
+        pinfo("Received reply (by \(replyProbe2.address.path)) from singleton: \(got2)")
+        if got2 == "Hello-4 Bob-2 (1)!" {
+            var counter = 0
+            while try replyProbe2.maybeExpectMessage(within: .milliseconds(100)) != nil {
+                counter += 1
+            }
+            pinfo("  No messages were lost! Including \(counter) more, following the previous delivery.")
+        } else {
+            pinfo("  Initial messages may have been lost, delivered message: \(got2)")
+        }
+
+        let got3 = try replyProbe3.expectMessage()
+        got3.shouldStartWith(prefix: "Hello-4 Charlie-3")
+        pinfo("Received reply (by \(replyProbe3.address.path)) from singleton: \(got3)")
+        if got3 == "Hello-4 Charlie-3 (1)!" {
+            var counter = 0
+            while try replyProbe3.maybeExpectMessage(within: .milliseconds(100)) != nil {
+                counter += 1
+            }
+            pinfo("  No messages were lost! Including \(counter) more, following the previous delivery.")
+        } else {
+            pinfo("  Initial messages may have been lost, delivered message: \(got3)")
+        }
+
+        let stop = fourth.uptimeNanoseconds()
+        pinfo("Singleton re-pointing took: \(TimeAmount.nanoseconds(stop - start).prettyDescription)")
+
+        pinfo("Nodes communicated successfully with singleton on [fourth]")
     }
 
     /// Since during re-balancing it may happen that a message gets lost, we send messages a few times and only if none "got through" it would be a serious error.

--- a/Tests/DistributedActorsTestKitTests/ActorTestKitTests.swift
+++ b/Tests/DistributedActorsTestKitTests/ActorTestKitTests.swift
@@ -29,20 +29,9 @@ final class ActorTestKitTests: XCTestCase {
         self.system.shutdown().wait()
     }
 
-    func test_error_withoutMessage() throws {
-        let error = self.testKit.error()
-        guard case CallSiteError.error(let message) = error else {
-            throw error
-        }
-        message.contains("<no message>").shouldBeTrue()
-    }
-
     func test_error_withMessage() throws {
         let error = self.testKit.error("test")
-        guard case CallSiteError.error(let message) = error else {
-            throw error
-        }
-        message.contains("test").shouldBeTrue()
+        "\(error)".contains("test").shouldBeTrue()
     }
 
     func test_fail_shouldNotImmediatelyFailWithinEventuallyBlock() throws {

--- a/Tests/DistributedActorsTests/ActorAddressTests.swift
+++ b/Tests/DistributedActorsTests/ActorAddressTests.swift
@@ -20,11 +20,11 @@ final class ActorAddressTests: XCTestCase {
     // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: ActorPath
 
-    func test_shouldNotAllow_illegalCharacters() {
-        shouldThrow(expected: ActorPathError.self) {
+    func test_shouldNotAllow_illegalCharacters() throws {
+        try shouldThrow(expected: ActorPathError.self) {
             _ = try ActorPath(root: "")
         }
-        shouldThrow(expected: ActorPathError.self) {
+        try shouldThrow(expected: ActorPathError.self) {
             _ = try ActorPath(root: " ")
         }
     }

--- a/Tests/DistributedActorsTests/ActorAskTests.swift
+++ b/Tests/DistributedActorsTests/ActorAskTests.swift
@@ -62,7 +62,7 @@ final class ActorAskTests: ActorSystemXCTestCase {
 
         let response = ref.ask(for: String.self, timeout: .seconds(1)) { TestMessage(replyTo: $0) }
 
-        let error = shouldThrow {
+        let error = try shouldThrow {
             _ = try response.wait()
         }
 
@@ -193,7 +193,7 @@ final class ActorAskTests: ActorSystemXCTestCase {
             AnswerMePlease(replyTo: $0)
         }
 
-        let error = shouldThrow {
+        let error = try shouldThrow {
             try result.wait()
         }
 

--- a/Tests/DistributedActorsTests/ActorLifecycleTests.swift
+++ b/Tests/DistributedActorsTests/ActorLifecycleTests.swift
@@ -24,7 +24,7 @@ class ActorLifecycleTests: ActorSystemXCTestCase {
     func test_spawn_shouldNotAllowStartingWith_Same() throws {
         // since there is no previous behavior to stay "same" name at the same time:
 
-        let ex = shouldThrow {
+        let ex = try shouldThrow {
             let sameBehavior: Behavior<String> = .same
             _ = try self.system.spawn("same", sameBehavior)
         }
@@ -41,7 +41,7 @@ class ActorLifecycleTests: ActorSystemXCTestCase {
         //
         // We do allow starting with .ignore though since that's like a "blackhole"
 
-        let ex = shouldThrow {
+        let ex = try shouldThrow {
             let unhandledBehavior: Behavior<String> = .unhandled
             _ = try system.spawn("unhandled", unhandledBehavior)
         }
@@ -51,7 +51,7 @@ class ActorLifecycleTests: ActorSystemXCTestCase {
 
     func test_spawn_shouldNotAllowIllegalActorNames() throws {
         func check(illegalName: String, expectedError: String) throws {
-            let err = shouldThrow {
+            let err = try shouldThrow {
                 let b: Behavior<String> = .ignore
 
                 // more coverage for all the different chars in [[ActorPathTests]]

--- a/Tests/DistributedActorsTests/ActorRefAdapterTests.swift
+++ b/Tests/DistributedActorsTests/ActorRefAdapterTests.swift
@@ -269,7 +269,7 @@ class ActorRefAdapterTests: ActorSystemXCTestCase {
         let expectedFile = #file
 
         let deadLetterLogMessage = try logCapture.shouldContain(
-            message: "*was not delivered to [*", 
+            message: "*was not delivered to [*",
             at: .info
         )
         deadLetterLogMessage.metadata!["deadLetter/location"]!.shouldEqual("\(expectedFile):\(expectedLine)")

--- a/Tests/DistributedActorsTests/ActorSystemTests.swift
+++ b/Tests/DistributedActorsTests/ActorSystemTests.swift
@@ -23,7 +23,7 @@ final class ActorSystemTests: ActorSystemXCTestCase {
     func test_system_spawn_shouldThrowOnDuplicateName() throws {
         let _: ActorRef<String> = try system.spawn("test", .ignore)
 
-        let error = shouldThrow {
+        let error = try shouldThrow {
             let _: ActorRef<String> = try system.spawn("test", .ignore)
         }
 

--- a/Tests/DistributedActorsTests/CRDT/CRDTGossipReplicationClusteredTests.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTGossipReplicationClusteredTests.swift
@@ -73,85 +73,81 @@ final class CRDTGossipReplicationTests: ClusteredActorSystemsXCTestCase {
     // MARK: Local only direct writes, end up on other nodes via gossip
 
     func test_gossip_localUpdate_toOtherNode() throws {
-        try shouldNotThrow {
-            let configure: (inout ActorSystemSettings) -> Void = { settings in
-                settings.crdt.gossipInterval = .seconds(1)
-                settings.crdt.gossipIntervalRandomFactor = 0 // no random factor, exactly 1second intervals
-            }
-            let first = self.setUpNode("first", configure)
-            let second = self.setUpNode("second", configure)
-            try self.joinNodes(node: first, with: second, ensureMembers: .up)
-
-            let p1 = self.testKit(first).spawnTestProbe("probe-one", expecting: CRDT.ORSet<String>.self)
-            let p2 = self.testKit(second).spawnTestProbe("probe-two", expecting: CRDT.ORSet<String>.self)
-
-            let one = try first.spawn("one", ownsSet(p: p1))
-            let two = try second.spawn("two", ownsSet(p: p2))
-
-            one.tell(.insert("a", .local))
-            one.tell(.insert("aa", .local))
-
-            try self.expectSet(probe: p1, expected: ["a", "aa"])
-            try self.expectSet(probe: p2, expected: ["a", "aa"])
-
-            two.tell(.insert("b", .local))
-
-            try self.expectSet(probe: p1, expected: ["a", "aa", "b"])
-            try self.expectSet(probe: p2, expected: ["a", "aa", "b"])
+        let configure: (inout ActorSystemSettings) -> Void = { settings in
+            settings.crdt.gossipInterval = .seconds(1)
+            settings.crdt.gossipIntervalRandomFactor = 0 // no random factor, exactly 1second intervals
         }
+        let first = self.setUpNode("first", configure)
+        let second = self.setUpNode("second", configure)
+        try self.joinNodes(node: first, with: second, ensureMembers: .up)
+
+        let p1 = self.testKit(first).spawnTestProbe("probe-one", expecting: CRDT.ORSet<String>.self)
+        let p2 = self.testKit(second).spawnTestProbe("probe-two", expecting: CRDT.ORSet<String>.self)
+
+        let one = try first.spawn("one", self.ownsSet(p: p1))
+        let two = try second.spawn("two", self.ownsSet(p: p2))
+
+        one.tell(.insert("a", .local))
+        one.tell(.insert("aa", .local))
+
+        try self.expectSet(probe: p1, expected: ["a", "aa"])
+        try self.expectSet(probe: p2, expected: ["a", "aa"])
+
+        two.tell(.insert("b", .local))
+
+        try self.expectSet(probe: p1, expected: ["a", "aa", "b"])
+        try self.expectSet(probe: p2, expected: ["a", "aa", "b"])
     }
 
     func test_gossip_readAll_gossipedOwnerAlwaysIncludesAddress() throws {
-        try shouldNotThrow {
-            let configure: (inout ActorSystemSettings) -> Void = { settings in
-                settings.crdt.gossipInterval = .seconds(1)
-                settings.crdt.gossipIntervalRandomFactor = 0 // no random factor, exactly 1second intervals
-            }
-            let first = self.setUpNode("first", configure)
-            let second = self.setUpNode("second", configure)
-            let third = self.setUpNode("third", configure)
-            let fourth = self.setUpNode("fourth", configure)
+        let configure: (inout ActorSystemSettings) -> Void = { settings in
+            settings.crdt.gossipInterval = .seconds(1)
+            settings.crdt.gossipIntervalRandomFactor = 0 // no random factor, exactly 1second intervals
+        }
+        let first = self.setUpNode("first", configure)
+        let second = self.setUpNode("second", configure)
+        let third = self.setUpNode("third", configure)
+        let fourth = self.setUpNode("fourth", configure)
 
-            try self.joinNodes(node: first, with: second, ensureMembers: .up)
-            try self.joinNodes(node: second, with: third, ensureMembers: .up)
-            try self.joinNodes(node: third, with: fourth, ensureMembers: .up)
-            try self.ensureNodes(.up, nodes: first.cluster.node, second.cluster.node, third.cluster.node, fourth.cluster.node)
+        try self.joinNodes(node: first, with: second, ensureMembers: .up)
+        try self.joinNodes(node: second, with: third, ensureMembers: .up)
+        try self.joinNodes(node: third, with: fourth, ensureMembers: .up)
+        try self.ensureNodes(.up, nodes: first.cluster.node, second.cluster.node, third.cluster.node, fourth.cluster.node)
 
-            let one = try first.spawn("one", ownsCounter(p: nil))
-            let two = try second.spawn("two", ownsCounter(p: nil))
-            let three = try third.spawn("three", ownsCounter(p: nil))
-            let four = try fourth.spawn("four", ownsCounter(p: nil))
+        let one = try first.spawn("one", self.ownsCounter(p: nil))
+        let two = try second.spawn("two", self.ownsCounter(p: nil))
+        let three = try third.spawn("three", self.ownsCounter(p: nil))
+        let four = try fourth.spawn("four", self.ownsCounter(p: nil))
 
-            one.tell(1)
-            two.tell(2)
-            three.tell(3)
-            four.tell(4)
+        one.tell(1)
+        two.tell(2)
+        three.tell(3)
+        four.tell(4)
 
-            let testKit = self.testKit(first)
-            let p = testKit.spawnTestProbe(expecting: CRDT.Replicator.LocalCommand.ReadResult.self)
+        let testKit = self.testKit(first)
+        let p = testKit.spawnTestProbe(expecting: CRDT.Replicator.LocalCommand.ReadResult.self)
 
-            // asserting that a read sees all the individual writes, and that they all have "proper" replica IDs
-            try testKit.eventually(within: .seconds(10)) {
-                first.replicator.tell(.localCommand(.read(CRDT.Identity("counter"), consistency: .all, timeout: .effectivelyInfinite, replyTo: p.ref)))
-                switch try p.maybeExpectMessage(within: .seconds(3)) {
-                case nil:
-                    throw p.error("No message")
-                case .some(let .success(data as CRDT.GCounter)):
-                    // each of the owners has a row
-                    data.state.count.shouldEqual(4)
+        // asserting that a read sees all the individual writes, and that they all have "proper" replica IDs
+        try testKit.eventually(within: .seconds(10)) {
+            first.replicator.tell(.localCommand(.read(CRDT.Identity("counter"), consistency: .all, timeout: .effectivelyInfinite, replyTo: p.ref)))
+            switch try p.maybeExpectMessage(within: .seconds(3)) {
+            case nil:
+                throw p.error("No message")
+            case .some(let .success(data as CRDT.GCounter)):
+                // each of the owners has a row
+                data.state.count.shouldEqual(4)
 
-                    // each of the rows is owned by an actor; each must have the full address in there
-                    for replicaID in data.state.keys {
-                        switch replicaID.storage {
-                        case .actorAddress(let address):
-                            address.node.shouldNotBeNil()
-                        default:
-                            throw testKit.fail("Unexpected replicaID which was not an actor address: \(replicaID)")
-                        }
+                // each of the rows is owned by an actor; each must have the full address in there
+                for replicaID in data.state.keys {
+                    switch replicaID.storage {
+                    case .actorAddress(let address):
+                        address.node.shouldNotBeNil()
+                    default:
+                        throw testKit.fail("Unexpected replicaID which was not an actor address: \(replicaID)")
                     }
-                case .some(let other):
-                    throw p.error("Unexpected result \(other)")
                 }
+            case .some(let other):
+                throw p.error("Unexpected result \(other)")
             }
         }
     }
@@ -160,66 +156,64 @@ final class CRDTGossipReplicationTests: ClusteredActorSystemsXCTestCase {
     // MARK: Gossip stop conditions
 
     func test_gossip_shouldEventuallyStopSpreading() throws {
-        try shouldNotThrow {
-            let configure: (inout ActorSystemSettings) -> Void = { settings in
-                settings.crdt.gossipInterval = .milliseconds(300)
-                settings.crdt.gossipIntervalRandomFactor = 0 // no random factor, exactly 1second intervals
+        let configure: (inout ActorSystemSettings) -> Void = { settings in
+            settings.crdt.gossipInterval = .milliseconds(300)
+            settings.crdt.gossipIntervalRandomFactor = 0 // no random factor, exactly 1second intervals
+        }
+        let first = self.setUpNode("first", configure)
+        let second = self.setUpNode("second", configure)
+        let third = self.setUpNode("third", configure)
+        let fourth = self.setUpNode("fourth", configure)
+
+        try self.joinNodes(node: first, with: second, ensureMembers: .up)
+        try self.joinNodes(node: second, with: third, ensureMembers: .up)
+        try self.ensureNodes(.up, nodes: first.cluster.node, second.cluster.node, third.cluster.node)
+
+        let p1 = self.testKit(first).spawnTestProbe(expecting: CRDT.GCounter.self)
+        let one = try first.spawn("one", self.ownsCounter(p: p1))
+
+        let p2 = self.testKit(second).spawnTestProbe(expecting: CRDT.GCounter.self)
+        let two = try second.spawn("two", self.ownsCounter(p: p2))
+
+        let p3 = self.testKit(third).spawnTestProbe(expecting: CRDT.GCounter.self)
+        let three = try third.spawn("three", self.ownsCounter(p: p3))
+
+        one.tell(1)
+        two.tell(2)
+        three.tell(3)
+
+        let testKit: ActorTestKit = self.testKit(first)
+
+        _ = try p1.fishFor(Int.self, within: .seconds(5)) { counter in
+            if counter.value == 6 {
+                return .complete
+            } else {
+                return .ignore
             }
-            let first = self.setUpNode("first", configure)
-            let second = self.setUpNode("second", configure)
-            let third = self.setUpNode("third", configure)
-            let fourth = self.setUpNode("fourth", configure)
+        }
 
-            try self.joinNodes(node: first, with: second, ensureMembers: .up)
-            try self.joinNodes(node: second, with: third, ensureMembers: .up)
-            try self.ensureNodes(.up, nodes: first.cluster.node, second.cluster.node, third.cluster.node)
+        try testKit.assertHolds(for: .seconds(5), interval: .seconds(1)) {
+            let logs: [CapturedLogMessage] = self.capturedLogs(of: first)
+                .grep("Received gossip", metadata: ["gossip/identity": "counter"])
 
-            let p1 = self.testKit(first).spawnTestProbe(expecting: CRDT.GCounter.self)
-            let one = try first.spawn("one", ownsCounter(p: p1))
-
-            let p2 = self.testKit(second).spawnTestProbe(expecting: CRDT.GCounter.self)
-            let two = try second.spawn("two", ownsCounter(p: p2))
-
-            let p3 = self.testKit(third).spawnTestProbe(expecting: CRDT.GCounter.self)
-            let three = try third.spawn("three", ownsCounter(p: p3))
-
-            one.tell(1)
-            two.tell(2)
-            three.tell(3)
-
-            let testKit: ActorTestKit = self.testKit(first)
-
-            _ = try p1.fishFor(Int.self, within: .seconds(5)) { counter in
-                if counter.value == 6 {
-                    return .complete
-                } else {
-                    return .ignore
-                }
+            guard logs.count < 5 else {
+                throw testKit.error("Received gossip more times than expected! Logs: \(lineByLine: logs)")
             }
+        }
 
-            try testKit.assertHolds(for: .seconds(5), interval: .seconds(1)) {
-                let logs: [CapturedLogMessage] = self.capturedLogs(of: first)
-                    .grep("Received gossip", metadata: ["gossip/identity": "counter"])
+        // ==== Join 4th node, it should gain the information ------------------------------------------------------
+        fourth.cluster.join(node: second.cluster.node.node)
+        fourth.cluster.join(node: first.cluster.node.node)
 
-                guard logs.count < 5 else {
-                    throw testKit.error("Received gossip more times than expected! Logs: \(lineByLine: logs)")
-                }
-            }
+        let p4 = self.testKit(fourth).spawnTestProbe(expecting: CRDT.GCounter.self)
+        _ = try fourth.spawn("reader-4", self.ownsCounter(p: p4))
 
-            // ==== Join 4th node, it should gain the information ------------------------------------------------------
-            fourth.cluster.join(node: second.cluster.node.node)
-            fourth.cluster.join(node: first.cluster.node.node)
+        try testKit.assertHolds(for: .seconds(5), interval: .seconds(1)) {
+            let logs = self.capturedLogs(of: fourth)
+                .grep("Received gossip", metadata: ["gossip/identity": "counter"])
 
-            let p4 = self.testKit(fourth).spawnTestProbe(expecting: CRDT.GCounter.self)
-            _ = try fourth.spawn("reader-4", ownsCounter(p: p4))
-
-            try testKit.assertHolds(for: .seconds(5), interval: .seconds(1)) {
-                let logs = self.capturedLogs(of: fourth)
-                    .grep("Received gossip", metadata: ["gossip/identity": "counter"])
-
-                guard logs.count < 5 else {
-                    throw testKit.error("Received gossip more times than expected! Logs: \(lineByLine: logs)")
-                }
+            guard logs.count < 5 else {
+                throw testKit.error("Received gossip more times than expected! Logs: \(lineByLine: logs)")
             }
         }
     }

--- a/Tests/DistributedActorsTests/CRDT/CRDTOperationExecutionTests.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTOperationExecutionTests.swift
@@ -67,7 +67,7 @@ final class CRDTOperationExecutionTests: ClusteredActorSystemsXCTestCase {
     func test_OperationExecution_consistency_local_throwIfLocalNotConfirmed() throws {
         let remoteMembersCount = 5
 
-        let error = shouldThrow {
+        let error = try shouldThrow {
             _ = try OperationExecution<Int>(with: .local, remoteMembersCount: remoteMembersCount, localConfirmed: false)
         }
 
@@ -141,7 +141,7 @@ final class CRDTOperationExecutionTests: ClusteredActorSystemsXCTestCase {
     func test_OperationExecution_consistency_atLeast_throwIfInvalidInput() throws {
         let remoteMembersCount = 5
 
-        let error = shouldThrow {
+        let error = try shouldThrow {
             _ = try OperationExecution<Int>(with: .atLeast(0), remoteMembersCount: remoteMembersCount, localConfirmed: true)
         }
 
@@ -153,7 +153,7 @@ final class CRDTOperationExecutionTests: ClusteredActorSystemsXCTestCase {
     func test_OperationExecution_consistency_atLeast_throwIfUnableToFulfill_localConfirmed() throws {
         let remoteMembersCount = 5
 
-        let error = shouldThrow {
+        let error = try shouldThrow {
             // Ask for 1 more than remote + local combined
             _ = try OperationExecution<Int>(with: .atLeast(remoteMembersCount + 2), remoteMembersCount: remoteMembersCount, localConfirmed: true)
         }
@@ -170,7 +170,7 @@ final class CRDTOperationExecutionTests: ClusteredActorSystemsXCTestCase {
     func test_OperationExecution_consistency_atLeast_throwIfUnableToFulfill_localNotConfirmed() throws {
         let remoteMembersCount = 5
 
-        let error = shouldThrow {
+        let error = try shouldThrow {
             // `remoteMembersCount + 1` essentially means we want all members to confirm.
             // Send false for `localConfirmed` so the operation cannot be fulfilled.
             _ = try OperationExecution<Int>(with: .atLeast(remoteMembersCount + 1), remoteMembersCount: remoteMembersCount, localConfirmed: false)
@@ -215,7 +215,7 @@ final class CRDTOperationExecutionTests: ClusteredActorSystemsXCTestCase {
     func test_OperationExecution_consistency_quorum_throwIfNoRemoteMember() throws {
         let remoteMembersCount = 0
 
-        let error = shouldThrow {
+        let error = try shouldThrow {
             _ = try OperationExecution<Int>(with: .quorum, remoteMembersCount: remoteMembersCount, localConfirmed: true)
         }
 
@@ -227,7 +227,7 @@ final class CRDTOperationExecutionTests: ClusteredActorSystemsXCTestCase {
     func test_OperationExecution_consistency_quorum_throwIfUnableToFulfill() throws {
         let remoteMembersCount = 1
 
-        let error = shouldThrow {
+        let error = try shouldThrow {
             // Send false for `localConfirmed` so the operation cannot be fulfilled.
             _ = try OperationExecution<Int>(with: .quorum, remoteMembersCount: remoteMembersCount, localConfirmed: false)
         }
@@ -256,7 +256,7 @@ final class CRDTOperationExecutionTests: ClusteredActorSystemsXCTestCase {
     func test_OperationExecution_consistency_all_throwWhenLocalNotConfirmed() throws {
         let remoteMembersCount = 5
 
-        let error = shouldThrow {
+        let error = try shouldThrow {
             // Send false for `localConfirmed` so the operation cannot be fulfilled.
             _ = try OperationExecution<Int>(with: .all, remoteMembersCount: remoteMembersCount, localConfirmed: false)
         }

--- a/Tests/DistributedActorsTests/CRDT/CRDTReplicatorShellClusteredTests.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTReplicatorShellClusteredTests.swift
@@ -444,7 +444,7 @@ final class CRDTReplicatorShellClusteredTests: ClusteredActorSystemsXCTestCase {
     func test_OperationExecution_consistency_local_throwIfLocalNotConfirmed() throws {
         let remoteMembersCount = 5
 
-        let error = shouldThrow {
+        let error = try shouldThrow {
             _ = try OperationExecution<Int>(with: .local, remoteMembersCount: remoteMembersCount, localConfirmed: false)
         }
 
@@ -518,7 +518,7 @@ final class CRDTReplicatorShellClusteredTests: ClusteredActorSystemsXCTestCase {
     func test_OperationExecution_consistency_atLeast_throwIfInvalidInput() throws {
         let remoteMembersCount = 5
 
-        let error = shouldThrow {
+        let error = try shouldThrow {
             _ = try OperationExecution<Int>(with: .atLeast(0), remoteMembersCount: remoteMembersCount, localConfirmed: true)
         }
 
@@ -530,7 +530,7 @@ final class CRDTReplicatorShellClusteredTests: ClusteredActorSystemsXCTestCase {
     func test_OperationExecution_consistency_atLeast_throwIfUnableToFulfill_localConfirmed() throws {
         let remoteMembersCount = 5
 
-        let error = shouldThrow {
+        let error = try shouldThrow {
             // Ask for 1 more than remote + local combined
             _ = try OperationExecution<Int>(with: .atLeast(remoteMembersCount + 2), remoteMembersCount: remoteMembersCount, localConfirmed: true)
         }
@@ -547,7 +547,7 @@ final class CRDTReplicatorShellClusteredTests: ClusteredActorSystemsXCTestCase {
     func test_OperationExecution_consistency_atLeast_throwIfUnableToFulfill_localNotConfirmed() throws {
         let remoteMembersCount = 5
 
-        let error = shouldThrow {
+        let error = try shouldThrow {
             // `remoteMembersCount + 1` essentially means we want all members to confirm.
             // Send false for `localConfirmed` so the operation cannot be fulfilled.
             _ = try OperationExecution<Int>(with: .atLeast(remoteMembersCount + 1), remoteMembersCount: remoteMembersCount, localConfirmed: false)
@@ -592,7 +592,7 @@ final class CRDTReplicatorShellClusteredTests: ClusteredActorSystemsXCTestCase {
     func test_OperationExecution_consistency_quorum_throwIfNoRemoteMember() throws {
         let remoteMembersCount = 0
 
-        let error = shouldThrow {
+        let error = try shouldThrow {
             _ = try OperationExecution<Int>(with: .quorum, remoteMembersCount: remoteMembersCount, localConfirmed: true)
         }
 
@@ -604,7 +604,7 @@ final class CRDTReplicatorShellClusteredTests: ClusteredActorSystemsXCTestCase {
     func test_OperationExecution_consistency_quorum_throwIfUnableToFulfill() throws {
         let remoteMembersCount = 1
 
-        let error = shouldThrow {
+        let error = try shouldThrow {
             // Send false for `localConfirmed` so the operation cannot be fulfilled.
             _ = try OperationExecution<Int>(with: .quorum, remoteMembersCount: remoteMembersCount, localConfirmed: false)
         }
@@ -633,7 +633,7 @@ final class CRDTReplicatorShellClusteredTests: ClusteredActorSystemsXCTestCase {
     func test_OperationExecution_consistency_all_throwWhenLocalNotConfirmed() throws {
         let remoteMembersCount = 5
 
-        let error = shouldThrow {
+        let error = try shouldThrow {
             // Send false for `localConfirmed` so the operation cannot be fulfilled.
             _ = try OperationExecution<Int>(with: .all, remoteMembersCount: remoteMembersCount, localConfirmed: false)
         }

--- a/Tests/DistributedActorsTests/CRDT/Protobuf/CRDTEnvelope+SerializationTests.swift
+++ b/Tests/DistributedActorsTests/CRDT/Protobuf/CRDTEnvelope+SerializationTests.swift
@@ -20,25 +20,23 @@ final class CRDTEnvelopeSerializationTests: ActorSystemXCTestCase {
     let ownerAlpha = try! ActorAddress(path: ActorPath._user.appending("alpha"), incarnation: .wellKnown)
 
     func test_serializationOf_CRDTEnvelope_DeltaCRDTBox_GCounter() throws {
-        try shouldNotThrow {
-            var g1 = CRDT.GCounter(replicaID: .actorAddress(self.ownerAlpha))
-            g1.increment(by: 2)
-            g1.delta.shouldNotBeNil()
+        var g1 = CRDT.GCounter(replicaID: .actorAddress(self.ownerAlpha))
+        g1.increment(by: 2)
+        g1.delta.shouldNotBeNil()
 
-            let g1AsAny = g1
-            let envelope = CRDT.Envelope(manifest: .init(serializerID: Serialization.ReservedID.CRDTGCounter, hint: _typeName(CRDT.GCounter.self)), g1AsAny) // FIXME: real manifest
+        let g1AsAny = g1
+        let envelope = CRDT.Envelope(manifest: .init(serializerID: Serialization.ReservedID.CRDTGCounter, hint: _typeName(CRDT.GCounter.self)), g1AsAny) // FIXME: real manifest
 
-            let serialized = try system.serialization.serialize(envelope)
-            let deserialized = try system.serialization.deserialize(as: CRDT.Envelope.self, from: serialized)
+        let serialized = try system.serialization.serialize(envelope)
+        let deserialized = try system.serialization.deserialize(as: CRDT.Envelope.self, from: serialized)
 
-            guard let gg1 = deserialized.data as? CRDT.GCounter else {
-                throw self.testKit.fail("DeltaCRDTBox.underlying should be GCounter")
-            }
-
-            gg1.value.shouldEqual(g1.value)
-            gg1.delta.shouldNotBeNil()
-            "\(gg1.delta!.state)".shouldContain("[actor:sact://CRDTEnvelopeSerializationTests@127.0.0.1:9001/user/alpha: 2]")
+        guard let gg1 = deserialized.data as? CRDT.GCounter else {
+            throw self.testKit.fail("DeltaCRDTBox.underlying should be GCounter")
         }
+
+        gg1.value.shouldEqual(g1.value)
+        gg1.delta.shouldNotBeNil()
+        "\(gg1.delta!.state)".shouldContain("[actor:sact://CRDTEnvelopeSerializationTests@127.0.0.1:9001/user/alpha: 2]")
     }
 
 //    // TODO: use a "real" CvRDT rather than GCounter.Delta

--- a/Tests/DistributedActorsTests/CRDT/Protobuf/CRDTReplication+SerializationTests.swift
+++ b/Tests/DistributedActorsTests/CRDT/Protobuf/CRDTReplication+SerializationTests.swift
@@ -36,167 +36,151 @@ final class CRDTReplicationSerializationTests: ActorSystemXCTestCase {
     // MARK: CRDT.Replicator.RemoteCommand.write and .writeDelta
 
     func test_serializationOf_RemoteCommand_write_GCounter() throws {
-        try shouldNotThrow {
-            let id = CRDT.Identity("gcounter-1")
-            var g1 = CRDT.GCounter(replicaID: .actorAddress(self.ownerAlpha))
-            g1.increment(by: 5)
-            g1.delta.shouldNotBeNil()
+        let id = CRDT.Identity("gcounter-1")
+        var g1 = CRDT.GCounter(replicaID: .actorAddress(self.ownerAlpha))
+        g1.increment(by: 5)
+        g1.delta.shouldNotBeNil()
 
-            let resultProbe = self.testKit.spawnTestProbe(expecting: CRDT.Replicator.RemoteCommand.WriteResult.self)
-            let write: CRDT.Replicator.Message = .remoteCommand(.write(id, g1, replyTo: resultProbe.ref))
+        let resultProbe = self.testKit.spawnTestProbe(expecting: CRDT.Replicator.RemoteCommand.WriteResult.self)
+        let write: CRDT.Replicator.Message = .remoteCommand(.write(id, g1, replyTo: resultProbe.ref))
 
-            let serialized = try system.serialization.serialize(write)
-            let deserialized = try system.serialization.deserialize(as: CRDT.Replicator.Message.self, from: serialized)
+        let serialized = try system.serialization.serialize(write)
+        let deserialized = try system.serialization.deserialize(as: CRDT.Replicator.Message.self, from: serialized)
 
-            guard case .remoteCommand(.write(let deserializedId, let deserializedData, let deserializedReplyTo)) = deserialized else {
-                throw self.testKit.fail("Should be RemoteCommand.write message")
-            }
-            deserializedId.shouldEqual(id)
-            deserializedReplyTo.shouldEqual(resultProbe.ref)
-
-            guard let dg1 = deserializedData as? CRDT.GCounter else {
-                throw self.testKit.fail("Should be a GCounter")
-            }
-            dg1.value.shouldEqual(g1.value)
-            dg1.delta.shouldNotBeNil()
+        guard case .remoteCommand(.write(let deserializedId, let deserializedData, let deserializedReplyTo)) = deserialized else {
+            throw self.testKit.fail("Should be RemoteCommand.write message")
         }
+        deserializedId.shouldEqual(id)
+        deserializedReplyTo.shouldEqual(resultProbe.ref)
+
+        guard let dg1 = deserializedData as? CRDT.GCounter else {
+            throw self.testKit.fail("Should be a GCounter")
+        }
+        dg1.value.shouldEqual(g1.value)
+        dg1.delta.shouldNotBeNil()
     }
 
     func test_serializationOf_RemoteCommand_write_ORSet() throws {
-        try shouldNotThrow {
-            let id = CRDT.Identity("set-1")
-            var set = CRDT.ORSet<String>(replicaID: .actorAddress(self.ownerAlpha))
-            set.insert("hello")
-            set.insert("world")
-            set.delta.shouldNotBeNil()
+        let id = CRDT.Identity("set-1")
+        var set = CRDT.ORSet<String>(replicaID: .actorAddress(self.ownerAlpha))
+        set.insert("hello")
+        set.insert("world")
+        set.delta.shouldNotBeNil()
 
-            let resultProbe = self.testKit.spawnTestProbe(expecting: CRDT.Replicator.RemoteCommand.WriteResult.self)
-            let write: CRDT.Replicator.Message = .remoteCommand(.write(id, set, replyTo: resultProbe.ref))
+        let resultProbe = self.testKit.spawnTestProbe(expecting: CRDT.Replicator.RemoteCommand.WriteResult.self)
+        let write: CRDT.Replicator.Message = .remoteCommand(.write(id, set, replyTo: resultProbe.ref))
 
-            let serialized = try system.serialization.serialize(write)
-            let deserialized = try system.serialization.deserialize(as: CRDT.Replicator.Message.self, from: serialized)
+        let serialized = try system.serialization.serialize(write)
+        let deserialized = try system.serialization.deserialize(as: CRDT.Replicator.Message.self, from: serialized)
 
-            guard case .remoteCommand(.write(let deserializedId, let deserializedData, let deserializedReplyTo)) = deserialized else {
-                throw self.testKit.fail("Should be RemoteCommand.write message")
-            }
-            deserializedId.shouldEqual(id)
-            deserializedReplyTo.shouldEqual(resultProbe.ref)
-
-            guard let dset = deserializedData as? CRDT.ORSet<String> else {
-                throw self.testKit.fail("Should be a ORSet<String>")
-            }
-            dset.elements.shouldEqual(set.elements)
-            dset.delta.shouldNotBeNil()
+        guard case .remoteCommand(.write(let deserializedId, let deserializedData, let deserializedReplyTo)) = deserialized else {
+            throw self.testKit.fail("Should be RemoteCommand.write message")
         }
+        deserializedId.shouldEqual(id)
+        deserializedReplyTo.shouldEqual(resultProbe.ref)
+
+        guard let dset = deserializedData as? CRDT.ORSet<String> else {
+            throw self.testKit.fail("Should be a ORSet<String>")
+        }
+        dset.elements.shouldEqual(set.elements)
+        dset.delta.shouldNotBeNil()
     }
 
     func test_serializationOf_RemoteCommand_writeDelta_GCounter() throws {
-        try shouldNotThrow {
-            let id = CRDT.Identity("gcounter-1")
-            var g1 = CRDT.GCounter(replicaID: .actorAddress(self.ownerAlpha))
-            g1.increment(by: 5)
-            g1.delta.shouldNotBeNil()
+        let id = CRDT.Identity("gcounter-1")
+        var g1 = CRDT.GCounter(replicaID: .actorAddress(self.ownerAlpha))
+        g1.increment(by: 5)
+        g1.delta.shouldNotBeNil()
 
-            let resultProbe = self.testKit.spawnTestProbe(expecting: WriteResult.self)
-            let write: CRDT.Replicator.Message = .remoteCommand(.writeDelta(id, delta: g1.delta!, replyTo: resultProbe.ref)) // !-safe since we check for nil above
+        let resultProbe = self.testKit.spawnTestProbe(expecting: WriteResult.self)
+        let write: CRDT.Replicator.Message = .remoteCommand(.writeDelta(id, delta: g1.delta!, replyTo: resultProbe.ref)) // !-safe since we check for nil above
 
-            let serialized = try system.serialization.serialize(write)
-            let deserialized = try system.serialization.deserialize(as: CRDT.Replicator.Message.self, from: serialized)
+        let serialized = try system.serialization.serialize(write)
+        let deserialized = try system.serialization.deserialize(as: CRDT.Replicator.Message.self, from: serialized)
 
-            guard case .remoteCommand(.writeDelta(let deserializedId, let deserializedDelta, let deserializedReplyTo)) = deserialized else {
-                throw self.testKit.fail("Should be RemoteCommand.write message")
-            }
-            deserializedId.shouldEqual(id)
-            deserializedReplyTo.shouldEqual(resultProbe.ref)
-
-            guard let ddg1 = deserializedDelta as? CRDT.GCounterDelta else {
-                throw self.testKit.fail("Should be a GCounter")
-            }
-            "\(ddg1.state)".shouldContain("[actor:sact://CRDTReplicationSerializationTests@127.0.0.1:9001/user/alpha: 5]")
+        guard case .remoteCommand(.writeDelta(let deserializedId, let deserializedDelta, let deserializedReplyTo)) = deserialized else {
+            throw self.testKit.fail("Should be RemoteCommand.write message")
         }
+        deserializedId.shouldEqual(id)
+        deserializedReplyTo.shouldEqual(resultProbe.ref)
+
+        guard let ddg1 = deserializedDelta as? CRDT.GCounterDelta else {
+            throw self.testKit.fail("Should be a GCounter")
+        }
+        "\(ddg1.state)".shouldContain("[actor:sact://CRDTReplicationSerializationTests@127.0.0.1:9001/user/alpha: 5]")
     }
 
     func test_serializationOf_RemoteCommand_WriteResult_success() throws {
-        try shouldNotThrow {
-            let result = WriteResult.success
+        let result = WriteResult.success
 
-            let serialized = try system.serialization.serialize(result)
-            let deserialized = try system.serialization.deserialize(as: WriteResult.self, from: serialized)
+        let serialized = try system.serialization.serialize(result)
+        let deserialized = try system.serialization.deserialize(as: WriteResult.self, from: serialized)
 
-            guard case .success = deserialized else {
-                throw self.testKit.fail("Should be RemoteCommand.WriteResult.success message")
-            }
+        guard case .success = deserialized else {
+            throw self.testKit.fail("Should be RemoteCommand.WriteResult.success message")
         }
     }
 
     func test_serializationOf_RemoteCommand_WriteResult_failed() throws {
-        try shouldNotThrow {
-            let hint = "should be this other type"
-            let result = WriteResult.failure(.inputAndStoredDataTypeMismatch(hint: hint))
+        let hint = "should be this other type"
+        let result = WriteResult.failure(.inputAndStoredDataTypeMismatch(hint: hint))
 
-            let serialized = try system.serialization.serialize(result)
-            let deserialized = try system.serialization.deserialize(as: WriteResult.self, from: serialized)
+        let serialized = try system.serialization.serialize(result)
+        let deserialized = try system.serialization.deserialize(as: WriteResult.self, from: serialized)
 
-            guard case .failure(.inputAndStoredDataTypeMismatch(let deserializedHint)) = deserialized else {
-                throw self.testKit.fail("Should be RemoteCommand.WriteResult.failure message with .inputAndStoredDataTypeMismatch error")
-            }
-            deserializedHint.shouldEqual(hint)
+        guard case .failure(.inputAndStoredDataTypeMismatch(let deserializedHint)) = deserialized else {
+            throw self.testKit.fail("Should be RemoteCommand.WriteResult.failure message with .inputAndStoredDataTypeMismatch error")
         }
+        deserializedHint.shouldEqual(hint)
     }
 
     // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: CRDT.Replicator.RemoteCommand.read
 
     func test_serializationOf_RemoteCommand_read() throws {
-        try shouldNotThrow {
-            let id = CRDT.Identity("gcounter-1")
+        let id = CRDT.Identity("gcounter-1")
 
-            let resultProbe = self.testKit.spawnTestProbe(expecting: ReadResult.self)
-            let read: CRDT.Replicator.Message = .remoteCommand(.read(id, replyTo: resultProbe.ref))
+        let resultProbe = self.testKit.spawnTestProbe(expecting: ReadResult.self)
+        let read: CRDT.Replicator.Message = .remoteCommand(.read(id, replyTo: resultProbe.ref))
 
-            let serialized = try system.serialization.serialize(read)
-            let deserialized = try system.serialization.deserialize(as: CRDT.Replicator.Message.self, from: serialized)
+        let serialized = try system.serialization.serialize(read)
+        let deserialized = try system.serialization.deserialize(as: CRDT.Replicator.Message.self, from: serialized)
 
-            guard case .remoteCommand(.read(let deserializedId, let deserializedReplyTo)) = deserialized else {
-                throw self.testKit.fail("Should be RemoteCommand.read message")
-            }
-            deserializedId.shouldEqual(id)
-            deserializedReplyTo.shouldEqual(resultProbe.ref)
+        guard case .remoteCommand(.read(let deserializedId, let deserializedReplyTo)) = deserialized else {
+            throw self.testKit.fail("Should be RemoteCommand.read message")
         }
+        deserializedId.shouldEqual(id)
+        deserializedReplyTo.shouldEqual(resultProbe.ref)
     }
 
     func test_serializationOf_RemoteCommand_ReadResult_success() throws {
-        try shouldNotThrow {
-            var g1 = CRDT.GCounter(replicaID: .actorAddress(self.ownerAlpha))
-            g1.increment(by: 5)
-            g1.delta.shouldNotBeNil()
+        var g1 = CRDT.GCounter(replicaID: .actorAddress(self.ownerAlpha))
+        g1.increment(by: 5)
+        g1.delta.shouldNotBeNil()
 
-            let result = ReadResult.success(g1)
+        let result = ReadResult.success(g1)
 
-            let serialized = try system.serialization.serialize(result)
-            let deserialized = try system.serialization.deserialize(as: ReadResult.self, from: serialized)
+        let serialized = try system.serialization.serialize(result)
+        let deserialized = try system.serialization.deserialize(as: ReadResult.self, from: serialized)
 
-            guard case .success(let deserializedData) = deserialized else {
-                throw self.testKit.fail("Should be RemoteCommand.ReadResult.success message")
-            }
-            guard let dg1 = deserializedData as? CRDT.GCounter else {
-                throw self.testKit.fail("Should be a GCounter")
-            }
-            dg1.value.shouldEqual(g1.value)
-            dg1.delta.shouldNotBeNil()
+        guard case .success(let deserializedData) = deserialized else {
+            throw self.testKit.fail("Should be RemoteCommand.ReadResult.success message")
         }
+        guard let dg1 = deserializedData as? CRDT.GCounter else {
+            throw self.testKit.fail("Should be a GCounter")
+        }
+        dg1.value.shouldEqual(g1.value)
+        dg1.delta.shouldNotBeNil()
     }
 
     func test_serializationOf_RemoteCommand_ReadResult_failed() throws {
-        try shouldNotThrow {
-            let result = ReadResult.failure(.notFound)
+        let result = ReadResult.failure(.notFound)
 
-            let serialized = try system.serialization.serialize(result)
-            let deserialized = try system.serialization.deserialize(as: ReadResult.self, from: serialized)
+        let serialized = try system.serialization.serialize(result)
+        let deserialized = try system.serialization.deserialize(as: ReadResult.self, from: serialized)
 
-            guard case .failure(.notFound) = deserialized else {
-                throw self.testKit.fail("Should be RemoteCommand.ReadResult.failure message with .notFound error")
-            }
+        guard case .failure(.notFound) = deserialized else {
+            throw self.testKit.fail("Should be RemoteCommand.ReadResult.failure message with .notFound error")
         }
     }
 
@@ -204,33 +188,29 @@ final class CRDTReplicationSerializationTests: ActorSystemXCTestCase {
     // MARK: CRDT.Replicator.RemoteCommand.delete
 
     func test_serializationOf_RemoteCommand_delete() throws {
-        try shouldNotThrow {
-            let id = CRDT.Identity("gcounter-1")
+        let id = CRDT.Identity("gcounter-1")
 
-            let resultProbe = self.testKit.spawnTestProbe(expecting: DeleteResult.self)
-            let delete: CRDT.Replicator.Message = .remoteCommand(.delete(id, replyTo: resultProbe.ref))
+        let resultProbe = self.testKit.spawnTestProbe(expecting: DeleteResult.self)
+        let delete: CRDT.Replicator.Message = .remoteCommand(.delete(id, replyTo: resultProbe.ref))
 
-            let serialized = try system.serialization.serialize(delete)
-            let deserialized = try system.serialization.deserialize(as: CRDT.Replicator.Message.self, from: serialized)
+        let serialized = try system.serialization.serialize(delete)
+        let deserialized = try system.serialization.deserialize(as: CRDT.Replicator.Message.self, from: serialized)
 
-            guard case .remoteCommand(.delete(let deserializedId, let deserializedReplyTo)) = deserialized else {
-                throw self.testKit.fail("Should be RemoteCommand.delete message")
-            }
-            deserializedId.shouldEqual(id)
-            deserializedReplyTo.shouldEqual(resultProbe.ref)
+        guard case .remoteCommand(.delete(let deserializedId, let deserializedReplyTo)) = deserialized else {
+            throw self.testKit.fail("Should be RemoteCommand.delete message")
         }
+        deserializedId.shouldEqual(id)
+        deserializedReplyTo.shouldEqual(resultProbe.ref)
     }
 
     func test_serializationOf_RemoteCommand_DeleteResult_success() throws {
-        try shouldNotThrow {
-            let result = DeleteResult.success
+        let result = DeleteResult.success
 
-            let serialized = try system.serialization.serialize(result)
-            let deserialized = try system.serialization.deserialize(as: DeleteResult.self, from: serialized)
+        let serialized = try system.serialization.serialize(result)
+        let deserialized = try system.serialization.deserialize(as: DeleteResult.self, from: serialized)
 
-            guard case .success = deserialized else {
-                throw self.testKit.fail("Should be RemoteCommand.DeleteResult.success message")
-            }
+        guard case .success = deserialized else {
+            throw self.testKit.fail("Should be RemoteCommand.DeleteResult.success message")
         }
     }
 }

--- a/Tests/DistributedActorsTests/Cluster/ClusterLeaderActionsClusteredTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/ClusterLeaderActionsClusteredTests.swift
@@ -23,183 +23,175 @@ final class ClusterLeaderActionsClusteredTests: ClusteredActorSystemsXCTestCase 
     // MARK: leader decision: .joining -> .up
 
     func test_singleLeader() throws {
-        try shouldNotThrow {
-            let first = self.setUpNode("first") { settings in
-                settings.cluster.node.port = 7111
-                settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 1)
-            }
+        let first = self.setUpNode("first") { settings in
+            settings.cluster.node.port = 7111
+            settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 1)
+        }
 
-            let p = self.testKit(first).spawnTestProbe(expecting: Cluster.Event.self)
+        let p = self.testKit(first).spawnTestProbe(expecting: Cluster.Event.self)
 
-            _ = try first.spawn(
-                "selfishSingleLeader",
-                Behavior<Cluster.Event>.setup { context in
-                    context.system.cluster.events.subscribe(context.myself)
+        _ = try first.spawn(
+            "selfishSingleLeader",
+            Behavior<Cluster.Event>.setup { context in
+                context.system.cluster.events.subscribe(context.myself)
 
-                    return .receiveMessage { event in
-                        switch event {
-                        case .leadershipChange:
-                            p.tell(event)
-                            return .same
-                        default:
-                            return .same
-                        }
+                return .receiveMessage { event in
+                    switch event {
+                    case .leadershipChange:
+                        p.tell(event)
+                        return .same
+                    default:
+                        return .same
                     }
                 }
-            )
-
-            switch try p.expectMessage() {
-            case .leadershipChange(let change):
-                guard let leader = change.newLeader else {
-                    throw self.testKit(first).fail("Expected \(first.cluster.node) to be leader")
-                }
-                leader.node.shouldEqual(first.cluster.node)
-            default:
-                throw self.testKit(first).fail("Expected leader change event")
             }
+        )
+
+        switch try p.expectMessage() {
+        case .leadershipChange(let change):
+            guard let leader = change.newLeader else {
+                throw self.testKit(first).fail("Expected \(first.cluster.node) to be leader")
+            }
+            leader.node.shouldEqual(first.cluster.node)
+        default:
+            throw self.testKit(first).fail("Expected leader change event")
         }
     }
 
     func test_joining_to_up_decisionByLeader() throws {
-        try shouldNotThrow {
-            let first = self.setUpNode("first") { settings in
-                settings.cluster.node.port = 7111
-                settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
-            }
-            let second = self.setUpNode("second") { settings in
-                settings.cluster.node.port = 8222
-                settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
-            }
-            let third = self.setUpNode("third") { settings in
-                settings.cluster.node.port = 9333
-                settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
-            }
+        let first = self.setUpNode("first") { settings in
+            settings.cluster.node.port = 7111
+            settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
+        }
+        let second = self.setUpNode("second") { settings in
+            settings.cluster.node.port = 8222
+            settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
+        }
+        let third = self.setUpNode("third") { settings in
+            settings.cluster.node.port = 9333
+            settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
+        }
 
-            first.cluster.join(node: second.cluster.node.node)
-            third.cluster.join(node: second.cluster.node.node)
+        first.cluster.join(node: second.cluster.node.node)
+        third.cluster.join(node: second.cluster.node.node)
 
-            try assertAssociated(first, withAtLeast: second.cluster.node)
-            try assertAssociated(second, withAtLeast: third.cluster.node)
-            try assertAssociated(first, withAtLeast: third.cluster.node)
+        try assertAssociated(first, withAtLeast: second.cluster.node)
+        try assertAssociated(second, withAtLeast: third.cluster.node)
+        try assertAssociated(first, withAtLeast: third.cluster.node)
 
-            try self.testKit(first).eventually(within: .seconds(10)) {
-                try self.assertMemberStatus(on: first, node: first.cluster.node, is: .up)
-                try self.assertMemberStatus(on: first, node: second.cluster.node, is: .up)
-                try self.assertMemberStatus(on: first, node: third.cluster.node, is: .up)
-            }
+        try self.testKit(first).eventually(within: .seconds(10)) {
+            try self.assertMemberStatus(on: first, node: first.cluster.node, is: .up)
+            try self.assertMemberStatus(on: first, node: second.cluster.node, is: .up)
+            try self.assertMemberStatus(on: first, node: third.cluster.node, is: .up)
+        }
 
-            try self.testKit(second).eventually(within: .seconds(10)) {
-                try self.assertMemberStatus(on: second, node: first.cluster.node, is: .up)
-                try self.assertMemberStatus(on: second, node: second.cluster.node, is: .up)
-                try self.assertMemberStatus(on: second, node: third.cluster.node, is: .up)
-            }
+        try self.testKit(second).eventually(within: .seconds(10)) {
+            try self.assertMemberStatus(on: second, node: first.cluster.node, is: .up)
+            try self.assertMemberStatus(on: second, node: second.cluster.node, is: .up)
+            try self.assertMemberStatus(on: second, node: third.cluster.node, is: .up)
+        }
 
-            try self.testKit(third).eventually(within: .seconds(10)) {
-                try self.assertMemberStatus(on: third, node: first.cluster.node, is: .up)
-                try self.assertMemberStatus(on: third, node: second.cluster.node, is: .up)
-                try self.assertMemberStatus(on: third, node: third.cluster.node, is: .up)
-            }
+        try self.testKit(third).eventually(within: .seconds(10)) {
+            try self.assertMemberStatus(on: third, node: first.cluster.node, is: .up)
+            try self.assertMemberStatus(on: third, node: second.cluster.node, is: .up)
+            try self.assertMemberStatus(on: third, node: third.cluster.node, is: .up)
         }
     }
 
     func test_joining_to_up_earlyYetStillLettingAllNodesKnowAboutLatestMembershipStatus() throws {
-        try shouldNotThrow {
-            // This showcases a racy situation, where we allow a leader elected when at least 2 nodes joined
-            // yet we actually join 3 nodes -- meaning that the joining up is _slightly_ racy:
-            // - maybe nodes 1 and 2 join each other first and 1 starts upping
-            // - maybe nodes 2 and 3 join each other and 2 starts upping
-            // - and at the same time, maybe while 1 and 2 have started joining, 2 and 3 already joined, and 2 issued up for itself and 3
-            //
-            // All this is _fine_. The cluster leader is such that under whichever rules we allowed it to be elected
-            // it shall perform its duties. This tests however quickly shows that lack of letting the "third" node,
-            // via gossip or some other way about the ->up of other nodes once it joins the "others", it'd be stuck waiting for
-            // the ->up forever.
-            //
-            // In other words, this test exercises that there must be _some_ (gossip, or similar "push" membership once a new member joins),
-            // to a new member.
-            //
-            let first = self.setUpNode("first") { settings in
-                settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 2)
-            }
-            let second = self.setUpNode("second") { settings in
-                settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 2)
-            }
-            let third = self.setUpNode("third") { settings in
-                settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 2)
-            }
-
-            let fourth = self.setUpNode("fourth") { settings in
-                settings.cluster.autoLeaderElection = .none // even without election running, it will be notified by things by the others
-            }
-
-            first.cluster.join(node: second.cluster.node.node)
-            third.cluster.join(node: second.cluster.node.node)
-            try self.ensureNodes(.up, within: .seconds(10), nodes: first.cluster.node, second.cluster.node, third.cluster.node)
-
-            // Even the fourth node now could join and be notified about all the existing up members.
-            // It does not even have to run any leadership election -- there are leaders in the cluster.
-            //
-            // We only join one arbitrary node, we will be notified about all nodes:
-            fourth.cluster.join(node: third.cluster.node.node)
-
-            try self.ensureNodes(.up, within: .seconds(10), nodes: first.cluster.node, second.cluster.node, third.cluster.node, fourth.cluster.node)
+        // This showcases a racy situation, where we allow a leader elected when at least 2 nodes joined
+        // yet we actually join 3 nodes -- meaning that the joining up is _slightly_ racy:
+        // - maybe nodes 1 and 2 join each other first and 1 starts upping
+        // - maybe nodes 2 and 3 join each other and 2 starts upping
+        // - and at the same time, maybe while 1 and 2 have started joining, 2 and 3 already joined, and 2 issued up for itself and 3
+        //
+        // All this is _fine_. The cluster leader is such that under whichever rules we allowed it to be elected
+        // it shall perform its duties. This tests however quickly shows that lack of letting the "third" node,
+        // via gossip or some other way about the ->up of other nodes once it joins the "others", it'd be stuck waiting for
+        // the ->up forever.
+        //
+        // In other words, this test exercises that there must be _some_ (gossip, or similar "push" membership once a new member joins),
+        // to a new member.
+        //
+        let first = self.setUpNode("first") { settings in
+            settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 2)
         }
+        let second = self.setUpNode("second") { settings in
+            settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 2)
+        }
+        let third = self.setUpNode("third") { settings in
+            settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 2)
+        }
+
+        let fourth = self.setUpNode("fourth") { settings in
+            settings.cluster.autoLeaderElection = .none // even without election running, it will be notified by things by the others
+        }
+
+        first.cluster.join(node: second.cluster.node.node)
+        third.cluster.join(node: second.cluster.node.node)
+        try self.ensureNodes(.up, within: .seconds(10), nodes: first.cluster.node, second.cluster.node, third.cluster.node)
+
+        // Even the fourth node now could join and be notified about all the existing up members.
+        // It does not even have to run any leadership election -- there are leaders in the cluster.
+        //
+        // We only join one arbitrary node, we will be notified about all nodes:
+        fourth.cluster.join(node: third.cluster.node.node)
+
+        try self.ensureNodes(.up, within: .seconds(10), nodes: first.cluster.node, second.cluster.node, third.cluster.node, fourth.cluster.node)
     }
 
     func test_up_ensureAllSubscribersGetMovingUpEvents() throws {
-        try shouldNotThrow {
-            // it shall perform its duties. This tests however quickly shows that lack of letting the "third" node,
-            // via gossip or some other way about the ->up of other nodes once it joins the "others", it'd be stuck waiting for
-            // the ->up forever.
-            //
-            // In other words, this test exercises that there must be _some_ (gossip, or similar "push" membership once a new member joins),
-            // to a new member.
-            //
-            let first = self.setUpNode("first") { settings in
-                settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 2)
-            }
-            let second = self.setUpNode("second") { settings in
-                settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 2)
-            }
-
-            let p1 = self.testKit(first).spawnTestProbe(expecting: Cluster.Event.self)
-            first.cluster.events.subscribe(p1.ref)
-            let p2 = self.testKit(second).spawnTestProbe(expecting: Cluster.Event.self)
-            second.cluster.events.subscribe(p2.ref)
-
-            first.cluster.join(node: second.cluster.node.node)
-
-            // this ensures that the membership, as seen in ClusterShell converged on all members being up
-            try self.ensureNodes(.up, nodes: first.cluster.node, second.cluster.node)
-
-            // the following tests confirm that the manually subscribed actors, got all the events they expected
-            func assertExpectedClusterEvents(events: [Cluster.Event], probe: ActorTestProbe<Cluster.Event>) throws { // the specific type of snapshot we get is slightly racy: it could be .empty or contain already the node itself
-                guard case .some(Cluster.Event.snapshot) = events.first else {
-                    throw probe.error("First event always expected to be .snapshot, was: \(optional: events.first)")
-                }
-
-                // both nodes moved up
-                events.filter { event in
-                    switch event {
-                    case .membershipChange(let change) where change.isUp:
-                        return true
-                    default:
-                        return false
-                    }
-                }.count.shouldEqual(2) // both nodes moved to up
-
-                // the leader is the right node
-                events.shouldContain(.leadershipChange(Cluster.LeadershipChange(oldLeader: nil, newLeader: .init(node: first.cluster.node, status: .joining))!)) // !-safe, since new/old leader known to be different
-            }
-
-            // collect all events until we see leadership change; we should already have seen members become up then
-            let eventsOnFirstSub = try collectUntilAllMembers(p1, status: .up)
-            try assertExpectedClusterEvents(events: eventsOnFirstSub, probe: p1)
-
-            // on non-leader node
-            let eventsOnSecondSub = try collectUntilAllMembers(p2, status: .up)
-            try assertExpectedClusterEvents(events: eventsOnSecondSub, probe: p2)
+        // it shall perform its duties. This tests however quickly shows that lack of letting the "third" node,
+        // via gossip or some other way about the ->up of other nodes once it joins the "others", it'd be stuck waiting for
+        // the ->up forever.
+        //
+        // In other words, this test exercises that there must be _some_ (gossip, or similar "push" membership once a new member joins),
+        // to a new member.
+        //
+        let first = self.setUpNode("first") { settings in
+            settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 2)
         }
+        let second = self.setUpNode("second") { settings in
+            settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 2)
+        }
+
+        let p1 = self.testKit(first).spawnTestProbe(expecting: Cluster.Event.self)
+        first.cluster.events.subscribe(p1.ref)
+        let p2 = self.testKit(second).spawnTestProbe(expecting: Cluster.Event.self)
+        second.cluster.events.subscribe(p2.ref)
+
+        first.cluster.join(node: second.cluster.node.node)
+
+        // this ensures that the membership, as seen in ClusterShell converged on all members being up
+        try self.ensureNodes(.up, nodes: first.cluster.node, second.cluster.node)
+
+        // the following tests confirm that the manually subscribed actors, got all the events they expected
+        func assertExpectedClusterEvents(events: [Cluster.Event], probe: ActorTestProbe<Cluster.Event>) throws { // the specific type of snapshot we get is slightly racy: it could be .empty or contain already the node itself
+            guard case .some(Cluster.Event.snapshot) = events.first else {
+                throw probe.error("First event always expected to be .snapshot, was: \(optional: events.first)")
+            }
+
+            // both nodes moved up
+            events.filter { event in
+                switch event {
+                case .membershipChange(let change) where change.isUp:
+                    return true
+                default:
+                    return false
+                }
+            }.count.shouldEqual(2) // both nodes moved to up
+
+            // the leader is the right node
+            events.shouldContain(.leadershipChange(Cluster.LeadershipChange(oldLeader: nil, newLeader: .init(node: first.cluster.node, status: .joining))!)) // !-safe, since new/old leader known to be different
+        }
+
+        // collect all events until we see leadership change; we should already have seen members become up then
+        let eventsOnFirstSub = try collectUntilAllMembers(p1, status: .up)
+        try assertExpectedClusterEvents(events: eventsOnFirstSub, probe: p1)
+
+        // on non-leader node
+        let eventsOnSecondSub = try collectUntilAllMembers(p2, status: .up)
+        try assertExpectedClusterEvents(events: eventsOnSecondSub, probe: p2)
     }
 
     private func collectUntilAllMembers(_ probe: ActorTestProbe<Cluster.Event>, status: Cluster.MemberStatus) throws -> [Cluster.Event] {
@@ -226,132 +218,128 @@ final class ClusterLeaderActionsClusteredTests: ClusteredActorSystemsXCTestCase 
     // MARK: .down -> removal
 
     func test_down_to_removed_ensureRemovalHappensWhenAllHaveSeenDown() throws {
-        try shouldNotThrow {
-            let first = self.setUpNode("first") { settings in
-                settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 2)
-                settings.cluster.downingStrategy = .timeout(.init(downUnreachableMembersAfter: .milliseconds(300)))
+        let first = self.setUpNode("first") { settings in
+            settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 2)
+            settings.cluster.downingStrategy = .timeout(.init(downUnreachableMembersAfter: .milliseconds(300)))
+        }
+        let p1 = self.testKit(first).spawnTestProbe(expecting: Cluster.Event.self)
+        first.cluster.events.subscribe(p1.ref)
+
+        let second = self.setUpNode("second") { settings in
+            settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 2)
+            settings.cluster.downingStrategy = .timeout(.init(downUnreachableMembersAfter: .milliseconds(300)))
+        }
+        let p2 = self.testKit(second).spawnTestProbe(expecting: Cluster.Event.self)
+        second.cluster.events.subscribe(p2.ref)
+
+        let third = self.setUpNode("third") { settings in
+            settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 2)
+            settings.cluster.downingStrategy = .timeout(.init(downUnreachableMembersAfter: .milliseconds(300)))
+        }
+        let p3 = self.testKit(third).spawnTestProbe(expecting: Cluster.Event.self)
+        third.cluster.events.subscribe(p3.ref)
+
+        try self.joinNodes(node: first, with: second)
+        try self.joinNodes(node: second, with: third)
+        try self.joinNodes(node: first, with: third)
+
+        let secondNode = second.cluster.node
+        try self.ensureNodes(.up, nodes: first.cluster.node, secondNode, third.cluster.node)
+
+        first.cluster.down(node: secondNode.node)
+
+        // other nodes have observed it down
+        try self.ensureNodes(.down, on: first, nodes: secondNode)
+        try self.ensureNodes(.down, on: third, nodes: secondNode)
+
+        // on the leader node, the other node noticed as up:
+        var eventsOnFirstSub: [Cluster.Event] = []
+        var downFound = false
+        while eventsOnFirstSub.count < 12, !downFound {
+            let event = try p1.expectMessage()
+            pinfo("Captured event: \(event)")
+            eventsOnFirstSub.append(event)
+
+            switch event {
+            case .membershipChange(let change) where change.toStatus.isDown:
+                downFound = true
+            default:
+                ()
             }
-            let p1 = self.testKit(first).spawnTestProbe(expecting: Cluster.Event.self)
-            first.cluster.events.subscribe(p1.ref)
+        }
 
-            let second = self.setUpNode("second") { settings in
-                settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 2)
-                settings.cluster.downingStrategy = .timeout(.init(downUnreachableMembersAfter: .milliseconds(300)))
-            }
-            let p2 = self.testKit(second).spawnTestProbe(expecting: Cluster.Event.self)
-            second.cluster.events.subscribe(p2.ref)
+        eventsOnFirstSub.shouldContain(.snapshot(.empty))
+        eventsOnFirstSub.shouldContain(.membershipChange(.init(node: first.cluster.node, fromStatus: nil, toStatus: .joining)))
+        eventsOnFirstSub.shouldContain(.membershipChange(.init(node: secondNode, fromStatus: nil, toStatus: .joining)))
+        eventsOnFirstSub.shouldContain(.membershipChange(.init(node: first.cluster.node, fromStatus: .joining, toStatus: .up)))
+        eventsOnFirstSub.shouldContain(.membershipChange(.init(node: secondNode, fromStatus: .joining, toStatus: .up)))
+        eventsOnFirstSub.shouldContain(.leadershipChange(Cluster.LeadershipChange(oldLeader: nil, newLeader: .init(node: first.cluster.node, status: .joining))!)) // !-safe, since new/old leader known to be different
+        eventsOnFirstSub.shouldContain(.membershipChange(.init(node: third.cluster.node, fromStatus: nil, toStatus: .joining)))
+        eventsOnFirstSub.shouldContain(.membershipChange(.init(node: third.cluster.node, fromStatus: .joining, toStatus: .up)))
 
-            let third = self.setUpNode("third") { settings in
-                settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 2)
-                settings.cluster.downingStrategy = .timeout(.init(downUnreachableMembersAfter: .milliseconds(300)))
-            }
-            let p3 = self.testKit(third).spawnTestProbe(expecting: Cluster.Event.self)
-            third.cluster.events.subscribe(p3.ref)
+        eventsOnFirstSub.shouldContain(.membershipChange(.init(node: secondNode, fromStatus: .up, toStatus: .down)))
 
-            try self.joinNodes(node: first, with: second)
-            try self.joinNodes(node: second, with: third)
-            try self.joinNodes(node: first, with: third)
-
-            let secondNode = second.cluster.node
-            try self.ensureNodes(.up, nodes: first.cluster.node, secondNode, third.cluster.node)
-
-            first.cluster.down(node: secondNode.node)
-
-            // other nodes have observed it down
-            try self.ensureNodes(.down, on: first, nodes: secondNode)
-            try self.ensureNodes(.down, on: third, nodes: secondNode)
-
-            // on the leader node, the other node noticed as up:
-            var eventsOnFirstSub: [Cluster.Event] = []
-            var downFound = false
-            while eventsOnFirstSub.count < 12, !downFound {
-                let event = try p1.expectMessage()
-                pinfo("Captured event: \(event)")
-                eventsOnFirstSub.append(event)
-
-                switch event {
-                case .membershipChange(let change) where change.toStatus.isDown:
-                    downFound = true
-                default:
-                    ()
-                }
-            }
-
-            eventsOnFirstSub.shouldContain(.snapshot(.empty))
-            eventsOnFirstSub.shouldContain(.membershipChange(.init(node: first.cluster.node, fromStatus: nil, toStatus: .joining)))
-            eventsOnFirstSub.shouldContain(.membershipChange(.init(node: secondNode, fromStatus: nil, toStatus: .joining)))
-            eventsOnFirstSub.shouldContain(.membershipChange(.init(node: first.cluster.node, fromStatus: .joining, toStatus: .up)))
-            eventsOnFirstSub.shouldContain(.membershipChange(.init(node: secondNode, fromStatus: .joining, toStatus: .up)))
-            eventsOnFirstSub.shouldContain(.leadershipChange(Cluster.LeadershipChange(oldLeader: nil, newLeader: .init(node: first.cluster.node, status: .joining))!)) // !-safe, since new/old leader known to be different
-            eventsOnFirstSub.shouldContain(.membershipChange(.init(node: third.cluster.node, fromStatus: nil, toStatus: .joining)))
-            eventsOnFirstSub.shouldContain(.membershipChange(.init(node: third.cluster.node, fromStatus: .joining, toStatus: .up)))
-
-            eventsOnFirstSub.shouldContain(.membershipChange(.init(node: secondNode, fromStatus: .up, toStatus: .down)))
-
-            try self.testKit(first).eventually(within: .seconds(3)) {
-                let p1s = self.testKit(first).spawnTestProbe(expecting: Cluster.Membership.self)
-                first.cluster.ref.tell(.query(.currentMembership(p1s.ref)))
-            }
+        try self.testKit(first).eventually(within: .seconds(3)) {
+            let p1s = self.testKit(first).spawnTestProbe(expecting: Cluster.Membership.self)
+            first.cluster.ref.tell(.query(.currentMembership(p1s.ref)))
         }
     }
 
     func test_ensureDownAndRemovalSpreadsToAllMembers() throws {
-        try shouldNotThrow {
-            let first = self.setUpNode("first") { settings in
-                settings.cluster.swim.probeInterval = .milliseconds(300)
-                settings.cluster.swim.pingTimeout = .milliseconds(100)
-                settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 2)
-                settings.cluster.downingStrategy = .timeout(.init(downUnreachableMembersAfter: .milliseconds(200)))
+        let first = self.setUpNode("first") { settings in
+            settings.cluster.swim.probeInterval = .milliseconds(300)
+            settings.cluster.swim.pingTimeout = .milliseconds(100)
+            settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 2)
+            settings.cluster.downingStrategy = .timeout(.init(downUnreachableMembersAfter: .milliseconds(200)))
+        }
+        let p1 = self.testKit(first).spawnTestProbe(expecting: Cluster.Event.self)
+        first.cluster.events.subscribe(p1.ref)
+
+        let second = self.setUpNode("second") { settings in
+            settings.cluster.swim.probeInterval = .milliseconds(300)
+            settings.cluster.swim.pingTimeout = .milliseconds(100)
+            settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 2)
+            settings.cluster.downingStrategy = .timeout(.init(downUnreachableMembersAfter: .milliseconds(200)))
+        }
+        let p2 = self.testKit(second).spawnTestProbe(expecting: Cluster.Event.self)
+        second.cluster.events.subscribe(p2.ref)
+
+        let third = self.setUpNode("third") { settings in
+            settings.cluster.swim.probeInterval = .milliseconds(300)
+            settings.cluster.swim.pingTimeout = .milliseconds(100)
+            settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 2)
+            settings.cluster.downingStrategy = .timeout(.init(downUnreachableMembersAfter: .milliseconds(200)))
+        }
+        let p3 = self.testKit(third).spawnTestProbe(expecting: Cluster.Event.self)
+        third.cluster.events.subscribe(p3.ref)
+
+        try self.joinNodes(node: first, with: second)
+        try self.joinNodes(node: second, with: third)
+        try self.joinNodes(node: first, with: third)
+
+        try self.ensureNodes(.up, nodes: first.cluster.node, second.cluster.node, third.cluster.node)
+
+        // crash the second node
+        second.shutdown()
+
+        // other nodes have observed it down
+        try self.ensureNodes(.down, on: first, within: .seconds(15), nodes: second.cluster.node)
+        try self.ensureNodes(.down, on: third, within: .seconds(15), nodes: second.cluster.node)
+
+        // on the leader node, the other node noticed as up:
+        let testKit = self.testKit(first)
+        try testKit.eventually(within: .seconds(20)) {
+            let event: Cluster.Event? = try p1.maybeExpectMessage()
+            switch event {
+            case .membershipChange(.init(node: second.cluster.node, fromStatus: .up, toStatus: .down)): ()
+            case let other: throw testKit.error("Expected `second` [     up] -> [  .down], on first node, was: \(other, orElse: "nil")")
             }
-            let p1 = self.testKit(first).spawnTestProbe(expecting: Cluster.Event.self)
-            first.cluster.events.subscribe(p1.ref)
-
-            let second = self.setUpNode("second") { settings in
-                settings.cluster.swim.probeInterval = .milliseconds(300)
-                settings.cluster.swim.pingTimeout = .milliseconds(100)
-                settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 2)
-                settings.cluster.downingStrategy = .timeout(.init(downUnreachableMembersAfter: .milliseconds(200)))
-            }
-            let p2 = self.testKit(second).spawnTestProbe(expecting: Cluster.Event.self)
-            second.cluster.events.subscribe(p2.ref)
-
-            let third = self.setUpNode("third") { settings in
-                settings.cluster.swim.probeInterval = .milliseconds(300)
-                settings.cluster.swim.pingTimeout = .milliseconds(100)
-                settings.cluster.autoLeaderElection = .lowestReachable(minNumberOfMembers: 2)
-                settings.cluster.downingStrategy = .timeout(.init(downUnreachableMembersAfter: .milliseconds(200)))
-            }
-            let p3 = self.testKit(third).spawnTestProbe(expecting: Cluster.Event.self)
-            third.cluster.events.subscribe(p3.ref)
-
-            try self.joinNodes(node: first, with: second)
-            try self.joinNodes(node: second, with: third)
-            try self.joinNodes(node: first, with: third)
-
-            try self.ensureNodes(.up, nodes: first.cluster.node, second.cluster.node, third.cluster.node)
-
-            // crash the second node
-            second.shutdown()
-
-            // other nodes have observed it down
-            try self.ensureNodes(.down, on: first, within: .seconds(15), nodes: second.cluster.node)
-            try self.ensureNodes(.down, on: third, within: .seconds(15), nodes: second.cluster.node)
-
-            // on the leader node, the other node noticed as up:
-            let testKit = self.testKit(first)
-            try testKit.eventually(within: .seconds(20)) {
-                let event: Cluster.Event? = try p1.maybeExpectMessage()
-                switch event {
-                case .membershipChange(.init(node: second.cluster.node, fromStatus: .up, toStatus: .down)): ()
-                case let other: throw testKit.error("Expected `second` [     up] -> [  .down], on first node, was: \(other, orElse: "nil")")
-                }
-            }
-            try testKit.eventually(within: .seconds(20)) {
-                let event: Cluster.Event? = try p1.maybeExpectMessage()
-                switch event {
-                case .membershipChange(.init(node: second.cluster.node, fromStatus: .down, toStatus: .removed)): ()
-                case let other: throw testKit.error("Expected `second` [     up] -> [  .down], on first node, was: \(other, orElse: "nil")")
-                }
+        }
+        try testKit.eventually(within: .seconds(20)) {
+            let event: Cluster.Event? = try p1.maybeExpectMessage()
+            switch event {
+            case .membershipChange(.init(node: second.cluster.node, fromStatus: .down, toStatus: .removed)): ()
+            case let other: throw testKit.error("Expected `second` [     up] -> [  .down], on first node, was: \(other, orElse: "nil")")
             }
         }
     }

--- a/Tests/DistributedActorsTests/Cluster/ClusterOnDownActionTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/ClusterOnDownActionTests.swift
@@ -19,38 +19,34 @@ import XCTest
 
 final class ClusterOnDownActionTests: ClusteredActorSystemsXCTestCase {
     func test_onNodeDowned_performShutdown() throws {
-        try shouldNotThrow {
-            let (first, second) = self.setUpPair { settings in
-                settings.cluster.onDownAction = .gracefulShutdown(delay: .milliseconds(300))
-            }
+        let (first, second) = self.setUpPair { settings in
+            settings.cluster.onDownAction = .gracefulShutdown(delay: .milliseconds(300))
+        }
 
-            try self.joinNodes(node: first, with: second)
+        try self.joinNodes(node: first, with: second)
 
-            second.cluster.down(node: first.cluster.node.node)
+        second.cluster.down(node: first.cluster.node.node)
 
-            try self.capturedLogs(of: first).awaitLogContaining(self.testKit(first), text: "Self node was marked [.down]!")
+        try self.capturedLogs(of: first).awaitLogContaining(self.testKit(first), text: "Self node was marked [.down]!")
 
-            try self.testKit(first).eventually(within: .seconds(3)) {
-                guard first.isShuttingDown else {
-                    throw TestError("System \(first) was not shutting down. It was marked down and the default onDownAction should have triggered!")
-                }
+        try self.testKit(first).eventually(within: .seconds(3)) {
+            guard first.isShuttingDown else {
+                throw TestError("System \(first) was not shutting down. It was marked down and the default onDownAction should have triggered!")
             }
         }
     }
 
     func test_onNodeDowned_configuredNoop_doNothing() throws {
-        try shouldNotThrow {
-            let (first, second) = self.setUpPair { settings in
-                settings.cluster.onDownAction = .none
-            }
-
-            try self.joinNodes(node: first, with: second)
-
-            second.cluster.down(node: first.cluster.node.node)
-
-            try self.capturedLogs(of: first).awaitLogContaining(self.testKit(first), text: "Self node was marked [.down]!")
-
-            first.isShuttingDown.shouldBeFalse()
+        let (first, second) = self.setUpPair { settings in
+            settings.cluster.onDownAction = .none
         }
+
+        try self.joinNodes(node: first, with: second)
+
+        second.cluster.down(node: first.cluster.node.node)
+
+        try self.capturedLogs(of: first).awaitLogContaining(self.testKit(first), text: "Self node was marked [.down]!")
+
+        first.isShuttingDown.shouldBeFalse()
     }
 }

--- a/Tests/DistributedActorsTests/Cluster/MembershipGossipClusteredTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/MembershipGossipClusteredTests.swift
@@ -38,44 +38,42 @@ final class MembershipGossipClusteredTests: ClusteredActorSystemsXCTestCase {
     // MARK: Marking .down
 
     func test_down_beGossipedToOtherNodes() throws {
-        try shouldNotThrow {
-            let strategy = ClusterSettings.LeadershipSelectionSettings.lowestReachable(minNumberOfMembers: 3)
-            let first = self.setUpNode("first") { settings in
-                settings.cluster.autoLeaderElection = strategy
-                settings.cluster.onDownAction = .none
-            }
-            let second = self.setUpNode("second") { settings in
-                settings.cluster.autoLeaderElection = strategy
-                settings.cluster.onDownAction = .none
-            }
-            let third = self.setUpNode("third") { settings in
-                settings.cluster.autoLeaderElection = strategy
-                settings.cluster.onDownAction = .none
-            }
-
-            first.cluster.join(node: second.cluster.node.node)
-            third.cluster.join(node: second.cluster.node.node)
-
-            try assertAssociated(first, withAtLeast: second.cluster.node)
-            try assertAssociated(second, withAtLeast: third.cluster.node)
-            try assertAssociated(first, withAtLeast: third.cluster.node)
-
-            try self.testKit(second).eventually(within: .seconds(10)) {
-                try self.assertMemberStatus(on: second, node: first.cluster.node, is: .up)
-                try self.assertMemberStatus(on: second, node: second.cluster.node, is: .up)
-                try self.assertMemberStatus(on: second, node: third.cluster.node, is: .up)
-            }
-
-            let firstEvents = testKit(first).spawnEventStreamTestProbe(subscribedTo: first.cluster.events)
-            let secondEvents = testKit(second).spawnEventStreamTestProbe(subscribedTo: second.cluster.events)
-            let thirdEvents = testKit(third).spawnEventStreamTestProbe(subscribedTo: third.cluster.events)
-
-            second.cluster.down(node: third.cluster.node.node)
-
-            try self.assertMemberDown(firstEvents, node: third.cluster.node)
-            try self.assertMemberDown(secondEvents, node: third.cluster.node)
-            try self.assertMemberDown(thirdEvents, node: third.cluster.node)
+        let strategy = ClusterSettings.LeadershipSelectionSettings.lowestReachable(minNumberOfMembers: 3)
+        let first = self.setUpNode("first") { settings in
+            settings.cluster.autoLeaderElection = strategy
+            settings.cluster.onDownAction = .none
         }
+        let second = self.setUpNode("second") { settings in
+            settings.cluster.autoLeaderElection = strategy
+            settings.cluster.onDownAction = .none
+        }
+        let third = self.setUpNode("third") { settings in
+            settings.cluster.autoLeaderElection = strategy
+            settings.cluster.onDownAction = .none
+        }
+
+        first.cluster.join(node: second.cluster.node.node)
+        third.cluster.join(node: second.cluster.node.node)
+
+        try assertAssociated(first, withAtLeast: second.cluster.node)
+        try assertAssociated(second, withAtLeast: third.cluster.node)
+        try assertAssociated(first, withAtLeast: third.cluster.node)
+
+        try self.testKit(second).eventually(within: .seconds(10)) {
+            try self.assertMemberStatus(on: second, node: first.cluster.node, is: .up)
+            try self.assertMemberStatus(on: second, node: second.cluster.node, is: .up)
+            try self.assertMemberStatus(on: second, node: third.cluster.node, is: .up)
+        }
+
+        let firstEvents = testKit(first).spawnEventStreamTestProbe(subscribedTo: first.cluster.events)
+        let secondEvents = testKit(second).spawnEventStreamTestProbe(subscribedTo: second.cluster.events)
+        let thirdEvents = testKit(third).spawnEventStreamTestProbe(subscribedTo: third.cluster.events)
+
+        second.cluster.down(node: third.cluster.node.node)
+
+        try self.assertMemberDown(firstEvents, node: third.cluster.node)
+        try self.assertMemberDown(secondEvents, node: third.cluster.node)
+        try self.assertMemberDown(thirdEvents, node: third.cluster.node)
     }
 
     // ==== ------------------------------------------------------------------------------------------------------------

--- a/Tests/DistributedActorsTests/Cluster/Reception/OpLogClusterReceptionistClusteredTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/Reception/OpLogClusterReceptionistClusteredTests.swift
@@ -45,133 +45,127 @@ final class OpLogClusterReceptionistClusteredTests: ClusteredActorSystemsXCTestC
     // MARK: Sync
 
     func test_shouldReplicateRegistrations() throws {
-        try shouldNotThrow {
-            let (local, remote) = setUpPair()
-            let testKit: ActorTestKit = self.testKit(local)
-            try self.joinNodes(node: local, with: remote)
+        let (local, remote) = setUpPair()
+        let testKit: ActorTestKit = self.testKit(local)
+        try self.joinNodes(node: local, with: remote)
 
-            let probe = testKit.spawnTestProbe(expecting: String.self)
-            let registeredProbe = testKit.spawnTestProbe("registered", expecting: Receptionist.Registered<String>.self)
+        let probe = testKit.spawnTestProbe(expecting: String.self)
+        let registeredProbe = testKit.spawnTestProbe("registered", expecting: Receptionist.Registered<String>.self)
 
-            let ref: ActorRef<String> = try local.spawn(
-                .anonymous,
-                .receiveMessage {
-                    probe.tell("received:\($0)")
-                    return .same
-                }
-            )
-
-            let key = Receptionist.RegistrationKey(messageType: String.self, id: "test")
-
-            // subscribe on `remote`
-            let subscriberProbe = testKit.spawnTestProbe(expecting: Receptionist.Listing<String>.self)
-            remote.receptionist.subscribe(key: key, subscriber: subscriberProbe.ref)
-            _ = try subscriberProbe.expectMessage()
-
-            // register on `local`
-            local.receptionist.register(ref, key: key, replyTo: registeredProbe.ref)
-            _ = try registeredProbe.expectMessage()
-
-            let listing = try subscriberProbe.expectMessage()
-            listing.refs.count.shouldEqual(1)
-            guard let registeredRef = listing.refs.first else {
-                throw subscriberProbe.error("listing contained no entries, expected 1")
+        let ref: ActorRef<String> = try local.spawn(
+            .anonymous,
+            .receiveMessage {
+                probe.tell("received:\($0)")
+                return .same
             }
-            registeredRef.tell("test")
+        )
 
-            try probe.expectMessage("received:test")
+        let key = Receptionist.RegistrationKey(messageType: String.self, id: "test")
+
+        // subscribe on `remote`
+        let subscriberProbe = testKit.spawnTestProbe(expecting: Receptionist.Listing<String>.self)
+        remote.receptionist.subscribe(key: key, subscriber: subscriberProbe.ref)
+        _ = try subscriberProbe.expectMessage()
+
+        // register on `local`
+        local.receptionist.register(ref, key: key, replyTo: registeredProbe.ref)
+        _ = try registeredProbe.expectMessage()
+
+        let listing = try subscriberProbe.expectMessage()
+        listing.refs.count.shouldEqual(1)
+        guard let registeredRef = listing.refs.first else {
+            throw subscriberProbe.error("listing contained no entries, expected 1")
         }
+        registeredRef.tell("test")
+
+        try probe.expectMessage("received:test")
     }
 
     func test_shouldSyncPeriodically() throws {
-        try shouldNotThrow {
-            let (local, remote) = setUpPair {
-                $0.cluster.receptionist.ackPullReplicationIntervalSlow = .seconds(1)
-            }
-
-            let probe = self.testKit(local).spawnTestProbe(expecting: String.self)
-            let registeredProbe = self.testKit(local).spawnTestProbe(expecting: Receptionist.Registered<String>.self)
-            let lookupProbe = self.testKit(local).spawnTestProbe(expecting: Receptionist.Listing<String>.self)
-
-            let ref: ActorRef<String> = try local.spawn(
-                .anonymous,
-                .receiveMessage {
-                    probe.tell("received:\($0)")
-                    return .same
-                }
-            )
-
-            let key = Receptionist.RegistrationKey(messageType: String.self, id: "test")
-
-            remote.receptionist.tell(Receptionist.Subscribe(key: key, subscriber: lookupProbe.ref))
-
-            _ = try lookupProbe.expectMessage()
-
-            local.receptionist.tell(Receptionist.Register(ref, key: key, replyTo: registeredProbe.ref))
-            _ = try registeredProbe.expectMessage()
-
-            local.cluster.join(node: remote.cluster.node.node)
-            try assertAssociated(local, withExactly: remote.settings.cluster.uniqueBindNode)
-
-            let listing = try lookupProbe.expectMessage()
-            listing.refs.count.shouldEqual(1)
-            guard let registeredRef = listing.refs.first else {
-                throw lookupProbe.error("listing contained no entries, expected 1")
-            }
-            registeredRef.tell("test")
-
-            try probe.expectMessage("received:test")
+        let (local, remote) = setUpPair {
+            $0.cluster.receptionist.ackPullReplicationIntervalSlow = .seconds(1)
         }
+
+        let probe = self.testKit(local).spawnTestProbe(expecting: String.self)
+        let registeredProbe = self.testKit(local).spawnTestProbe(expecting: Receptionist.Registered<String>.self)
+        let lookupProbe = self.testKit(local).spawnTestProbe(expecting: Receptionist.Listing<String>.self)
+
+        let ref: ActorRef<String> = try local.spawn(
+            .anonymous,
+            .receiveMessage {
+                probe.tell("received:\($0)")
+                return .same
+            }
+        )
+
+        let key = Receptionist.RegistrationKey(messageType: String.self, id: "test")
+
+        remote.receptionist.tell(Receptionist.Subscribe(key: key, subscriber: lookupProbe.ref))
+
+        _ = try lookupProbe.expectMessage()
+
+        local.receptionist.tell(Receptionist.Register(ref, key: key, replyTo: registeredProbe.ref))
+        _ = try registeredProbe.expectMessage()
+
+        local.cluster.join(node: remote.cluster.node.node)
+        try assertAssociated(local, withExactly: remote.settings.cluster.uniqueBindNode)
+
+        let listing = try lookupProbe.expectMessage()
+        listing.refs.count.shouldEqual(1)
+        guard let registeredRef = listing.refs.first else {
+            throw lookupProbe.error("listing contained no entries, expected 1")
+        }
+        registeredRef.tell("test")
+
+        try probe.expectMessage("received:test")
     }
 
     func test_shouldMergeEntriesOnSync() throws {
-        try shouldNotThrow {
-            let (local, remote) = setUpPair {
-                $0.cluster.receptionist.ackPullReplicationIntervalSlow = .seconds(1)
-            }
-
-            let registeredProbe = self.testKit(local).spawnTestProbe("registeredProbe", expecting: Receptionist.Registered<String>.self)
-            let localLookupProbe = self.testKit(local).spawnTestProbe("localLookupProbe", expecting: Receptionist.Listing<String>.self)
-            let remoteLookupProbe = self.testKit(remote).spawnTestProbe("remoteLookupProbe", expecting: Receptionist.Listing<String>.self)
-
-            let behavior: Behavior<String> = .receiveMessage { _ in
-                .same
-            }
-
-            let refA: ActorRef<String> = try local.spawn("refA", behavior)
-            let refB: ActorRef<String> = try local.spawn("refB", behavior)
-            let refC: ActorRef<String> = try remote.spawn("refC", behavior)
-            let refD: ActorRef<String> = try remote.spawn("refD", behavior)
-
-            let key = Receptionist.RegistrationKey(messageType: String.self, id: "test")
-
-            local.receptionist.tell(Receptionist.Register(refA, key: key, replyTo: registeredProbe.ref))
-            _ = try registeredProbe.expectMessage()
-
-            local.receptionist.tell(Receptionist.Register(refB, key: key, replyTo: registeredProbe.ref))
-            _ = try registeredProbe.expectMessage()
-
-            remote.receptionist.tell(Receptionist.Register(refC, key: key, replyTo: registeredProbe.ref))
-            _ = try registeredProbe.expectMessage()
-
-            remote.receptionist.tell(Receptionist.Register(refD, key: key, replyTo: registeredProbe.ref))
-            _ = try registeredProbe.expectMessage()
-
-            local.receptionist.tell(Receptionist.Subscribe(key: key, subscriber: localLookupProbe.ref))
-            _ = try localLookupProbe.expectMessage()
-
-            remote.receptionist.tell(Receptionist.Subscribe(key: key, subscriber: remoteLookupProbe.ref))
-            _ = try remoteLookupProbe.expectMessage()
-
-            local.cluster.join(node: remote.cluster.node.node)
-            try assertAssociated(local, withExactly: remote.settings.cluster.uniqueBindNode)
-
-            let localListing = try localLookupProbe.expectMessage()
-            localListing.refs.count.shouldEqual(4)
-
-            let remoteListing = try remoteLookupProbe.expectMessage()
-            remoteListing.refs.count.shouldEqual(4)
+        let (local, remote) = setUpPair {
+            $0.cluster.receptionist.ackPullReplicationIntervalSlow = .seconds(1)
         }
+
+        let registeredProbe = self.testKit(local).spawnTestProbe("registeredProbe", expecting: Receptionist.Registered<String>.self)
+        let localLookupProbe = self.testKit(local).spawnTestProbe("localLookupProbe", expecting: Receptionist.Listing<String>.self)
+        let remoteLookupProbe = self.testKit(remote).spawnTestProbe("remoteLookupProbe", expecting: Receptionist.Listing<String>.self)
+
+        let behavior: Behavior<String> = .receiveMessage { _ in
+            .same
+        }
+
+        let refA: ActorRef<String> = try local.spawn("refA", behavior)
+        let refB: ActorRef<String> = try local.spawn("refB", behavior)
+        let refC: ActorRef<String> = try remote.spawn("refC", behavior)
+        let refD: ActorRef<String> = try remote.spawn("refD", behavior)
+
+        let key = Receptionist.RegistrationKey(messageType: String.self, id: "test")
+
+        local.receptionist.tell(Receptionist.Register(refA, key: key, replyTo: registeredProbe.ref))
+        _ = try registeredProbe.expectMessage()
+
+        local.receptionist.tell(Receptionist.Register(refB, key: key, replyTo: registeredProbe.ref))
+        _ = try registeredProbe.expectMessage()
+
+        remote.receptionist.tell(Receptionist.Register(refC, key: key, replyTo: registeredProbe.ref))
+        _ = try registeredProbe.expectMessage()
+
+        remote.receptionist.tell(Receptionist.Register(refD, key: key, replyTo: registeredProbe.ref))
+        _ = try registeredProbe.expectMessage()
+
+        local.receptionist.tell(Receptionist.Subscribe(key: key, subscriber: localLookupProbe.ref))
+        _ = try localLookupProbe.expectMessage()
+
+        remote.receptionist.tell(Receptionist.Subscribe(key: key, subscriber: remoteLookupProbe.ref))
+        _ = try remoteLookupProbe.expectMessage()
+
+        local.cluster.join(node: remote.cluster.node.node)
+        try assertAssociated(local, withExactly: remote.settings.cluster.uniqueBindNode)
+
+        let localListing = try localLookupProbe.expectMessage()
+        localListing.refs.count.shouldEqual(4)
+
+        let remoteListing = try remoteLookupProbe.expectMessage()
+        remoteListing.refs.count.shouldEqual(4)
     }
 
     // ==== ------------------------------------------------------------------------------------------------------------
@@ -183,43 +177,41 @@ final class OpLogClusterReceptionistClusteredTests: ClusteredActorSystemsXCTestC
     }
 
     func shared_clusterReceptionist_shouldRemoveRemoteRefsStop(killActors: KillActorsMode) throws {
-        try shouldNotThrow {
-            let (first, second) = setUpPair {
-                $0.cluster.receptionist.ackPullReplicationIntervalSlow = .seconds(1)
-            }
-
-            let registeredProbe = self.testKit(first).spawnTestProbe(expecting: Receptionist.Registered<String>.self)
-            let remoteLookupProbe = self.testKit(second).spawnTestProbe(expecting: Receptionist.Listing<String>.self)
-
-            let refA: ActorRef<String> = try first.spawn(.anonymous, self.stopOnMessage)
-            let refB: ActorRef<String> = try first.spawn(.anonymous, self.stopOnMessage)
-
-            let key = Receptionist.RegistrationKey(messageType: String.self, id: "test")
-
-            first.receptionist.register(refA, key: key, replyTo: registeredProbe.ref)
-            _ = try registeredProbe.expectMessage()
-
-            first.receptionist.register(refB, key: key, replyTo: registeredProbe.ref)
-            _ = try registeredProbe.expectMessage()
-
-            second.receptionist.subscribe(key: key, subscriber: remoteLookupProbe.ref)
-            _ = try remoteLookupProbe.expectMessage()
-
-            first.cluster.join(node: second.cluster.node.node)
-            try assertAssociated(first, withExactly: second.settings.cluster.uniqueBindNode)
-
-            try remoteLookupProbe.eventuallyExpectListing(expected: [refA, refB], within: .seconds(3))
-
-            switch killActors {
-            case .sendStop:
-                refA.tell("stop")
-                refB.tell("stop")
-            case .shutdownNode:
-                first.shutdown().wait()
-            }
-
-            try remoteLookupProbe.eventuallyExpectListing(expected: [], within: .seconds(3))
+        let (first, second) = setUpPair {
+            $0.cluster.receptionist.ackPullReplicationIntervalSlow = .seconds(1)
         }
+
+        let registeredProbe = self.testKit(first).spawnTestProbe(expecting: Receptionist.Registered<String>.self)
+        let remoteLookupProbe = self.testKit(second).spawnTestProbe(expecting: Receptionist.Listing<String>.self)
+
+        let refA: ActorRef<String> = try first.spawn(.anonymous, self.stopOnMessage)
+        let refB: ActorRef<String> = try first.spawn(.anonymous, self.stopOnMessage)
+
+        let key = Receptionist.RegistrationKey(messageType: String.self, id: "test")
+
+        first.receptionist.register(refA, key: key, replyTo: registeredProbe.ref)
+        _ = try registeredProbe.expectMessage()
+
+        first.receptionist.register(refB, key: key, replyTo: registeredProbe.ref)
+        _ = try registeredProbe.expectMessage()
+
+        second.receptionist.subscribe(key: key, subscriber: remoteLookupProbe.ref)
+        _ = try remoteLookupProbe.expectMessage()
+
+        first.cluster.join(node: second.cluster.node.node)
+        try assertAssociated(first, withExactly: second.settings.cluster.uniqueBindNode)
+
+        try remoteLookupProbe.eventuallyExpectListing(expected: [refA, refB], within: .seconds(3))
+
+        switch killActors {
+        case .sendStop:
+            refA.tell("stop")
+            refB.tell("stop")
+        case .shutdownNode:
+            first.shutdown().wait()
+        }
+
+        try remoteLookupProbe.eventuallyExpectListing(expected: [], within: .seconds(3))
     }
 
     func test_clusterReceptionist_shouldRemoveRemoteRefs_whenTheyStop() throws {
@@ -231,144 +223,136 @@ final class OpLogClusterReceptionistClusteredTests: ClusteredActorSystemsXCTestC
     }
 
     func test_clusterReceptionist_shouldRemoveRefFromAllListingsItWasRegisteredWith_ifTerminates() throws {
-        try shouldNotThrow {
-            let (first, second) = setUpPair {
-                $0.cluster.receptionist.ackPullReplicationIntervalSlow = .milliseconds(200)
-            }
-            first.cluster.join(node: second.cluster.node.node)
-            try assertAssociated(first, withExactly: second.settings.cluster.uniqueBindNode)
-
-            let firstKey = Receptionist.RegistrationKey(messageType: String.self, id: "first")
-            let extraKey = Receptionist.RegistrationKey(messageType: String.self, id: "extra")
-
-            let ref = try first.spawn("hi", self.stopOnMessage)
-            first.receptionist.register(ref, key: firstKey)
-            first.receptionist.register(ref, key: extraKey)
-
-            let p1f = self.testKit(first).spawnTestProbe("p1f", expecting: Receptionist.Listing<String>.self)
-            let p1e = self.testKit(first).spawnTestProbe("p1e", expecting: Receptionist.Listing<String>.self)
-            let p2f = self.testKit(second).spawnTestProbe("p2f", expecting: Receptionist.Listing<String>.self)
-            let p2e = self.testKit(second).spawnTestProbe("p2e", expecting: Receptionist.Listing<String>.self)
-
-            // ensure the ref is registered and known under both keys to both nodes
-            first.receptionist.subscribe(key: firstKey, subscriber: p1f.ref)
-            first.receptionist.subscribe(key: extraKey, subscriber: p1e.ref)
-
-            second.receptionist.subscribe(key: firstKey, subscriber: p2f.ref)
-            second.receptionist.subscribe(key: extraKey, subscriber: p2e.ref)
-
-            func expectListingOnAllProbes(expected: Set<ActorRef<String>>) throws {
-                try p1f.eventuallyExpectListing(expected: expected, within: .seconds(3))
-                try p1e.eventuallyExpectListing(expected: expected, within: .seconds(3))
-
-                try p2f.eventuallyExpectListing(expected: expected, within: .seconds(3))
-                try p2e.eventuallyExpectListing(expected: expected, within: .seconds(3))
-            }
-
-            try expectListingOnAllProbes(expected: [ref])
-
-            // terminate it
-            ref.tell("stop!")
-
-            // it should be removed from all listings; on both nodes, for all keys
-            try expectListingOnAllProbes(expected: [])
+        let (first, second) = setUpPair {
+            $0.cluster.receptionist.ackPullReplicationIntervalSlow = .milliseconds(200)
         }
+        first.cluster.join(node: second.cluster.node.node)
+        try assertAssociated(first, withExactly: second.settings.cluster.uniqueBindNode)
+
+        let firstKey = Receptionist.RegistrationKey(messageType: String.self, id: "first")
+        let extraKey = Receptionist.RegistrationKey(messageType: String.self, id: "extra")
+
+        let ref = try first.spawn("hi", self.stopOnMessage)
+        first.receptionist.register(ref, key: firstKey)
+        first.receptionist.register(ref, key: extraKey)
+
+        let p1f = self.testKit(first).spawnTestProbe("p1f", expecting: Receptionist.Listing<String>.self)
+        let p1e = self.testKit(first).spawnTestProbe("p1e", expecting: Receptionist.Listing<String>.self)
+        let p2f = self.testKit(second).spawnTestProbe("p2f", expecting: Receptionist.Listing<String>.self)
+        let p2e = self.testKit(second).spawnTestProbe("p2e", expecting: Receptionist.Listing<String>.self)
+
+        // ensure the ref is registered and known under both keys to both nodes
+        first.receptionist.subscribe(key: firstKey, subscriber: p1f.ref)
+        first.receptionist.subscribe(key: extraKey, subscriber: p1e.ref)
+
+        second.receptionist.subscribe(key: firstKey, subscriber: p2f.ref)
+        second.receptionist.subscribe(key: extraKey, subscriber: p2e.ref)
+
+        func expectListingOnAllProbes(expected: Set<ActorRef<String>>) throws {
+            try p1f.eventuallyExpectListing(expected: expected, within: .seconds(3))
+            try p1e.eventuallyExpectListing(expected: expected, within: .seconds(3))
+
+            try p2f.eventuallyExpectListing(expected: expected, within: .seconds(3))
+            try p2e.eventuallyExpectListing(expected: expected, within: .seconds(3))
+        }
+
+        try expectListingOnAllProbes(expected: [ref])
+
+        // terminate it
+        ref.tell("stop!")
+
+        // it should be removed from all listings; on both nodes, for all keys
+        try expectListingOnAllProbes(expected: [])
     }
 
     func test_clusterReceptionist_shouldRemoveActorsOfTerminatedNodeFromListings_onNodeCrash() throws {
-        try shouldNotThrow {
-            let (first, second) = setUpPair {
-                $0.cluster.receptionist.ackPullReplicationIntervalSlow = .milliseconds(200)
-            }
-            first.cluster.join(node: second.cluster.node.node)
-            try assertAssociated(first, withExactly: second.settings.cluster.uniqueBindNode)
-
-            let key = Receptionist.RegistrationKey(messageType: String.self, id: "key")
-
-            let firstRef = try first.spawn("onFirst", self.stopOnMessage)
-            first.receptionist.register(firstRef, key: key)
-
-            let secondRef = try second.spawn("onSecond", self.stopOnMessage)
-            second.receptionist.register(secondRef, key: key)
-
-            let p1 = self.testKit(first).spawnTestProbe("p1", expecting: Receptionist.Listing<String>.self)
-            let p2 = self.testKit(second).spawnTestProbe("p2", expecting: Receptionist.Listing<String>.self)
-
-            // ensure the ref is registered and known under both keys to both nodes
-            first.receptionist.subscribe(key: key, subscriber: p1.ref)
-            second.receptionist.subscribe(key: key, subscriber: p2.ref)
-
-            try p1.eventuallyExpectListing(expected: [firstRef, secondRef], within: .seconds(3))
-            try p2.eventuallyExpectListing(expected: [firstRef, secondRef], within: .seconds(3))
-
-            // crash the second node
-            second.shutdown().wait()
-
-            // it should be removed from all listings; on both nodes, for all keys
-            try p1.eventuallyExpectListing(expected: [firstRef], within: .seconds(5))
+        let (first, second) = setUpPair {
+            $0.cluster.receptionist.ackPullReplicationIntervalSlow = .milliseconds(200)
         }
+        first.cluster.join(node: second.cluster.node.node)
+        try assertAssociated(first, withExactly: second.settings.cluster.uniqueBindNode)
+
+        let key = Receptionist.RegistrationKey(messageType: String.self, id: "key")
+
+        let firstRef = try first.spawn("onFirst", self.stopOnMessage)
+        first.receptionist.register(firstRef, key: key)
+
+        let secondRef = try second.spawn("onSecond", self.stopOnMessage)
+        second.receptionist.register(secondRef, key: key)
+
+        let p1 = self.testKit(first).spawnTestProbe("p1", expecting: Receptionist.Listing<String>.self)
+        let p2 = self.testKit(second).spawnTestProbe("p2", expecting: Receptionist.Listing<String>.self)
+
+        // ensure the ref is registered and known under both keys to both nodes
+        first.receptionist.subscribe(key: key, subscriber: p1.ref)
+        second.receptionist.subscribe(key: key, subscriber: p2.ref)
+
+        try p1.eventuallyExpectListing(expected: [firstRef, secondRef], within: .seconds(3))
+        try p2.eventuallyExpectListing(expected: [firstRef, secondRef], within: .seconds(3))
+
+        // crash the second node
+        second.shutdown().wait()
+
+        // it should be removed from all listings; on both nodes, for all keys
+        try p1.eventuallyExpectListing(expected: [firstRef], within: .seconds(5))
     }
 
     // ==== ----------------------------------------------------------------------------------------------------------------
     // MARK: Multi node / streaming
 
     func test_clusterReceptionist_shouldStreamAllRegisteredActorsInChunks() throws {
-        try shouldNotThrow {
-            let (first, second) = setUpPair {
-                $0.cluster.receptionist.ackPullReplicationIntervalSlow = .milliseconds(200)
-            }
-            first.cluster.join(node: second.cluster.node.node)
-            try assertAssociated(first, withExactly: second.settings.cluster.uniqueBindNode)
-
-            let key: Receptionist.RegistrationKey<String> = .init(messageType: String.self, id: "first")
-
-            var allRefs: Set<ActorRef<String>> = []
-            for i in 1 ... (first.settings.cluster.receptionist.syncBatchSize * 10) {
-                let ref = try first.spawn("example-\(i)", self.stopOnMessage)
-                first.receptionist.register(ref, key: key)
-                _ = allRefs.insert(ref)
-            }
-
-            let p1 = self.testKit(first).spawnTestProbe("p1", expecting: Receptionist.Listing<String>.self)
-            let p2 = self.testKit(second).spawnTestProbe("p2", expecting: Receptionist.Listing<String>.self)
-
-            // ensure the ref is registered and known under both keys to both nodes
-            first.receptionist.subscribe(key: key, subscriber: p1.ref)
-            second.receptionist.subscribe(key: key, subscriber: p2.ref)
-
-            try p1.eventuallyExpectListing(expected: allRefs, within: .seconds(10))
-            try p2.eventuallyExpectListing(expected: allRefs, within: .seconds(10))
+        let (first, second) = setUpPair {
+            $0.cluster.receptionist.ackPullReplicationIntervalSlow = .milliseconds(200)
         }
+        first.cluster.join(node: second.cluster.node.node)
+        try assertAssociated(first, withExactly: second.settings.cluster.uniqueBindNode)
+
+        let key: Receptionist.RegistrationKey<String> = .init(messageType: String.self, id: "first")
+
+        var allRefs: Set<ActorRef<String>> = []
+        for i in 1 ... (first.settings.cluster.receptionist.syncBatchSize * 10) {
+            let ref = try first.spawn("example-\(i)", self.stopOnMessage)
+            first.receptionist.register(ref, key: key)
+            _ = allRefs.insert(ref)
+        }
+
+        let p1 = self.testKit(first).spawnTestProbe("p1", expecting: Receptionist.Listing<String>.self)
+        let p2 = self.testKit(second).spawnTestProbe("p2", expecting: Receptionist.Listing<String>.self)
+
+        // ensure the ref is registered and known under both keys to both nodes
+        first.receptionist.subscribe(key: key, subscriber: p1.ref)
+        second.receptionist.subscribe(key: key, subscriber: p2.ref)
+
+        try p1.eventuallyExpectListing(expected: allRefs, within: .seconds(10))
+        try p2.eventuallyExpectListing(expected: allRefs, within: .seconds(10))
     }
 
     func test_clusterReceptionist_shouldSpreadInformationAmongManyNodes() throws {
-        try shouldNotThrow {
-            let (first, second) = setUpPair {
-                $0.cluster.receptionist.ackPullReplicationIntervalSlow = .milliseconds(200)
-            }
-            let third = setUpNode("third")
-            let fourth = setUpNode("fourth")
-
-            try self.joinNodes(node: first, with: second)
-            try self.joinNodes(node: first, with: third)
-            try self.joinNodes(node: fourth, with: second)
-
-            let key = Receptionist.RegistrationKey(messageType: String.self, id: "key")
-
-            let ref = try first.spawn("hi", self.stopOnMessage)
-            first.receptionist.register(ref, key: key)
-
-            func expectListingContainsRef(on system: ActorSystem) throws {
-                let p = self.testKit(system).spawnTestProbe("p", expecting: Receptionist.Listing<String>.self)
-                system.receptionist.subscribe(key: key, subscriber: p.ref)
-
-                try p.eventuallyExpectListing(expected: [ref], within: .seconds(3))
-            }
-
-            try expectListingContainsRef(on: first)
-            try expectListingContainsRef(on: second)
-            try expectListingContainsRef(on: third)
-            try expectListingContainsRef(on: fourth)
+        let (first, second) = setUpPair {
+            $0.cluster.receptionist.ackPullReplicationIntervalSlow = .milliseconds(200)
         }
+        let third = setUpNode("third")
+        let fourth = setUpNode("fourth")
+
+        try self.joinNodes(node: first, with: second)
+        try self.joinNodes(node: first, with: third)
+        try self.joinNodes(node: fourth, with: second)
+
+        let key = Receptionist.RegistrationKey(messageType: String.self, id: "key")
+
+        let ref = try first.spawn("hi", self.stopOnMessage)
+        first.receptionist.register(ref, key: key)
+
+        func expectListingContainsRef(on system: ActorSystem) throws {
+            let p = self.testKit(system).spawnTestProbe("p", expecting: Receptionist.Listing<String>.self)
+            system.receptionist.subscribe(key: key, subscriber: p.ref)
+
+            try p.eventuallyExpectListing(expected: [ref], within: .seconds(3))
+        }
+
+        try expectListingContainsRef(on: first)
+        try expectListingContainsRef(on: second)
+        try expectListingContainsRef(on: third)
+        try expectListingContainsRef(on: fourth)
     }
 }

--- a/Tests/DistributedActorsTests/Cluster/RemoteMessagingClusteredTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/RemoteMessagingClusteredTests.swift
@@ -264,47 +264,45 @@ final class RemoteMessagingClusteredTests: ClusteredActorSystemsXCTestCase {
         }
         remote.cluster.join(node: local.cluster.node.node)
 
-        try shouldNotThrow {
-            try assertAssociated(local, withExactly: remote.cluster.node)
+        try assertAssociated(local, withExactly: remote.cluster.node)
 
-            let thirdSystem = self.setUpNode("ClusterAssociationTests") { settings in
-                settings.cluster.bindPort = 9119
-                settings.serialization.register(SerializationTestMessage.self)
-                settings.serialization.register(EchoTestMessage.self)
-            }
-            defer { thirdSystem.shutdown().wait() }
-
-            thirdSystem.cluster.join(node: local.cluster.node.node)
-            thirdSystem.cluster.join(node: remote.cluster.node.node)
-            try assertAssociated(thirdSystem, withExactly: [local.cluster.node, remote.cluster.node])
-            let thirdTestKit = ActorTestKit(thirdSystem)
-
-            let localRef: ActorRef<EchoTestMessage> = try local.spawn(
-                "Local",
-                .receiveMessage { message in
-                    message.respondTo.tell("local:\(message.string)")
-                    return .stop
-                }
-            )
-
-            let localRefRemote = remote._resolveKnownRemote(localRef, onRemoteSystem: local)
-
-            let remoteRef: ActorRef<EchoTestMessage> = try remote.spawn(
-                "Remote",
-                .receiveMessage { message in
-                    localRefRemote.tell(EchoTestMessage(string: "remote:\(message.string)", respondTo: message.respondTo))
-                    return .stop
-                }
-            )
-
-            let remoteRefThird = thirdSystem._resolveKnownRemote(remoteRef, onRemoteSystem: remote)
-
-            let probeThird = thirdTestKit.spawnTestProbe(expecting: String.self)
-
-            remoteRefThird.tell(EchoTestMessage(string: "test", respondTo: probeThird.ref))
-
-            try probeThird.expectMessage().shouldEqual("local:remote:test")
+        let thirdSystem = self.setUpNode("ClusterAssociationTests") { settings in
+            settings.cluster.bindPort = 9119
+            settings.serialization.register(SerializationTestMessage.self)
+            settings.serialization.register(EchoTestMessage.self)
         }
+        defer { thirdSystem.shutdown().wait() }
+
+        thirdSystem.cluster.join(node: local.cluster.node.node)
+        thirdSystem.cluster.join(node: remote.cluster.node.node)
+        try assertAssociated(thirdSystem, withExactly: [local.cluster.node, remote.cluster.node])
+        let thirdTestKit = ActorTestKit(thirdSystem)
+
+        let localRef: ActorRef<EchoTestMessage> = try local.spawn(
+            "Local",
+            .receiveMessage { message in
+                message.respondTo.tell("local:\(message.string)")
+                return .stop
+            }
+        )
+
+        let localRefRemote = remote._resolveKnownRemote(localRef, onRemoteSystem: local)
+
+        let remoteRef: ActorRef<EchoTestMessage> = try remote.spawn(
+            "Remote",
+            .receiveMessage { message in
+                localRefRemote.tell(EchoTestMessage(string: "remote:\(message.string)", respondTo: message.respondTo))
+                return .stop
+            }
+        )
+
+        let remoteRefThird = thirdSystem._resolveKnownRemote(remoteRef, onRemoteSystem: remote)
+
+        let probeThird = thirdTestKit.spawnTestProbe(expecting: String.self)
+
+        remoteRefThird.tell(EchoTestMessage(string: "test", respondTo: probeThird.ref))
+
+        try probeThird.expectMessage().shouldEqual("local:remote:test")
     }
 }
 

--- a/Tests/DistributedActorsTests/DeadLetterTests.swift
+++ b/Tests/DistributedActorsTests/DeadLetterTests.swift
@@ -74,7 +74,7 @@ final class DeadLetterTests: ActorSystemXCTestCase {
             "This is a question, reply to \(replyTo)"
         }
 
-        _ = shouldThrow {
+        _ = try shouldThrow {
             try answer.wait()
         }
 

--- a/Tests/DistributedActorsTests/MembershipTests.swift
+++ b/Tests/DistributedActorsTests/MembershipTests.swift
@@ -185,17 +185,15 @@ final class MembershipTests: XCTestCase {
 
         let firstReplacement = Cluster.Member(node: UniqueNode(node: self.nodeA.node, nid: .init(111_111)), status: .up)
 
-        try shouldNotThrow {
-            guard let change = membership.applyMembershipChange(Cluster.MembershipChange(member: firstReplacement)) else {
-                throw TestError("Expected a change, but didn't get one")
-            }
-
-            change.isReplacement.shouldBeTrue()
-            change.replaced.shouldEqual(self.memberA)
-            change.replaced!.status.shouldEqual(self.memberA.status)
-            change.node.shouldEqual(firstReplacement.node)
-            change.toStatus.shouldEqual(firstReplacement.status)
+        guard let change = membership.applyMembershipChange(Cluster.MembershipChange(member: firstReplacement)) else {
+            throw TestError("Expected a change, but didn't get one")
         }
+
+        change.isReplacement.shouldBeTrue()
+        change.replaced.shouldEqual(self.memberA)
+        change.replaced!.status.shouldEqual(self.memberA.status)
+        change.node.shouldEqual(firstReplacement.node)
+        change.toStatus.shouldEqual(firstReplacement.status)
     }
 
     func test_apply_memberRemoval() throws {
@@ -203,17 +201,15 @@ final class MembershipTests: XCTestCase {
 
         let removal = Cluster.Member(node: self.memberA.node, status: .removed)
 
-        try shouldNotThrow {
-            guard let change = membership.applyMembershipChange(Cluster.MembershipChange(member: removal)) else {
-                throw TestError("Expected a change, but didn't get one")
-            }
-
-            change.isReplacement.shouldBeFalse()
-            change.node.shouldEqual(removal.node)
-            change.toStatus.shouldEqual(removal.status)
-
-            membership.uniqueMember(self.memberA.node).shouldBeNil()
+        guard let change = membership.applyMembershipChange(Cluster.MembershipChange(member: removal)) else {
+            throw TestError("Expected a change, but didn't get one")
         }
+
+        change.isReplacement.shouldBeFalse()
+        change.node.shouldEqual(removal.node)
+        change.toStatus.shouldEqual(removal.status)
+
+        membership.uniqueMember(self.memberA.node).shouldBeNil()
     }
 
     // ==== ------------------------------------------------------------------------------------------------------------
@@ -352,16 +348,14 @@ final class MembershipTests: XCTestCase {
 
         let firstReplacement = Cluster.Member(node: UniqueNode(node: self.nodeA.node, nid: .random()), status: .up)
 
-        try shouldNotThrow {
-            guard let change = membership.mark(firstReplacement.node, as: firstReplacement.status) else {
-                throw TestError("Expected a change")
-            }
-            change.isReplacement.shouldBeTrue()
-            change.replaced.shouldEqual(self.memberA)
-            change.fromStatus.shouldEqual(.up)
-            change.node.shouldEqual(firstReplacement.node)
-            change.toStatus.shouldEqual(.up)
+        guard let change = membership.mark(firstReplacement.node, as: firstReplacement.status) else {
+            throw TestError("Expected a change")
         }
+        change.isReplacement.shouldBeTrue()
+        change.replaced.shouldEqual(self.memberA)
+        change.fromStatus.shouldEqual(.up)
+        change.node.shouldEqual(firstReplacement.node)
+        change.toStatus.shouldEqual(.up)
     }
 
     func test_mark_status_whenReplacingWithNewNode() {

--- a/Tests/DistributedActorsTests/NodeDeathWatcherTests.swift
+++ b/Tests/DistributedActorsTests/NodeDeathWatcherTests.swift
@@ -19,61 +19,59 @@ import XCTest
 
 final class NodeDeathWatcherTests: ClusteredActorSystemsXCTestCase {
     func test_nodeDeath_shouldFailAllRefsOnSpecificAddress() throws {
-        try shouldNotThrow {
-            let first = self.setUpNode("first") { settings in
-                settings.cluster.swim.probeInterval = .milliseconds(100)
-            }
-            let second = self.setUpNode("second") { settings in
-                settings.cluster.swim.probeInterval = .milliseconds(100)
-            }
-
-            try self.joinNodes(node: first, with: second)
-
-            let refOnRemote1: ActorRef<String> = try second.spawn("remote-1", .ignore)
-            let refOnFirstToRemote1 = first._resolve(ref: refOnRemote1, onSystem: second)
-
-            let refOnRemote2: ActorRef<String> = try second.spawn("remote-2", .ignore)
-            let refOnFirstToRemote2 = first._resolve(ref: refOnRemote2, onSystem: second)
-
-            let testKit = ActorTestKit(first)
-            let p = testKit.spawnTestProbe(expecting: Signals.Terminated.self)
-
-            // --- prepare actor on [first], which watches remote actors ---
-
-            _ = try first.spawn(
-                "watcher1",
-                Behavior<String>.setup { context in
-                    context.watch(refOnFirstToRemote1)
-                    context.watch(refOnFirstToRemote2)
-
-                    let recv: Behavior<String> = .receiveMessage { _ in
-                        .same
-                    }
-
-                    return recv.receiveSpecificSignal(Signals.Terminated.self) { _, terminated in
-                        p.ref.tell(terminated)
-                        return .same
-                    }
-                }
-            )
-
-            try self.ensureNodes(.up, nodes: first.cluster.node, second.cluster.node)
-            first.cluster.down(node: second.cluster.node.node)
-
-            // should cause termination of all remote actors, observed by the local actors on [first]
-            let termination1: Signals.Terminated = try p.expectMessage()
-            let termination2: Signals.Terminated = try p.expectMessage()
-            let terminations: [Signals.Terminated] = [termination1, termination2]
-            terminations.shouldContain(where: { terminated in
-                (!terminated.existenceConfirmed) && terminated.address.name == "remote-1"
-            })
-            terminations.shouldContain(where: { terminated in
-                (!terminated.existenceConfirmed) && terminated.address.name == "remote-2"
-            })
-
-            // should not trigger terminated again for any of the remote refs
-            first.cluster.down(node: second.cluster.node.node)
-            try p.expectNoMessage(for: .milliseconds(50))
+        let first = self.setUpNode("first") { settings in
+            settings.cluster.swim.probeInterval = .milliseconds(100)
         }
+        let second = self.setUpNode("second") { settings in
+            settings.cluster.swim.probeInterval = .milliseconds(100)
+        }
+
+        try self.joinNodes(node: first, with: second)
+
+        let refOnRemote1: ActorRef<String> = try second.spawn("remote-1", .ignore)
+        let refOnFirstToRemote1 = first._resolve(ref: refOnRemote1, onSystem: second)
+
+        let refOnRemote2: ActorRef<String> = try second.spawn("remote-2", .ignore)
+        let refOnFirstToRemote2 = first._resolve(ref: refOnRemote2, onSystem: second)
+
+        let testKit = ActorTestKit(first)
+        let p = testKit.spawnTestProbe(expecting: Signals.Terminated.self)
+
+        // --- prepare actor on [first], which watches remote actors ---
+
+        _ = try first.spawn(
+            "watcher1",
+            Behavior<String>.setup { context in
+                context.watch(refOnFirstToRemote1)
+                context.watch(refOnFirstToRemote2)
+
+                let recv: Behavior<String> = .receiveMessage { _ in
+                    .same
+                }
+
+                return recv.receiveSpecificSignal(Signals.Terminated.self) { _, terminated in
+                    p.ref.tell(terminated)
+                    return .same
+                }
+            }
+        )
+
+        try self.ensureNodes(.up, nodes: first.cluster.node, second.cluster.node)
+        first.cluster.down(node: second.cluster.node.node)
+
+        // should cause termination of all remote actors, observed by the local actors on [first]
+        let termination1: Signals.Terminated = try p.expectMessage()
+        let termination2: Signals.Terminated = try p.expectMessage()
+        let terminations: [Signals.Terminated] = [termination1, termination2]
+        terminations.shouldContain(where: { terminated in
+            (!terminated.existenceConfirmed) && terminated.address.name == "remote-1"
+            })
+        terminations.shouldContain(where: { terminated in
+            (!terminated.existenceConfirmed) && terminated.address.name == "remote-2"
+            })
+
+        // should not trigger terminated again for any of the remote refs
+        first.cluster.down(node: second.cluster.node.node)
+        try p.expectNoMessage(for: .milliseconds(50))
     }
 }

--- a/Tests/DistributedActorsTests/Pattern/WorkerPoolTests.swift
+++ b/Tests/DistributedActorsTests/Pattern/WorkerPoolTests.swift
@@ -243,7 +243,7 @@ final class WorkerPoolTests: ActorSystemXCTestCase {
     }
 
     func test_workerPool_static_throwOnEmptyInitialSet() throws {
-        let error = shouldThrow {
+        let error = try shouldThrow {
             let _: WorkerPoolRef<Never> = try WorkerPool.spawn(system, "wrongConfigPool", select: .static([]))
         }
 

--- a/Tests/DistributedActorsTests/SerializationTests.swift
+++ b/Tests/DistributedActorsTests/SerializationTests.swift
@@ -85,7 +85,7 @@ class SerializationTests: ActorSystemXCTestCase {
     }
 
     func test_serialize_actorAddress_shouldDemandContext() throws {
-        let err = shouldThrow {
+        let err = try shouldThrow {
             let address = try ActorPath(root: "user").appending("hello").makeLocalAddress(incarnation: .random())
 
             let encoder = JSONEncoder()
@@ -96,29 +96,27 @@ class SerializationTests: ActorSystemXCTestCase {
     }
 
     func test_serialize_actorAddress_usingContext() throws {
-        try shouldNotThrow {
-            let address = try ActorPath(root: "user").appending("hello").makeLocalAddress(incarnation: .random())
+        let address = try ActorPath(root: "user").appending("hello").makeLocalAddress(incarnation: .random())
 
-            let encoder = JSONEncoder()
-            let decoder = JSONDecoder()
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
 
-            let context = Serialization.Context(
-                log: self.system.log,
-                system: self.system,
-                allocator: ByteBufferAllocator()
-            )
+        let context = Serialization.Context(
+            log: self.system.log,
+            system: self.system,
+            allocator: ByteBufferAllocator()
+        )
 
-            encoder.userInfo[.actorSerializationContext] = context
-            decoder.userInfo[.actorSerializationContext] = context
+        encoder.userInfo[.actorSerializationContext] = context
+        decoder.userInfo[.actorSerializationContext] = context
 
-            let encoded = try encoder.encode(address)
-            pinfo("Serialized actor path: \(encoded.copyToNewByteBuffer().stringDebugDescription())")
+        let encoded = try encoder.encode(address)
+        pinfo("Serialized actor path: \(encoded.copyToNewByteBuffer().stringDebugDescription())")
 
-            let addressAgain = try decoder.decode(ActorAddress.self, from: encoded)
-            pinfo("Deserialized again: \(String(reflecting: addressAgain))")
+        let addressAgain = try decoder.decode(ActorAddress.self, from: encoded)
+        pinfo("Deserialized again: \(String(reflecting: addressAgain))")
 
-            "\(addressAgain)".shouldEqual("sact://SerializationTests@127.0.0.1:9001/user/hello")
-        }
+        "\(addressAgain)".shouldEqual("sact://SerializationTests@127.0.0.1:9001/user/hello")
     }
 
     // ==== ------------------------------------------------------------------------------------------------------------
@@ -240,7 +238,7 @@ class SerializationTests: ActorSystemXCTestCase {
     }
 
     func test_serialize_shouldNotSerializeNotRegisteredType() throws {
-        _ = shouldThrow {
+        _ = try shouldThrow {
             try system.serialization.serialize(NotCodableHasInt(containedInt: 1337))
         }
     }
@@ -413,7 +411,7 @@ class SerializationTests: ActorSystemXCTestCase {
             system2.shutdown().wait()
         }
 
-        _ = shouldThrow {
+        _ = try shouldThrow {
             _ = try system2.serialization.deserialize(as: PListXMLCodableTest.self, from: serialized)
         }
 

--- a/Tests/DistributedActorsTests/StashBufferTests.swift
+++ b/Tests/DistributedActorsTests/StashBufferTests.swift
@@ -60,7 +60,7 @@ final class StashBufferTests: ActorSystemXCTestCase {
 
         try stash.stash(message: 1)
 
-        shouldThrow(expected: StashError.self) {
+        try shouldThrow(expected: StashError.self) {
             _ = try stash.stash(message: 2)
         }
     }

--- a/Tests/DistributedActorsTests/TraversalTests.swift
+++ b/Tests/DistributedActorsTests/TraversalTests.swift
@@ -83,6 +83,7 @@ final class TraversalTests: ActorSystemXCTestCase {
                 "receptionist",
                 "replicator",
                 "gossip",
+                "clusterEvents",
                 "user",
                 "other",
                 "inner-1",


### PR DESCRIPTION
More consistent error reporting, to avoid sometimes missing the "pretty" output which contains very important details quite often.

This means:

- we always print the error in XCTFail, this always prints the details
  - XCTAssertBlabla do NOT print the details (!) so we sometimes were missing useful information (!!!)
- throwing test functions DO call `String(describing:)` on the error, yet we did not have the pretty descriptions in there, but only when we called "detailedMessage...", this made it hard and tricky to compose when we used things like eventually etc.
  - now all errors implement the description and will print "pretty" if they're thrown from a test.

This will help us avoid those https://github.com/apple/swift-distributed-actors/issues/643 "inline escaped" error messages.