### PR TITLE
!shutdown now has a callback /async version 

### DIFF
--- a/IntegrationTests/disabled_tests_03_xpc_actorable/it_XPCActorable_echo/main.swift
+++ b/IntegrationTests/disabled_tests_03_xpc_actorable/it_XPCActorable_echo/main.swift
@@ -47,4 +47,4 @@ case let unknown:
     exit(-1)
 }
 
-system.park()
+try! system.park()

--- a/IntegrationTests/disabled_tests_03_xpc_actorable/it_XPCActorable_echo_service/main.swift
+++ b/IntegrationTests/disabled_tests_03_xpc_actorable/it_XPCActorable_echo_service/main.swift
@@ -36,5 +36,5 @@ try! _file.append("service booted...\n")
 let service = try XPCActorableService(system, XPCEchoService.init)
 
 service.park()
-system.park() // TODO: system park should invoke the service park, we only need to park once for XPC to kickoff dispatch_main
+try! system.park() // TODO: system park should invoke the service park, we only need to park once for XPC to kickoff dispatch_main
 // unreachable, park never exits

--- a/Samples/Sources/SampleCRDTPlayground/CRDTPlayground.swift
+++ b/Samples/Sources/SampleCRDTPlayground/CRDTPlayground.swift
@@ -67,7 +67,7 @@ struct CRDTPlayground {
             peer.tell("write-2-\(peer.path.name)")
         }
 
-        first.park(atMost: time)
+        try! first.park(atMost: time)
     }
 }
 

--- a/Samples/Sources/SampleCluster/main.swift
+++ b/Samples/Sources/SampleCluster/main.swift
@@ -76,6 +76,7 @@ system.cluster.events.subscribe(eventsListener) // <2>
 //    case announcement(String)
 //    case text(String, from: ActorRef<ChatMessage>)
 // }
+
 // tag::cluster-sample-actors-discover-and-chat[]
 let chatter: ActorRef<String> = try system.spawn(
     "chatter",
@@ -87,7 +88,7 @@ let chatter: ActorRef<String> = try system.spawn(
 system.receptionist.register(chatter, with: "chat-room") // <1>
 
 if system.cluster.uniqueNode.port == 7337 { // <2>
-    let greeter = try system.spawn(
+    try system.spawn(
         "greeter",
         of: Reception.Listing<ActorRef<String>>.self,
         .setup { context in // <3>
@@ -105,4 +106,4 @@ if system.cluster.uniqueNode.port == 7337 { // <2>
 
 // end::cluster-sample-actors-discover-and-chat[]
 
-system.park(atMost: .seconds(6000))
+try! system.park(atMost: .seconds(6000))

--- a/Samples/Sources/SampleDiningPhilosophers/DiningPhilosophers.swift
+++ b/Samples/Sources/SampleDiningPhilosophers/DiningPhilosophers.swift
@@ -32,6 +32,6 @@ struct DiningPhilosophers {
         let _: Philosopher.Ref = try system.spawn("Cory", Philosopher(left: fork3, right: fork4).behavior)
         let _: Philosopher.Ref = try system.spawn("Norman", Philosopher(left: fork4, right: fork5).behavior)
 
-        system.park(atMost: time)
+        try system.park(atMost: time)
     }
 }

--- a/Samples/Sources/SampleDiningPhilosophers/DistributedDiningPhilosophers.swift
+++ b/Samples/Sources/SampleDiningPhilosophers/DistributedDiningPhilosophers.swift
@@ -54,6 +54,6 @@ struct DistributedDiningPhilosophers {
         _ = try systemC.spawn("Cory", Philosopher(left: fork3, right: fork4).behavior)
         _ = try systemC.spawn("Norman", Philosopher(left: fork4, right: fork5).behavior)
 
-        systemA.park(atMost: time)
+        try systemA.park(atMost: time)
     }
 }

--- a/Samples/Sources/SampleDistributedCRDTScoreGame/ScoreGame.swift
+++ b/Samples/Sources/SampleDistributedCRDTScoreGame/ScoreGame.swift
@@ -62,7 +62,7 @@ struct ScoreGame {
         // which other non participants may observe as well.
         _ = try first.spawn("game-engine", self.game(with: players))
 
-        first.park(atMost: time)
+        try first.park(atMost: time)
     }
 }
 

--- a/Samples/Sources/SampleGenActorsDiningPhilosophers/DistributedDiningPhilosophers.swift
+++ b/Samples/Sources/SampleGenActorsDiningPhilosophers/DistributedDiningPhilosophers.swift
@@ -54,6 +54,6 @@ struct DistributedDiningPhilosophers {
         _ = try systemC.spawn("Cory") { Philosopher(context: $0, leftFork: fork3, rightFork: fork4) }
         _ = try systemC.spawn("Norman") { Philosopher(context: $0, leftFork: fork4, rightFork: fork5) }
 
-        systemA.park(atMost: time)
+        try systemA.park(atMost: time)
     }
 }

--- a/Samples/Sources/SampleMetrics/main.swift
+++ b/Samples/Sources/SampleMetrics/main.swift
@@ -104,5 +104,5 @@ for i in 1 ... 10 {
 
 Thread.sleep(.seconds(100))
 
-system.shutdown().wait()
+try! system.shutdown().wait()
 print("~~~~~~~~~~~~~~~ SHUTTING DOWN ~~~~~~~~~~~~~~~")

--- a/Samples/Sources/XPCActorCaller/main.swift
+++ b/Samples/Sources/XPCActorCaller/main.swift
@@ -41,7 +41,7 @@ reply.withTimeout(after: .seconds(3))._onComplete {
     system.log.info("Reply from service.greet(Capybara) = \($0)")
 }
 
-system.park()
+try! system.park()
 
 // end::xpc_example[]
 #endif

--- a/Sources/DistributedActors/Refs.swift
+++ b/Sources/DistributedActors/Refs.swift
@@ -585,7 +585,7 @@ public class Guardian {
                     system.log.error("\(message)", metadata: ["actor/path": "\(self.address.path)"])
 
                     _ = try! Thread {
-                        system.shutdown().wait() // so we don't block anyone who sent us this signal (as we execute synchronously in the guardian)
+                        try! system.shutdown().wait() // so we don't block anyone who sent us this signal (as we execute synchronously in the guardian)
                         print("Guardian shutdown of [\(system.name)] ActorSystem complete.")
                     }
                     #if os(iOS) || os(watchOS) || os(tvOS)

--- a/Sources/DistributedActorsBenchmarks/ActorMessageFloodingBenchmarks.swift
+++ b/Sources/DistributedActorsBenchmarks/ActorMessageFloodingBenchmarks.swift
@@ -38,7 +38,7 @@ private func setUp() {
 }
 
 private func tearDown() {
-    system.shutdown().wait()
+    try! system.shutdown().wait()
     _system = nil
 }
 

--- a/Sources/DistributedActorsBenchmarks/ActorPingPongBenchmarks.swift
+++ b/Sources/DistributedActorsBenchmarks/ActorPingPongBenchmarks.swift
@@ -93,7 +93,7 @@ private func setUp(and postSetUp: () -> Void = { () in () }) {
 }
 
 private func tearDown() {
-    system.shutdown().wait()
+    try! system.shutdown().wait()
     _system = nil
 }
 
@@ -255,6 +255,6 @@ private func bench_actors_ping_pong(numActors: Int) -> (Int) -> Void {
         let time = SwiftBenchmarkTools.Timer().getTimeAsInt() - startNanoTime
 
         pprint("    \(totalNumMessages) messages by \(numActors) actors took: \(time.milliseconds) ms (total: \(totalNumMessages / time.milliseconds * 1000) msg/s)")
-        system.shutdown().wait()
+        try! system.shutdown().wait()
     }
 }

--- a/Sources/DistributedActorsBenchmarks/ActorRemotePingPongBenchmarks.swift
+++ b/Sources/DistributedActorsBenchmarks/ActorRemotePingPongBenchmarks.swift
@@ -80,9 +80,9 @@ private func setUp(and postSetUp: () -> Void = { () in () }) {
 }
 
 private func tearDown() {
-    system.shutdown().wait()
+    try! system.shutdown().wait()
     _system = nil
-    _pongNode?.shutdown().wait()
+    try! _pongNode?.shutdown().wait()
     _pongNode = nil
 }
 
@@ -243,6 +243,6 @@ private func bench_actors_remote_ping_pong(numActors: Int) -> (Int) -> Void {
         let time = SwiftBenchmarkTools.Timer().getTimeAsInt() - startNanoTime
 
         pprint("    \(totalNumMessages) messages by \(numActors) actors took: \(time.milliseconds) ms (total: \(totalNumMessages / time.milliseconds * 1000) msg/s)")
-        system.shutdown().wait()
+        try! system.shutdown().wait()
     }
 }

--- a/Sources/DistributedActorsBenchmarks/ActorResolveBenchmarks.swift
+++ b/Sources/DistributedActorsBenchmarks/ActorResolveBenchmarks.swift
@@ -38,7 +38,7 @@ private func setUp(and postSetUp: () -> Void) {
 }
 
 private func tearDown() {
-    system.shutdown().wait()
+    try! system.shutdown().wait()
     _system = nil
 }
 

--- a/Sources/DistributedActorsBenchmarks/ActorRingBenchmarks.swift
+++ b/Sources/DistributedActorsBenchmarks/ActorRingBenchmarks.swift
@@ -55,7 +55,7 @@ private func setUp(and postSetUp: () -> Void = { () in () }) {
 }
 
 private func tearDown() {
-    system.shutdown().wait()
+    try! system.shutdown().wait()
     _system = nil
 }
 

--- a/Sources/DistributedActorsBenchmarks/ActorSpawnBenchmarks.swift
+++ b/Sources/DistributedActorsBenchmarks/ActorSpawnBenchmarks.swift
@@ -60,7 +60,7 @@ func bench_SpawnTopLevel(_ actorCount: Int) throws {
     print("Spawned \(actorCount) top-level actors in \(String(format: "%.3f", seconds)) seconds. (\(perSecond) actors/s)")
 
     let shutdownStart = timer.getTime()
-    system.shutdown().wait()
+    try! system.shutdown().wait()
     let shutdownStop = timer.getTime()
     let shutdownTime = timer.diffTimeInNanoSeconds(from: shutdownStart, to: shutdownStop)
     let shutdownSeconds = (Double(shutdownTime) / 1_000_000_000)
@@ -99,7 +99,7 @@ func bench_SpawnChildren(_ actorCount: Int) throws {
     print("Spawned \(actorCount) child actors in \(String(format: "%.3f", seconds)) seconds. (\(perSecond) actors/s)")
 
     let shutdownStart = timer.getTime()
-    system.shutdown().wait()
+    try! system.shutdown().wait()
     let shutdownStop = timer.getTime()
     let shutdownTime = timer.diffTimeInNanoSeconds(from: shutdownStart, to: shutdownStop)
     let shutdownSeconds = (Double(shutdownTime) / 1_000_000_000)

--- a/Sources/DistributedActorsBenchmarks/SerializationCodableBenchmarks.swift
+++ b/Sources/DistributedActorsBenchmarks/SerializationCodableBenchmarks.swift
@@ -47,7 +47,7 @@ private func setUp(and postSetUp: () -> Void = { () in () }) {
 }
 
 private func tearDown() {
-    system.shutdown().wait()
+    try! system.shutdown().wait()
     _system = nil
 }
 

--- a/Sources/DistributedActorsBenchmarks/SerializationProtobufBenchmarks.swift
+++ b/Sources/DistributedActorsBenchmarks/SerializationProtobufBenchmarks.swift
@@ -69,7 +69,7 @@ private func setUp(and postSetUp: () -> Void = { () in
 }
 
 private func tearDown() {
-    system.shutdown().wait()
+    try! system.shutdown().wait()
     _system = nil
 }
 

--- a/Sources/DistributedActorsTestKit/Cluster/ClusteredActorSystemsXCTestCase.swift
+++ b/Sources/DistributedActorsTestKit/Cluster/ClusteredActorSystemsXCTestCase.swift
@@ -104,7 +104,7 @@ open class ClusteredActorSystemsXCTestCase: XCTestCase {
             self.printAllCapturedLogs()
         }
 
-        self._nodes.forEach { $0.shutdown().wait() }
+        self._nodes.forEach { try! $0.shutdown().wait() }
 
         self._nodes = []
         self._testKits = []

--- a/Tests/ActorSingletonPluginTests/ActorSingletonPluginTests.swift
+++ b/Tests/ActorSingletonPluginTests/ActorSingletonPluginTests.swift
@@ -26,7 +26,7 @@ final class ActorSingletonPluginTests: ActorSystemXCTestCase {
         }
 
         defer {
-            system.shutdown().wait()
+            try! system.shutdown().wait()
         }
 
         let replyProbe = ActorTestKit(system).spawnTestProbe(expecting: String.self)
@@ -50,7 +50,7 @@ final class ActorSingletonPluginTests: ActorSystemXCTestCase {
         }
 
         defer {
-            system.shutdown().wait()
+            try! system.shutdown().wait()
         }
 
         let replyProbe = ActorTestKit(system).spawnTestProbe(expecting: String.self)

--- a/Tests/DistributedActorsDocumentationTests/Actorable/ActorableActorTestKitDocExamples.swift
+++ b/Tests/DistributedActorsDocumentationTests/Actorable/ActorableActorTestKitDocExamples.swift
@@ -44,7 +44,7 @@ final class ActorTestKitTests: XCTestCase {
     }
 
     override func tearDown() {
-        self.system.shutdown().wait()
+        try! self.system.shutdown().wait()
     }
 
     // tag::test[]

--- a/Tests/DistributedActorsDocumentationTests/ClusteringDocExamples.swift
+++ b/Tests/DistributedActorsDocumentationTests/ClusteringDocExamples.swift
@@ -31,7 +31,7 @@ class ClusteringDocExamples: XCTestCase {
         }
         // end::config_tls[]
 
-        system.shutdown().wait()
+        try! system.shutdown().wait()
     }
 
     func example_config_tls_passphrase() throws {
@@ -44,6 +44,6 @@ class ClusteringDocExamples: XCTestCase {
         }
         // end::config_tls_passphrase[]
 
-        system.shutdown().wait()
+        try! system.shutdown().wait()
     }
 }

--- a/Tests/DistributedActorsDocumentationTests/InteropDocExamples.swift
+++ b/Tests/DistributedActorsDocumentationTests/InteropDocExamples.swift
@@ -27,7 +27,7 @@ class InteropDocExamples: XCTestCase {
         // end::message_greetings[]
 
         let system = ActorSystem("System")
-        defer { system.shutdown().wait() }
+        defer { try! system.shutdown().wait() }
         let behavior: Behavior<Messages> = .receiveMessage { _ in
             // ...
             .same
@@ -58,7 +58,7 @@ class InteropDocExamples: XCTestCase {
         // end::asyncOp_sendResult_insideActor_enum_Messages[]
 
         let system = ActorSystem("System")
-        defer { system.shutdown().wait() }
+        defer { try! system.shutdown().wait() }
 
         func someComputation() -> String {
             "test"
@@ -116,7 +116,7 @@ class InteropDocExamples: XCTestCase {
         // end::asyncOp_onResultAsync_enum_Messages[]
 
         let system = ActorSystem("System")
-        defer { system.shutdown().wait() }
+        defer { try! system.shutdown().wait() }
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let eventLoop = eventLoopGroup.next()
         func fetchUser(_: String) -> EventLoopFuture<User?> {
@@ -167,7 +167,7 @@ class InteropDocExamples: XCTestCase {
         // end::asyncOp_awaitResult_enum_Messages[]
 
         let system = ActorSystem("System")
-        defer { system.shutdown().wait() }
+        defer { try! system.shutdown().wait() }
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let eventLoop = eventLoopGroup.next()
         func fetchDataAsync() -> EventLoopFuture<String> {
@@ -206,7 +206,7 @@ class InteropDocExamples: XCTestCase {
         }
 
         let system = ActorSystem("System")
-        defer { system.shutdown().wait() }
+        defer { try! system.shutdown().wait() }
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let eventLoop = eventLoopGroup.next()
         func fetchDataAsync() -> EventLoopFuture<String> {

--- a/Tests/DistributedActorsTestKitTests/ActorTestKitTests.swift
+++ b/Tests/DistributedActorsTestKitTests/ActorTestKitTests.swift
@@ -26,7 +26,7 @@ final class ActorTestKitTests: XCTestCase {
     }
 
     override func tearDown() {
-        self.system.shutdown().wait()
+        try! self.system.shutdown().wait()
     }
 
     func test_error_withMessage() throws {

--- a/Tests/DistributedActorsTestKitTests/ActorTestProbeTests.swift
+++ b/Tests/DistributedActorsTestKitTests/ActorTestProbeTests.swift
@@ -26,7 +26,7 @@ class ActorTestProbeTests: XCTestCase {
     }
 
     override func tearDown() {
-        self.system.shutdown().wait()
+        try! self.system.shutdown().wait()
     }
 
     func test_maybeExpectMessage_shouldReturnTheReceivedMessage() throws {

--- a/Tests/DistributedActorsTests/ActorAskTests.swift
+++ b/Tests/DistributedActorsTests/ActorAskTests.swift
@@ -214,7 +214,7 @@ final class ActorAskTests: ActorSystemXCTestCase {
             }
         )
 
-        system.shutdown().wait()
+        try! system.shutdown().wait()
 
         _ = ref.ask(for: String.self, timeout: .milliseconds(300)) { replyTo in
             TestMessage(replyTo: replyTo)

--- a/Tests/DistributedActorsTests/ActorLeakingTests.swift
+++ b/Tests/DistributedActorsTests/ActorLeakingTests.swift
@@ -234,7 +234,7 @@ final class ActorLeakingTests: ActorSystemXCTestCase {
 
         for n in 1 ... 5 {
             let system = ActorSystem("Test-\(n)")
-            system.shutdown().wait()
+            try! system.shutdown().wait()
         }
 
         ActorSystem.actorSystemInitCounter.load().shouldEqual(initialSystemCount)
@@ -284,7 +284,7 @@ final class ActorLeakingTests: ActorSystemXCTestCase {
             context.log.trace("Not going to be logged")
             return .receiveMessage { _ in .same }
         })
-        system?.shutdown().wait()
+        try! system?.shutdown().wait()
         system = nil
 
         ActorSystem.actorSystemInitCounter.load().shouldEqual(initialSystemCount)
@@ -304,7 +304,7 @@ final class ActorLeakingTests: ActorSystemXCTestCase {
             context.log.warning("Not going to be logged")
             return .receiveMessage { _ in .same }
         })
-        system?.shutdown().wait()
+        try! system?.shutdown().wait()
         system = nil
 
         ActorSystem.actorSystemInitCounter.load().shouldEqual(initialSystemCount)

--- a/Tests/DistributedActorsTests/ActorRefAdapterTests.swift
+++ b/Tests/DistributedActorsTests/ActorRefAdapterTests.swift
@@ -237,7 +237,7 @@ class ActorRefAdapterTests: ActorSystemXCTestCase {
         let system = ActorSystem("\(type(of: self))-2") { settings in
             settings.logging.logger = logCapture.logger(label: settings.cluster.node.systemName)
         }
-        defer { system.shutdown().wait() }
+        defer { try! system.shutdown().wait() }
 
         let probe = self.testKit.spawnTestProbe(expecting: String.self)
         let receiveRefProbe = self.testKit.spawnTestProbe(expecting: ActorRef<String>.self)

--- a/Tests/DistributedActorsTests/BehaviorTests.swift
+++ b/Tests/DistributedActorsTests/BehaviorTests.swift
@@ -350,7 +350,7 @@ final class BehaviorTests: ActorSystemXCTestCase {
             settings.logging.logger = capture.logger(label: "mock")
         }
         defer {
-            system.shutdown().wait()
+            try! system.shutdown().wait()
         }
 
         let p: ActorTestProbe<String> = self.testKit.spawnTestProbe()

--- a/Tests/DistributedActorsTests/Cluster/DowningStrategy/DowningClusteredTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/DowningStrategy/DowningClusteredTests.swift
@@ -246,7 +246,7 @@ final class DowningClusteredTests: ClusteredActorSystemsXCTestCase {
 
         pinfo("Downing \(nodesToDown.count) nodes: \(nodesToDown.map { $0.cluster.uniqueNode })")
         for node in nodesToDown {
-            node.shutdown().wait()
+            try! node.shutdown().wait()
         }
 
         func expectedDownMemberEventsFishing(

--- a/Tests/DistributedActorsTests/Cluster/Reception/OpLogClusterReceptionistClusteredTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/Reception/OpLogClusterReceptionistClusteredTests.swift
@@ -208,7 +208,7 @@ final class OpLogClusterReceptionistClusteredTests: ClusteredActorSystemsXCTestC
             refA.tell("stop")
             refB.tell("stop")
         case .shutdownNode:
-            first.shutdown().wait()
+            try first.shutdown().wait()
         }
 
         try remoteLookupProbe.eventuallyExpectListing(expected: [], within: .seconds(3))
@@ -291,7 +291,7 @@ final class OpLogClusterReceptionistClusteredTests: ClusteredActorSystemsXCTestC
         try p2.eventuallyExpectListing(expected: [firstRef, secondRef], within: .seconds(3))
 
         // crash the second node
-        second.shutdown().wait()
+        try second.shutdown().wait()
 
         // it should be removed from all listings; on both nodes, for all keys
         try p1.eventuallyExpectListing(expected: [firstRef], within: .seconds(5))
@@ -328,7 +328,7 @@ final class OpLogClusterReceptionistClusteredTests: ClusteredActorSystemsXCTestC
         try p2.eventuallyExpectListing(expected: allRefs, within: .seconds(5))
 
         // crash the second node
-        second.shutdown().wait()
+        try second.shutdown().wait()
 
         // it should be removed from all listings; on both nodes, for all keys
         try p1.eventuallyExpectListing(expected: [firstRef], within: .seconds(5), verbose: true)

--- a/Tests/DistributedActorsTests/Cluster/RemoteMessagingClusteredTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/RemoteMessagingClusteredTests.swift
@@ -271,7 +271,7 @@ final class RemoteMessagingClusteredTests: ClusteredActorSystemsXCTestCase {
             settings.serialization.register(SerializationTestMessage.self)
             settings.serialization.register(EchoTestMessage.self)
         }
-        defer { thirdSystem.shutdown().wait() }
+        defer { try! thirdSystem.shutdown().wait() }
 
         thirdSystem.cluster.join(node: local.cluster.uniqueNode.node)
         thirdSystem.cluster.join(node: remote.cluster.uniqueNode.node)

--- a/Tests/DistributedActorsTests/Cluster/SystemMessageRedeliveryHandlerTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/SystemMessageRedeliveryHandlerTests.swift
@@ -162,7 +162,7 @@ final class SystemMessageRedeliveryHandlerTests: ActorSystemXCTestCase {
 //
 //        let settings = OutboundSystemMessageRedeliverySettings()
 //        let system = ActorSystem("OtherSystem") // formatting is such specific to align names in printout
-//        defer { system.shutdown().wait() }
+//        defer { try! system.shutdown().wait() }
 //
 //        var lossySettings = FaultyNetworkSimulationSettings(mode: .drop(probability: 0.25))
 //        lossySettings.label = "    (DROP)    :" // formatting is such specific to align names in printout

--- a/Tests/DistributedActorsTests/Cluster/SystemMessagesRedeliveryTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/SystemMessagesRedeliveryTests.swift
@@ -257,7 +257,7 @@ final class SystemMessagesRedeliveryTests: ActorSystemXCTestCase {
     func test_redelivery_systemMessage_serialization() throws {
         let system = ActorSystem("\(type(of: self))")
         defer {
-            system.shutdown().wait()
+            try! system.shutdown().wait()
         }
 
         func validateRoundTrip<T: Equatable>(_ value: T) throws {

--- a/Tests/DistributedActorsTests/SerializationPoolTests.swift
+++ b/Tests/DistributedActorsTests/SerializationPoolTests.swift
@@ -107,7 +107,7 @@ final class SerializationPoolTests: XCTestCase {
     }
 
     override func tearDown() {
-        self.system.shutdown().wait()
+        try! self.system.shutdown().wait()
         try! self.elg.syncShutdownGracefully()
     }
 

--- a/Tests/DistributedActorsTests/SerializationTests.swift
+++ b/Tests/DistributedActorsTests/SerializationTests.swift
@@ -304,10 +304,10 @@ class SerializationTests: ActorSystemXCTestCase {
             echo.tell("hi!") // is a built-in serializable message
             try p.expectMessage("echo:hi!")
         } catch {
-            s2.shutdown().wait()
+            try! s2.shutdown().wait()
             throw error
         }
-        s2.shutdown().wait()
+        try! s2.shutdown().wait()
     }
 
     // ==== ------------------------------------------------------------------------------------------------------------
@@ -408,7 +408,7 @@ class SerializationTests: ActorSystemXCTestCase {
             settings.serialization.register(PListXMLCodableTest.self, serializerID: .foundationPropertyListBinary) // on purpose "wrong" format
         }
         defer {
-            system2.shutdown().wait()
+            try! system2.shutdown().wait()
         }
 
         _ = try shouldThrow {

--- a/Tests/GenActorsTests/GenCodableTests.swift
+++ b/Tests/GenActorsTests/GenCodableTests.swift
@@ -29,7 +29,7 @@ final class GenCodableTests: XCTestCase {
     }
 
     override func tearDown() {
-        self.system.shutdown().wait()
+        try! self.system.shutdown().wait()
         self.system = nil
         self.testKit = nil
     }

--- a/Tests/GenActorsTests/GenerateActorsTests.swift
+++ b/Tests/GenActorsTests/GenerateActorsTests.swift
@@ -32,7 +32,7 @@ final class GenerateActorsTests: XCTestCase {
     }
 
     override func tearDown() {
-        self.system.shutdown().wait()
+        try! self.system.shutdown().wait()
     }
 
     // ==== ----------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation:

Since we noticed it again in the sample app

```swift
        system.shutdown(queue: .global(), afterShutdownCompleted: { error in
            receptacle.offerOnce(error)
        })
```

### Modifications:

- we now have a callback on shutdown.
- the wait() can throw, which makes sense to get the errors out if we dont have the callback

### Result:

resolves #230