### PR TITLE
=ios fix availability requirements for iOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 Instruments/ActorInstruments/ActorInstruments.xcodeproj/xcuserdata
 Instruments/ActorInstruments/build/
 Instruments/ActorInstruments/ActorInstruments.xcodeproj/project.xcworkspace/xcuserdata
+Instruments/ActorInstruments/build
 
 Samples/swift-distributed-actors-samples.xcodeproj
 

--- a/Sources/DistributedActors/Instrumentation/os_signpost/ActorInstrumentation+os_signpost.swift
+++ b/Sources/DistributedActors/Instrumentation/os_signpost/ActorInstrumentation+os_signpost.swift
@@ -18,8 +18,8 @@ import os.log
 import os.signpost
 
 @available(OSX 10.14, *)
-@available(iOS 10.0, *)
-@available(tvOS 10.0, *)
+@available(iOS 12.0, *)
+@available(tvOS 12.0, *)
 @available(watchOS 3.0, *)
 public struct OSSignpostActorInstrumentation: ActorInstrumentation {
     static let subsystem: StaticString = "com.apple.actors"
@@ -49,8 +49,8 @@ public struct OSSignpostActorInstrumentation: ActorInstrumentation {
 // MARK: Instrumentation: Actor Lifecycle
 
 @available(OSX 10.14, *)
-@available(iOS 10.0, *)
-@available(tvOS 10.0, *)
+@available(iOS 12.0, *)
+@available(tvOS 12.0, *)
 @available(watchOS 3.0, *)
 extension OSSignpostActorInstrumentation {
     static let actorSpawnedStartFormat: StaticString =
@@ -142,8 +142,8 @@ extension OSSignpostActorInstrumentation {
 // MARK: Instrumentation: Actor Messages
 
 @available(OSX 10.14, *)
-@available(iOS 10.0, *)
-@available(tvOS 10.0, *)
+@available(iOS 12.0, *)
+@available(tvOS 12.0, *)
 @available(watchOS 3.0, *)
 extension OSSignpostActorInstrumentation {
     // ==== ----------------------------------------------------------------------------------------------------------------

--- a/Sources/DistributedActors/Instrumentation/os_signpost/ActorTransportInstrumentation+os_signpost.swift
+++ b/Sources/DistributedActors/Instrumentation/os_signpost/ActorTransportInstrumentation+os_signpost.swift
@@ -21,8 +21,8 @@ import os.log
 import os.signpost
 
 @available(OSX 10.14, *)
-@available(iOS 10.0, *)
-@available(tvOS 10.0, *)
+@available(iOS 12.0, *)
+@available(tvOS 12.0, *)
 @available(watchOS 3.0, *)
 public struct OSSignpostActorTransportInstrumentation: ActorTransportInstrumentation {
     static let subsystem: StaticString = "com.apple.actors"
@@ -46,8 +46,8 @@ public struct OSSignpostActorTransportInstrumentation: ActorTransportInstrumenta
 // MARK: Instrumentation: Serialization
 
 @available(OSX 10.14, *)
-@available(iOS 10.0, *)
-@available(tvOS 10.0, *)
+@available(iOS 12.0, *)
+@available(tvOS 12.0, *)
 @available(watchOS 3.0, *)
 extension OSSignpostActorTransportInstrumentation {
     static let actorMessageSerializeStartPattern: StaticString =

--- a/Sources/DistributedActors/Instrumentation/os_signpost/InstrumentationProvider+os_signpost.swift
+++ b/Sources/DistributedActors/Instrumentation/os_signpost/InstrumentationProvider+os_signpost.swift
@@ -18,7 +18,7 @@ public struct OSSignpostInstrumentationProvider: ActorSystemInstrumentationProvi
     public init() {}
 
     public var actorInstrumentation: ((AnyObject, ActorAddress) -> ActorInstrumentation)? {
-        if #available(OSX 10.14, *) {
+        if #available(OSX 10.14, iOS 12.0, *) {
             // TODO: how to guard in iOS etc here?
             return OSSignpostActorInstrumentation.init
         } else {
@@ -27,7 +27,7 @@ public struct OSSignpostInstrumentationProvider: ActorSystemInstrumentationProvi
     }
 
     public var actorTransportInstrumentation: (() -> ActorTransportInstrumentation)? {
-        if #available(OSX 10.14, *) {
+        if #available(OSX 10.14, iOS 12.0, *) {
             return OSSignpostActorTransportInstrumentation.init
         } else {
             return nil
@@ -35,7 +35,7 @@ public struct OSSignpostInstrumentationProvider: ActorSystemInstrumentationProvi
     }
 
     public var receptionistInstrumentation: (() -> ReceptionistInstrumentation)? {
-        if #available(OSX 10.14, *) {
+        if #available(OSX 10.14, iOS 12.0, *) {
             return OSSignpostReceptionistInstrumentation.init
         } else {
             return nil

--- a/Sources/DistributedActors/Instrumentation/os_signpost/ReceptionistInstrumentation+os_signpost.swift
+++ b/Sources/DistributedActors/Instrumentation/os_signpost/ReceptionistInstrumentation+os_signpost.swift
@@ -18,8 +18,8 @@ import os.log
 import os.signpost
 
 @available(OSX 10.14, *)
-@available(iOS 10.0, *)
-@available(tvOS 10.0, *)
+@available(iOS 12.0, *)
+@available(tvOS 12.0, *)
 @available(watchOS 3.0, *)
 public struct OSSignpostReceptionistInstrumentation: ReceptionistInstrumentation {
     static let subsystem: StaticString = "com.apple.actors"
@@ -40,8 +40,8 @@ public struct OSSignpostReceptionistInstrumentation: ReceptionistInstrumentation
 // MARK: Instrumentation: Receptionist
 
 @available(OSX 10.14, *)
-@available(iOS 10.0, *)
-@available(tvOS 10.0, *)
+@available(iOS 12.0, *)
+@available(tvOS 12.0, *)
 @available(watchOS 3.0, *)
 extension OSSignpostReceptionistInstrumentation {
     static let subscribedFormat: StaticString =

--- a/Tests/DistributedActorsTests/Cluster/ClusterLeaderActionsClusteredTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/ClusterLeaderActionsClusteredTests.swift
@@ -268,9 +268,9 @@ final class ClusterLeaderActionsClusteredTests: ClusteredActorSystemsXCTestCase 
             }
         }
 
-        // snapshot(nil) + first nil -> joining 
-        // OR 
-        // snapshot(first joining) 
+        // snapshot(nil) + first nil -> joining
+        // OR
+        // snapshot(first joining)
         // are both legal
         eventsOnFirstSub.shouldContain(.membershipChange(.init(node: secondNode, fromStatus: nil, toStatus: .joining)))
         eventsOnFirstSub.shouldContain(.membershipChange(.init(node: first.cluster.uniqueNode, fromStatus: .joining, toStatus: .up)))


### PR DESCRIPTION
Signposts are available from iOS 12, so we need to bump the availability here.
