### PR TITLE
exact nio ssl version for compat with specific project which requires it

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -249,7 +249,7 @@ targets.append(
 var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.12.0"),
     .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.2.0"),
-    .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.2.0"),
+    .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.8.0"),
 
     .package(name: "SwiftProtobuf", url: "https://github.com/apple/swift-protobuf.git", from: "1.7.0"),
 


### PR DESCRIPTION
Because: https://github.com/apple/swift-nio-ssl/issues/236

and a specific project pinning the NIO version, we have to also pin and add the try.

It is impossible for us to support both versions because the change https://github.com/apple/swift-nio-ssl/issues/236 causes either a deprecation warning, or an extrra try where there should not be one warning -- and we build with warnings as errors, so we can't build in either "compat with everything" style...

:-(

Not sure for a real solution other than the other project updating to 2.8+