### PR TITLE
=test fix #740 missing buffer usage in 2 other impls in the testcase

### DIFF
--- a/Tests/DistributedActorsTests/Actorable/ActorableExampleRouterTests.swift
+++ b/Tests/DistributedActorsTests/Actorable/ActorableExampleRouterTests.swift
@@ -165,7 +165,7 @@ final class MessageRefRouter: Actorable {
         if let target = targets[identifier] {
             target.tell(.handleMessage(message, replyTo: replyTo))
         } else {
-            // do some error handling
+            self.buffer.append((identifier, message, replyTo))
         }
     }
 }
@@ -200,7 +200,7 @@ final class MessageRouter: Actorable {
         if let target = targets[identifier] {
             target.handleMessage(message, replyTo: replyTo)
         } else {
-            // do some error handling
+            self.buffer.append((identifier, message, replyTo))
         }
     }
 }


### PR DESCRIPTION
Resolves #740 

The registration etc can be racy thus the buffer is there to serve as redelivery -- this is in tests only, this naive impl is fine.

This was solved in one of the impls, but missed to do the same in the other two.