### PR TITLE
ActorSystem.shutdown() should invoke afterShutdownCompleted when already shutdown

### DIFF
--- a/Sources/DistributedActors/ActorSystem.swift
+++ b/Sources/DistributedActors/ActorSystem.swift
@@ -386,6 +386,7 @@ public final class ActorSystem {
     public func shutdown(queue: DispatchQueue = DispatchQueue.global(), afterShutdownCompleted: @escaping (Error?) -> Void = { _ in () }) -> Shutdown {
         guard self.shutdownFlag.add(1) == 0 else {
             // shutdown already kicked off by someone else
+            afterShutdownCompleted(nil)
             return Shutdown(receptacle: self.shutdownReceptacle)
         }
 

--- a/Tests/DistributedActorsTests/ActorSystemTests.swift
+++ b/Tests/DistributedActorsTests/ActorSystemTests.swift
@@ -129,4 +129,23 @@ final class ActorSystemTests: ActorSystemXCTestCase {
 
         receptacle.wait(atMost: .seconds(3))!.shouldBeNil()
     }
+
+    func test_shutdown_callbackShouldBeInvokedWhenAlreadyShutdown() throws {
+        let system = ActorSystem("ShutMeDown")
+        let firstReceptacle = BlockingReceptacle<Error?>()
+
+        system.shutdown(afterShutdownCompleted: { error in
+            firstReceptacle.offerOnce(error)
+        })
+
+        firstReceptacle.wait(atMost: .seconds(3))!.shouldBeNil()
+
+        let secondReceptacle = BlockingReceptacle<Error?>()
+
+        system.shutdown(afterShutdownCompleted: { error in
+            secondReceptacle.offerOnce(error)
+        })
+
+        secondReceptacle.wait(atMost: .seconds(3))!.shouldBeNil()
+    }
 }


### PR DESCRIPTION
Calls the `afterShutdownCompleted` callback in `ActorSystem.shutdown()` if some other caller has already shut down the actor system. This avoids any logic awaiting on the callback being completed from getting stuck.

### Modifications:

In addition to returning a `Shutdown` instance immediately if another caller has shut down the actor system, also invoke the `afterShutdownCompleted` callback. I've chosen to pass a `nil` value but some `Error` type indicating that the shutdown has already been requested may be more appropriate. It may also be best to tie this in to whatever value is returned for the prior `shutdown()` invocation although this may be a bit more involed.

### Result:

- Resolves #760
