### PR TITLE
Swift 5.3 was released, use it for CI

### DIFF
--- a/docker/docker-compose.1804.53.yaml
+++ b/docker/docker-compose.1804.53.yaml
@@ -6,7 +6,8 @@ services:
     image: swift-distributed-actors:18.04-5.3
     build:
       args:
-        base_image: "swiftlang/swift:nightly-5.3-bionic"
+        ubuntu_version: "bionic"
+        swift_version: "5.3"
 
   unit-tests:
     image: swift-distributed-actors:18.04-5.3


### PR DESCRIPTION
motivation: Swift 5.3 was released, use if for CI

changes: update docker setup to use the release version of 5.3
