### PR TITLE
=test harden test_gossip_shouldEventuallyStopSpreading 

### DIFF
--- a/Tests/DistributedActorsTests/CRDT/CRDTGossipReplicationClusteredTests.swift
+++ b/Tests/DistributedActorsTests/CRDT/CRDTGossipReplicationClusteredTests.swift
@@ -220,7 +220,7 @@ final class CRDTGossipReplicationClusteredTests: ClusteredActorSystemsXCTestCase
 
     func test_gossip_shouldEventuallyStopSpreading() throws {
         let configure: (inout ActorSystemSettings) -> Void = { settings in
-            settings.crdt.gossipInterval = .milliseconds(300)
+            settings.crdt.gossipInterval = .milliseconds(200)
             settings.crdt.gossipIntervalRandomFactor = 0 // no random factor, exactly 1second intervals
         }
         let first = self.setUpNode("first", configure)
@@ -259,7 +259,7 @@ final class CRDTGossipReplicationClusteredTests: ClusteredActorSystemsXCTestCase
             let logs: [CapturedLogMessage] = self.capturedLogs(of: first)
                 .grep("Received gossip", metadata: ["gossip/identity": "counter"])
 
-            guard logs.count < 5 else {
+            guard logs.count < 10 else {
                 throw testKit.error("Received gossip more times than expected! Logs: \(lineByLine: logs)")
             }
         }


### PR DESCRIPTION

### Motivation:

Failure from nightly CI.

The test is too aggressive, it is probabilistic how many exact rounds will happen and it depends on ordering and timing of message exchanges.

All this test wants to check is that messages eventually stop flowing, we can check this with a more frequent gossip round and just checking that they definitely stop, rather than checking the exact number on "happy path"

### Modifications:

Loosen up the checks but still check what the test is intended to be testing

### Result:

- Resolves a flaky test
