### PR TITLE
adjust to released version of swift 5.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -274,7 +274,7 @@ var dependencies: [Package.Dependency] = [
 
 #if swift(>=5.3)
 dependencies.append(
-    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .revision("swift-5.3-DEVELOPMENT-SNAPSHOT-2020-07-02-a"))
+    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50300.0"))
 )
 #elseif swift(>=5.2)
 dependencies.append(

--- a/Sources/DistributedActors/Serialization/Serialization+Manifest.swift
+++ b/Sources/DistributedActors/Serialization/Serialization+Manifest.swift
@@ -141,7 +141,7 @@ extension Serialization {
             return _typeName(messageType)
         }
         #else
-        if #available(macOS 10.16, iOS 14.0, *) {
+        /*if #available(macOS 10.16, iOS 14.0, *) {
             // This is "special". A manifest containing a mangled type name can be summoned if the type remains unchanged
             // on a receiving node. Summoning a type is basically `_typeByName` with extra checks that this type should be allowed
             // to be deserialized (thus, we can disallow decoding random messages for security).
@@ -153,9 +153,9 @@ extension Serialization {
             } else {
                 return _typeName(messageType)
             }
-        } else {
+        } else {*/
             return _typeName(messageType)
-        }
+        //}
         #endif // os
         #else
         return _typeName(messageType)


### PR DESCRIPTION
motivation: swift 5.3 is out, use it

changes:
* update to swift-sytax stable 5.3
* workaround mangled name assumption

