### PR TITLE
=build bump to using stable 5.3 swift-syntax

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -274,7 +274,7 @@ var dependencies: [Package.Dependency] = [
 
 #if swift(>=5.3)
 dependencies.append(
-    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .revision("swift-5.3-DEVELOPMENT-SNAPSHOT-2020-07-02-a"))
+    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50300.0"))
 )
 #elseif swift(>=5.2)
 dependencies.append(


### PR DESCRIPTION
Bumps swift syntax to stable version, this resolves issues for users depending on as on 5.3.

There's a pending radar for nicer tags still though which we'll need to get through to avoid pains with Swift 5.4 or 6 