### PR TITLE
Update reference docs

### DIFF
--- a/Docs/actorables.adoc
+++ b/Docs/actorables.adoc
@@ -2,41 +2,35 @@
 [[actorable]]
 == Actorable Actors
 
-> The api:Actorable[protocol] protocol allows for defining Actors by writing structs (or classes),
-> and deriving the underlying message-passing machinery from the struct's function declarations.
+> The api:Actorable[protocol] protocol allows for defining Actors by writing structs (or classes), and deriving the underlying message-passing machinery from the struct's function declarations.
 
 NOTE: See also <<behaviors, Actor Behaviors>> which describes the underlying power-user API.
 
 === Getting Started: Actorable
 
 WARNING: api:Actorable[protocol] and `GenActors` are EXPERIMENTAL and may change.
-         This source generation tool is aimed to prove the concept of deriving actor message protocols from function declarations,
-         which may perhaps be possible to implement using compiler features in the future.
+This source generation tool is aimed to prove the concept of deriving actor message protocols from function declarations, which may perhaps be possible to implement using compiler features in the future.
 
 The api:Actorable[protocol] protocol allows for a no-hassle way for defining actor behavior.
-Any function in an actorable can be marked using the `@actor` (pseudo) "annotation" in its comment section in order to opt-in
-for source generation of any relevant actor runtime and message dispatch code for this message. It also serves as documentation,
-so you know which functions may be invoked as a result of remote message sends.
+Any function in an actorable can be marked using the `@actor` (pseudo) "annotation" in its comment section in order to opt-in for source generation of any relevant actor runtime and message dispatch code for this message.
+It also serves as documentation, so you know which functions may be invoked as a result of remote message sends.
 
-By conforming to the protocol all public and internal functions defined directly (not in extensions) in a type
-are made available as messages.
+By conforming to the protocol all public and internal functions defined directly (not in extensions) in a type are made available as messages.
 
 [source]
 ----
 include::{dir_sact_doc_tests}/Actorable/ActorableDocExamples.swift[tag=greeter_0]
 ----
 
-TIP:: In order to make a `func` available as an Actor message, it must be marked using the `@actor` "annotation" in its comment. +
-We recommend a simple `// @actor` following any actual documentation (marked using the `///` style), such that this noise is not included in its documentation. +
+TIP: In order to make a `func` available as an Actor message, it must be marked using the `@actor` "annotation" in its comment.
+We recommend a simple `// @actor` following any actual documentation (marked using the `///` style), such that this noise is not included in its documentation.
+    +
+    +
+    The annotated struct can be used as a synchronous implementation, but can also be spawned as an actor.
 
-Such struct can be used as synchronous implementation, but can also be spawned as an actor.
+Before we spawn the actor, we have to run the `GenActors` command line utility, which analyzes and generates messages, and supporting actor infrastructure for all api:Actorable[protocol] types.
 
-Before we spawn the actor, we have to run the `GenActors` command line utility, which analyzes and generates messages,
-and supporting actor infrastructure for all api:Actorable[protocol] types.
-
-NOTE: Remember to depend on `DistributedActors` in the target you intend to use them, as well as on `GenActors`
-in at least one target or main product; as SwiftPM is soon going to require more explicit dependencies in order to be
-able `run` executable targets offered by dependencies.
+NOTE: Remember to depend on `DistributedActors` in the target you intend to use them, as well as on `GenActors` in at least one target or main product -- SwiftPM is soon going to require more explicit dependencies in order to be able `run` executable targets offered by dependencies.
 
 To run the source code generator, invoke:
 
@@ -59,12 +53,11 @@ More advanced features of the source generator are documented in <<advanced_gena
 ----
 include::{dir_sact_doc_tests}/Actorable/ActorableDocExamples.swift[tag=spawn_greeter]
 ----
-<1> An api:ActorSystem[class] is where all actors are running
+<1> An api:ActorSystem[class] is where all actors are running.
 <2> Spawn the actor by passing a closure that creates an `Actorable`; The returned type is an `Actor`, wrapping the `Greeter` instance.
 <3> The `greet(name:)` call, results in *sending a message* to the greeter actor. It will execute it's `greet` implementation asynchronously, and eventually reply -- which is signified by the `Reply<String>` type.
 
-TIP: The generated sources are always created in a file named with the Actorables name, suffixed with `+GenActor.swift`.
-     E.g. generated sources for `Greeter` would be generated into `Greeter+GenActor.swift`.
+TIP: The generated sources are always created in a file named with the Actorables name, suffixed with `+GenActor.swift`, e.g. generated sources for `Greeter` would be generated into `Greeter+GenActor.swift`.
 
 ==== Messaging styles: tell, ask, call
 
@@ -72,40 +65,39 @@ Actors are very general constructs, and can perform many more interaction patter
 
 In general Actors support three discrete styles of interactions:
 
-- "tell" -- an uni-directional message pass; which is equivalent to a `Void` returning function.
-    * This is the underlying mechanism for all other interactions, and does not by itself exert any backpressure on senders.
-      Backpressure mechanisms are built on top of tell communication in the message protocol layer. E.g. with token based flow control,
-      similar to how Combine or Reactive Streams achieve this.
-    * Actorable example signature: `func printGreeting(name: String)`, i.e. it does not return/reply.
-- `ask` -- a general form of asking for a reply. An explicit `ActorRef<Reply>` is sent to the downstream,
-  making it possible to pass along the asking reference to another actor, which then eventually replies to the originator _directly_.
-    * Actorable example signature: `func greetMe(replyTo: Actor<GreetMe>)` or `func greetMe(replyTo: ActorRef<GreetMe>)`, i.e. we expect the greeting to be sent back to the `replyTo` actor.
-- "call" -- calls are the general shape of how api:Actorable[protocol] actors expose their request/reply interactions. I.e. when an actorable
-  method "returns a value", it actually is implemented by sending that value back to the calling actor.
-    * calls are implemented as a form of asks, though this is done transparently to the user.
-    * Actorable example signature: `func greet(name: String) -> Greeting`, or `func greet(name: String) -> EventLoopFuture<Greeting>`,
-      meaning we "return" the value we want to reply back with. The calling actor will receive an `Reply<Greeting>` in either case.
+* `tell` -- a uni-directional message pass, equivalent to a `Void` returning function.
+** This is the underlying mechanism for all other interactions, and does not by itself exert any backpressure on senders.
+    Backpressure mechanisms are built on top of tell communication in the message protocol layer, e.g. with token based flow control, similar to how Combine or Reactive Streams achieve this.
+** Actorable example signature: `func printGreeting(name: String)`, i.e. it does not return/reply.
+* `ask` -- a general form of asking for a reply.
+  An explicit `ActorRef<Reply>` is sent to the downstream, making it possible to pass along the asking reference to another actor, which then eventually replies to the originator _directly_.
+** Actorable example signature: `func greetMe(replyTo: Actor<GreetMe>)` or `func greetMe(replyTo: ActorRef<GreetMe>)`, i.e. we expect the greeting to be sent back to the `replyTo` actor.
+* `call` -- calls are the general shape of how api:Actorable[protocol] actors expose their request/reply interactions, i.e. when an actorable method "returns a value", it actually is implemented by sending that value back to the calling actor.
+** Calls are implemented as a form of asks, though this is done transparently to the user.
+** Actorable example signature: `func greet(name: String) -> Greeting`, or `func greet(name: String) -> EventLoopFuture<Greeting>`, meaning we "return" the value we want to reply back with.
+    The calling actor will receive an `Reply<Greeting>` in either case.
 
-NOTE: When using `call`-style APIs to message `myself` beware to NOT `awaitResult` (nor `await` if/when this feature lands)
-      on the `Reply` as this would deadlock, since the waiting suspends the actor, meaning it'd never get to process the
-      call message, resulting in the `Reply` never being sent. Such deadlock though is resolved by calls always being waited on with a timeout #TODO: calls do not force timeouts currently# #TODO: we can detect such deadlocks, and with traces, we could even print the chain of calls pretty easily#
+NOTE: When using `call`-style APIs to message `myself` beware to NOT `awaitResult` (nor `await` if/when this feature lands) on the `Reply` as this would deadlock, since the waiting suspends the actor, meaning it'd never get to process the call message, resulting in the `Reply` never being sent.
+Such deadlock is resolved by calls always being waited on with a timeout.
+#TODO: calls do not force timeouts currently#
+#TODO: we can detect such deadlocks, and with traces, we could even print the chain of calls pretty easily#
 
 [[actorable_context]]
 ==== Actor<Self>.Context
 
 TIP: The api:Behavior[struct] style offers the `ActorContext<Message>` type to access all actor functionality.
-     Its equivalent in Actorable style API is `Actor<Self>.Context` which is also accessible as `Myself.Context` inside an actorable.
+Its equivalent in Actorable style API is `Actor<Self>.Context` which is also accessible as `Myself.Context` inside an actorable.
 
-The actor context is what allows the actor to find out about its name, spawn other actors, and perform more advanced
-tasks such as starting timers or awaiting on tasks to complete.
+The actor context is what allows the actor to find out about its name, spawn other actors, and perform more advanced tasks such as starting timers or awaiting on tasks to complete.
 
-An api:Actorable[protocol] can obtain its own actor context in two ways, though most usefully, it can get it during spawning:
+An api:Actorable[protocol] can obtain its own actor context in two ways, most usefully it can get it during spawning:
 
 [source]
 ----
 include::{dir_sact_doc_tests}/Actorable/ActorableDocExamples.swift[tag=spawn_with_context_0]
 ----
-<1> Store the context as a field inside the actor. Be sure to *never* hand the context to other threads or actors, as it is strictly private to the actor itself.
+<1> Store the context as a field inside the actor.
+    Be sure to *never* hand the context to other threads or actors, as it is strictly private to the actor itself.
 <2> You may write an initializer to store the context explicitly, or rely on the struct's automatic initializer.
 
 [source]
@@ -115,24 +107,21 @@ include::{dir_sact_doc_tests}/Actorable/ActorableDocExamples.swift[tag=spawn_wit
 <1> `spawn` has an overload that allows creating the api:Actorable[protocol] using a closure which gets the context passed in.
 <2> For single parameter inits accepting the actor's context, you can use this shorthand version of spawning them.
 
-WARNING: When spawning actors, make sure to never close over any mutable shared state in the actorable-creating closure,
-         as it could break the promise of state isolation actors rely upon.
+WARNING: When spawning actors, make sure to never close over any mutable shared state in the actorable-creating closure, as it could break the promise of state isolation actors rely upon.
 
 Refer to api:Actor.Context[struct] API documentation to learn more, or the <<behaviors>> documentation, as many actor context features are the same.
 
 ==== Context.Myself
 
-The `myself` reference can be obtained by using `context.myself`. It is typed as `Myself` (a type alias to `Actor<Self>`), allowing you to pass
-it anywhere Actorable-conforming actors may be expected. Learn more about this in <<actorable_protocol_composition>>.
+The `myself` reference can be obtained by using `context.myself`. It is typed as `Myself` (a type alias to `Actor<Self>`), allowing you to pass it anywhere Actorable-conforming actors may be expected.
+Learn more about this in <<actorable_protocol_composition>>.
 
 ==== Sending messages to myself
 
 When implementing functions inside an actorable it is possible to invoke its functions directly, as well as send messages to `myself`.
 
-Both invocation styles may sometimes be useful. E.g. an asynchronous invocation on `context.myself` is useful to reuse
-an internal actor function as part of a few public interface methods, or for scheduling tasks for later execution.
-A synchronous execution of an actorable function is as useful as any other function reuse, but that function may also be
-exposed for others to call via messaging if it makes sense.
+Both invocation styles may sometimes be useful, e.g. an asynchronous invocation on `context.myself` is useful to reuse an internal actor function as part of a few public interface methods, or for scheduling tasks for later execution.
+A synchronous execution of an actorable function is as useful as any other function reuse, but that function may also be exposed for others to call via messaging if it makes sense.
 
 The following example showcases both "self invocation" and "myself call" styles:
 
@@ -140,9 +129,9 @@ The following example showcases both "self invocation" and "myself call" styles:
 ----
 include::{dir_sact_doc_tests}/Actorable/ActorableDocExamples.swift[tag=self_myself_call]
 ----
-<1> We call the `internalTask()` *synchronously*, directly on the actorable's `self`
-<2> In this function we will send a `internalTask` _message_ and want to return its reply, thus the return type changes
-<3> We use `context.myself.internalTask()` to *send a message* to `myself`
+<1> We call the `internalTask()` *synchronously*, directly on the actorable's `self`.
+<2> In this function we will send a `internalTask` _message_ and want to return its reply, thus the return type changes.
+<3> We use `context.myself.internalTask()` to *send a message* to `myself`.
 
 ==== Message Access-Control
 
@@ -156,9 +145,7 @@ For example, the following Actorable:
 include::{dir_sact_doc_tests}/Actorable/ActorableDocExamples.swift[tag=access_control_1]
 ----
 
-In order to NOT generate a message for a specific function that should be available for your actor, you can:
-
-- prefix it with `__` (double-underscore; as single-underscore sometimes is used for messages which "have to" be public, but really should not be called nor show up in auto completion.)
+In order to *NOT* generate a message for a specific function that should be available for your actor, you can prefix it with `__` (double-underscore; as single-underscore is sometimes used for messages which "have to" be public, but really should not be called nor show up in auto completion).
 
 ==== Actorable Lifecycle
 
@@ -170,42 +157,40 @@ An actorable can react to those lifecycle events by overriding the `preStart`, `
 include::{dir_sact_doc_tests}/Actorable/ActorableDocExamples.swift[tag=lifecycle_callbacks]
 ----
 <1> `preStart` executes before any other message is received by the actor, and is a good place to perform any post-init additional initialization work, e.g. scheduling timers or similar.
-<2> Note also that the Actor's context is passed into these lifecycle hooks, making it easy to log or perform additional tasks
+<2> Note also that the Actor's context is passed into these lifecycle hooks, making it easy to log or perform additional tasks.
 <3> `postStop` executes after the "last" message that an actor will handle is processed (or the actor is crashing), and before it is finally terminated and `Terminated` signals are sent to any actors which were watching it.
 <4> `receiveTerminated` executes whenever a watched actor is terminated (crashes or stops voluntarily), giving this actor a chance to react to that termination (e.g. by terminating itself, or spawning a "replacement" for the now dead actor).
 
-The entire lifecycle is perhaps best explained using the following diagram illustrates lifecycle transitions and signals
-which are delivered to an actor as it undergoes these transitions. Note that in normal situations, i.e. without faulty behaviors,
-the diagram is a simple linear transition from `Running` through `Stopped` to `Terminated`. All other states and transitions come
-into play only in face of faulty behaviors.
+The entire lifecycle is perhaps best explained using the following diagram illustrates lifecycle transitions and signals which are delivered to an actor as it undergoes these transitions.
+Note that in normal situations, i.e. without faulty behaviors, the diagram is a simple linear transition from `Running` through `Stopped` to `Terminated`.
+All other states and transitions come into play only in face of faulty behaviors.
 
-NOTE:: Actor Lifecycle funcs, same as any other message-driven funcs, MUST be marked using the `// @actor` annotation.
-       The source generator will warn and fail if these functions are used without the proper annotation, to keep the look and feel of message driven funcs the same.
+NOTE: Actor Lifecycle funcs, same as any other message-driven funcs, MUST be marked using the `// @actor` annotation.
+The source generator will warn and fail if these functions are used without the proper annotation, to keep the look and feel of message driven funcs the same.
 
 #TODO: The diagram and wording are based on the <<behaviors>> documentation, and not yet completely remade for Actorable.#
 
 image::actor_lifecycle.png[Actor Lifecycle]
 
-1. Start: Upon spawning, a special internal `Start` signal is interpreted by the actor, causing the `preStart` callback to execute
-2. Stop Myself: An actor may decide to stop itself by returning a api:Behavior[struct,alias='Behavior.stop'], causing it to transition to `Stopped`.
-3. Stop by Parent: Alternatively, the current actor's parent parent could send a stop signal (using `context.stop(childRef)`), which the actor would have to abide to.
-4. PostStop: Once the actor has `Stopped` and drained its mailbox (to dead letters), it will process one last signal, causing the `postStop` callback to execute
-However, regardless of the next behavior returned by handling this signal, the actor will always proceed to the `Terminated` state.
-Once `Terminated`, the actor will never again wake up nor process any more messages nor signals.
-5. Supervision: If an actor throws an error or causes a fault it will transition to Failing 🔥, and invoke its supervisor will be invoked, to see if the actor should be restated or not.
-To learn more about <<Supervision>> and the various supervision strategies, refer to the <<Failure Handling>> chapter of the documentation.
-6. Supervision (restart): If the configured supervisor decides that the actor should be restarted (now, or upon a delay), a :api:Signals[enum,alias='Signals.PreRestart'] signal will be delivered to the _current (failing) behavior_,
-before a new instance of the _initial behavior_ will be created to replace the faulty one. 
-7. Supervision (fail): If the supervisor decides that the actor should _not_ be restarted (e.g. because it exhausted its permitted restart count, or the fault captured is too serious to ignore),
-the actor will transition to `Stopped` and `Terminated`, similar to how it would behave if it were stopping itself manually. #TODO: I think we want to signal in PostStop that this is because we failed, and not a manual stop#
+1. *Start*: Upon spawning, a special internal `Start` signal is interpreted by the actor, causing the `preStart` callback to execute
+2. *Stop Myself*: An actor may decide to stop itself by returning a api:Behavior[struct,alias='Behavior.stop'], causing it to transition to `Stopped`.
+3. *Stop by Parent*: Alternatively, the current actor's parent parent could send a stop signal (using `context.stop(childRef)`), which the actor _cannot_ ignore, and will take effect as soon as it is received.
+4. *PostStop*: Once the actor has `Stopped` and drained its mailbox (to dead letters), it will process one last signal, causing the `postStop` callback to execute.
+Regardless of the next behavior returned by handling this signal, the actor will always proceed to the `Terminated` state.
+    Once `Terminated`, the actor will never again wake up nor process any more messages or signals.
+5. *Supervision*: If an actor throws an error or causes a fault it will transition to Failing 🔥, and its supervisor will be invoked to see if the actor should be restated or not.
+    To learn more about <<Supervision>> and the various supervision strategies, refer to the <<Failure Handling>> chapter of the documentation.
+6. *Supervision (restart)*: If the configured supervisor decides that the actor should be restarted (now, or upon a delay), a :api:Signals[enum,alias='Signals.PreRestart'] signal will be delivered to the _current (failing) behavior_, and a new instance of the _initial behavior_ will be created to replace the faulty one.
+7. *Supervision (fail)*: If the supervisor decides that the actor should _not_ be restarted (e.g. because it exhausted its permitted restart count, or the fault captured is too serious to ignore), the actor will transition to `Stopped` and `Terminated`, similar to how it would behave if it were stopping itself manually.
+#TODO: I think we want to signal in PostStop that this is because we failed, and not a manual stop#
 
 [[actorable_protocol_composition]]
 === Actorable Protocols & Composition
 
-It is possible to make protocols api:Actorable[protocol] as well, this allows other concrete actorables (such as classes or structs),
-to adopt them, and also enables composing multiple message protocols and implementing them in one actor.
+It is possible to make protocols api:Actorable[protocol] as well.
+This allows other concrete actorables (such as classes or structs) to adopt them, and also enables composing multiple message protocols and implementing them in one actor.
 
-TIP: In case you are familiar with behaviors and adapters, this composition style is vastly superior and less boiler-plate heavy.
+TIP: If you are familiar with behaviors and adapters, this composition style is vastly superior and less boiler-plate heavy.
 
 Let us define two protocols, which will perform two separate sets of tasks, and then we will implement them in the same actorable.
 
@@ -213,16 +198,16 @@ Let us define two protocols, which will perform two separate sets of tasks, and 
 ----
 include::{dir_sact_doc_tests}/Actorable/ActorableDocExamples.swift[tag=compose_protocols_1]
 ----
-<1> Create a (public) protocol and make it api:Actorable[protocol]
-<2> Boilerplate which we need to provide to allow boxing the `CoffeeMachine` messages in a concrete actor's message protocol (see below)
-<3> Create an (internal) protocol and make it api:Actorable[protocol]
-<4> Boilerplate which we need to provide to allow boxing the `Diagnostics` messages in a concrete actor's message protocol (see below)
+<1> Create a (public) protocol and make it api:Actorable[protocol].
+<2> Boilerplate which we need to provide to allow boxing the `CoffeeMachine` messages in a concrete actor's message protocol (see below).
+<3> Create an (internal) protocol and make it api:Actorable[protocol].
+<4> Boilerplate which we need to provide to allow boxing the `Diagnostics` messages in a concrete actor's message protocol (see below).
 <5> Finally, implement a concrete Actorable, conforming to api:Actorable[protocol] (!) as well as the two protocols we just defined.
 
-Since we intend to use them as actorable protocols, we need to allow any adopter of this protocol to box the protocols messages
-into the conforming type's message protocol. #TODO: Hopefully we could work around this somehow less painfully#
-In other words, we have to define a special boxing methods in the protocols. If we forget to do so, we will see the following error,
-asking us to provide the function declaration (without implementing it, as that is generated) to our protocol(s):
+Since we intend to use them as actorable protocols, we need to allow any adopter of this protocol to box the protocols messages into the conforming type's message protocol.
+#TODO: Hopefully we could work around this somehow less painfully#
+In other words, we have to define a special boxing methods in the protocols.
+If we forget to do so, we will see the following error, asking us to provide the function declaration (without implementing it, as that is generated) to our protocol(s):
 
 ----
 Actorable protocol [CoffeeMachine] MUST define a boxing function, in order to be adopted by other Actorables!
@@ -233,10 +218,9 @@ Please define a static boxing function in [CoffeeMachine]:
 Implementations for this function will be generated automatically for every concrete conformance of an Actorable and this protocol.
 ----
 
-Having done this, after invoking <<gen_actors, GenActors>>, we are able to use the `AllInOneMachine` as a `CoffeeMachine`,
-or as a `Diagnostics` actor which allows us to print some diagnostics. This is a fairly useful trick in which we keep some
-functions internal to our module, yet others public. #Sadly though, since we still generate all messages into the `AllInOneMachine.Message` enum,
-effectively they are all public; We should consider if we can improve this, but it'd mean stopping to use enums completely.#
+Having done this, after invoking <<gen_actors, GenActors>>, we are able to use the `AllInOneMachine` as a `CoffeeMachine`, or as a `Diagnostics` actor which allows us to print some diagnostics.
+This is a fairly useful trick in which we keep some functions internal to our module, yet others public.
+#Sadly though, since we still generate all messages into the `AllInOneMachine.Message` enum, effectively they are all public; We should consider if we can improve this, but it'd mean stopping the use of enums completely.#
 
 Now let us try out spawning, messaging, and passing around our such defined actor:
 
@@ -244,17 +228,14 @@ Now let us try out spawning, messaging, and passing around our such defined acto
 ----
 include::{dir_sact_doc_tests}/Actorable/ActorableDocExamples.swift[tag=compose_protocols_2]
 ----
-<1> We can send `CoffeeMachine` messages to our `Actor<AllInOneMachine>`
-<2> As well as the diagnostics messages
-<3> What is more, we can pass our api:Actor[struct] as parameter to any function which needs just a subset of our adopted message
-    protocols; e.g. a function `printAnyDiagnostics` which takes any actor implementing the `Diagnostics` protocol
+<1> We can send `CoffeeMachine` messages to our `Actor<AllInOneMachine>`.
+<2> As well as the diagnostics messages.
+<3> What's more, we can pass our api:Actor[struct] as parameter to any function which needs just a subset of our adopted message protocols; e.g. a function `printAnyDiagnostics` which takes any actor implementing the `Diagnostics` protocol.
 
-This way of composing actor protocols is very powerful, and allows you to have common protocols for typical tasks,
-which many of your actors can implement.
+This way of composing actor protocols is very powerful, and allows you to have common protocols for typical tasks, which many of your actors can implement.
 
-TIP: If you are wondering if you should adopt more protocols in the same actor, or introduce more actors to handle the tasks:
-     ask yourself if there is a meaningful asynchronous boundary between the two sets of tasks, or if they require some consistent
-     view on some data when performing each their actions. A single actor has stronger consistency and lesser complexity than splitting the tasks
+TIP: If you are wondering if you should adopt more protocols in the same actor, or introduce more actors to handle the tasks, ask yourself if there is a meaningful asynchronous boundary between the two sets of tasks, or if they require some consistent view on some data when performing each their actions.
+A single actor has stronger consistency and lesser complexity than splitting the tasks
      up into multiple actors, but it also limits the parallelism at which the tasks are performed.
 
 [[gen_actors]]
@@ -265,16 +246,15 @@ Inspect that file for generated source code.
 
 Using some Actorable type called `Greeter` as an example, here are a few notable aspects of the generated sources:
 
-- `Greeter.Message` refers to the message protocol as defined by the functions on the type.
-  - you refer to this type whenever a single message or an `ActorRef` for yourself is needed, i.e. you may offer
-    a `myself` reference by using `context.myself.underlying` which will be an `ActorRef<Greeter.Message>
-- all public and internal functions get corresponding generated "message" functions, i.e. matching by name.
+* `Greeter.Message` refers to the message protocol as defined by the functions on the type.
+** You refer to this type whenever a single message or an `ActorRef` for yourself is needed, i.e. you may offer a `myself` reference by using `context.myself.underlying`, which will be an `ActorRef<Greeter.Message>
+* All public and internal functions get corresponding generated "message" functions, i.e. matching by name.
 
 ==== GenActors Limitations
 
 The `GenActors` utility is only a proof of concept right now, and as such has some limitations, most notably:
 
-- nested types are not supported, i.e. nesting an actorable struct in another struct or class will not work.
+- Nested types are not supported, i.e. nesting an actorable struct in another struct or class will not work.
 
 ==== Actor Behaviors Inter-Op
 
@@ -289,41 +269,40 @@ func initialize(task: Task) -> Behavior<Self.Message>
 ==== Advanced GenActors Usage
 
 
-The `GenActors` tool allows for defining actors as if they were any normal struct, and by analysing their function declarations,
-generating a matching message protocol. api:Actorable[protocol] types are able to be spawned as api:Actor[struct]s, which turn
-what looks to be method calls into.
+The `GenActors` tool allows for defining actors as if they were any normal struct, and by analysing their function declarations, generating a matching message protocol.
+api:Actorable[protocol] types are able to be spawned as api:Actor[struct]s, which turn what looks to be method calls into api:Behavior[struct, alias="behaviors"].
 
 When depending on Distributed Actors in your `Package.swift` file, like so:
 
 [source]
 ----
-.package(url: "https://github.com/apple/swift-distributed-actors.git", from: "$version"),
+.package(url: "https://github.com/apple/swift-distributed-actors.git", from: "{sourceversion}"),
 ----
 
-The project will be checked out and available in `.build/checkouts/swift-distributed-actors`, thus is it possible to use the
-`GenActors` command line tool by invoking:
+The project will be checked out and available in `.build/checkouts/swift-distributed-actors`, making it possible to use the `GenActors` command line tool by invoking:
 
 [source]
 ----
 swift run GenActors
 ----
 
-The GenActors command by default inspects the `Sources/` directory for files and detects top level types conforming to the
-api:Actorable[protocol] protocol. Optionally, you may pass folder paths or file names explicitly.
+The GenActors command by default inspects the `Sources/` directory for files and detects top level types conforming to the api:Actorable[protocol] protocol.
+Optionally, you may pass folder paths or file names explicitly.
 
 === Actorables and Serialization
 
 #TODO: This needs a remake of the serialization story as we want them to automatically "just work".#
 
-Currently no special codegen is enabled for Actorables, so in order to send messages to other processes or nodes,
-you will have to register serializers same as in the behavior style, see: <<serialization>>.
+Currently no special codegen is enabled for Actorables, so in order to send messages to other processes or nodes, you will have to register serializers same as in the behavior style.
+See: <<serialization>>.
 
 === Actorable.Message and Serialization
 
 `GenActors` also generates an additional file suffixed `+GenCodable.swift` which contains `Codable` conformance for an actorable's `Message` type.
 
 TIP: Currently Swift does not automatically synthesize `Codable` conformances for enums with associated values, which messages are.
-     We hope to lift this limitation from the Swift compiler soon, however until that time, you can use `GenActors` and its generated conformance.
+We hope to lift this limitation from the Swift compiler soon.
+Until that time, you can use `GenActors` and its generated conformance.
 
 You can disable this conformance generation by overriding the static `generateCodableConformance` property in your api:Actorable[protocol], like this:
 
@@ -334,20 +313,17 @@ include::{dir_sact_doc_tests}/Actorable/ActorableDocExamples.swift[tag=disable_c
 
 You still have to *register* the the type with the serialization infrastructure as documented in <<serialization>> however.
 
-TIP: We aim to simplify the serialization infrastructure to be able to infer more about what serializer to use for a given type,
-     however the current approach remains valid (and most resilient in face of type refactorings).
+TIP: We aim to simplify the serialization infrastructure to be able to infer more about what serializer to use for a given type, however, the current approach remains valid (and most resilient in face of type refactorings).
 
 === ActorTestKit and ActorableTestProbe
 
 An api:ActorTestKit[class,module=DistributedActorsTestKit] is offered to simplify the testing of actors and asynchronous code.
-The most important part of the test kit is api:ActorTestProbe[class,module=DistributedActorsTestKit] (for `ActorRef` / `Behavior` style)
-and api:ActorableTestProbe[class,module=DistributedActorsTestKit] for actorables.
+The most important part of the test kit is api:ActorTestProbe[class,module=DistributedActorsTestKit] (for `ActorRef` / `Behavior` style) and api:ActorableTestProbe[class,module=DistributedActorsTestKit] for actorables.
 
-#TODO: Write full docs for ActorTestKit (and reconsider naming... w discussed but are unsure still ActorTestTools was an option)#
+#TODO: Write full docs for ActorTestKit (and reconsider naming... we discussed but are unsure still ActorTestTools was an option)#
 
 After creating an api:ActorTestKit[class,module=DistributedActorsTestKit] for an api:ActorSystem[class], one is able to `testKit.spawnActorableTestProbe` a probe for any given api:Actorable[protocol].
-The returned api:ActorableTestProbe[class,module=DistributedActorsTestKit] contains the "mocked" `.actor` reference as well as various `expectMessage`-style methods, which allow
-the test to block for a time, expecting a message to be send to the underlying test probe (configurable using the optional `within:` parameter).
+The returned api:ActorableTestProbe[class,module=DistributedActorsTestKit] contains the "mocked" `.actor` reference as well as various `expectMessage`-style methods, which allow the test to block for a time, expecting a message to be send to the underlying test probe (configurable using the optional `within:` parameter).
 
 For example, in order to mock out a reference to such an `GreetMe` actorable:
 
@@ -362,8 +338,8 @@ You may spawn a probe for it, and expect that it receives a hello message when p
 ----
 include::{dir_sact_doc_tests}/Actorable/ActorableActorTestKitDocExamples.swift[tag=full_testkit_example]
 ----
-<1> Spawn a test probe, abiding to `GreetMe`'s message protocol
-<2> Spawn a real `GreetMeGreeter` actor, and tell it to greet the probe actor
-<3> Expect that the probe gets the expected message, and that it's contents are indeed correct
+<1> Spawn a test probe, adhering to ``GreetMe``'s message protocol.
+<2> Spawn a real `GreetMeGreeter` actor, and tell it to greet the probe actor.
+<3> Expect that the probe gets the expected message, and that it's contents are indeed correct.
 
 NOTE: To learn more about all the available expectations on test probes, refer to api:ActorableTestProbe[class,module=DistributedActorsTestKit] API documentation.

--- a/Docs/actors_overview.adoc
+++ b/Docs/actors_overview.adoc
@@ -1,10 +1,10 @@
+
 [[actors_overview]]
 == Actors Overview
 
 > Actors provide a higher level of abstraction for building concurrent and distributed systems.
 >
-> They are a fundamental building block of the http://en.wikipedia.org/wiki/Actor_model[Actor Model],
-> published by Carl Hewitt in 1973, but since gained popularity thanks to numerous implementations of the model.
+> They are a fundamental building block of the http://en.wikipedia.org/wiki/Actor_model[Actor Model], published by Carl Hewitt in 1973, but since gained popularity thanks to numerous implementations of the model.
 
 
 Welcome to Swift Distributed Actors, a _type-safe_ implementation of the Actor Model for Swift.
@@ -12,63 +12,55 @@ Welcome to Swift Distributed Actors, a _type-safe_ implementation of the Actor M
 === Thinking in Actors
 
 In order to build systems successfully using actors first you will need to get into the right mindset.
-In this section we will try to guide you towards "thinking in actors," but perhaps it's also best to first realize that:
-"you probably already know actors!" As any time you implement some form of identity that is given tasks that it should
-work on, most likely using some concurrent queue or other synchronization mechanism, you are probably inventing some form of actor-like structures there yourself!
+In this section we will try to guide you towards "thinking in actors," but perhaps it's also best to first realize that "you probably already know actors!", as any time you implement some form of identity that is given tasks that it should work on, most likely using some concurrent queue or other synchronization mechanism, you are probably inventing some form of actor-like structures there yourself!
 
-Actors are a relatively low-level concurrency and distribution abstraction, modeled after how communication in the real world
-happens: via asynchronous message passing. Actors take this observation and make it the core principle of anything built using them:
+Actors are a relatively low-level concurrency and distribution abstraction, modeled after how communication in the real world happens: via asynchronous message passing.
+Actors take this observation and make it the core principle of anything built using them.
 
 > **Rule 1: Actors communicate only using messages.**
 
-Which is the single most important difference between actors and other concurrency styles. Actors communicate by sending
-messages to each other's mailboxes, and processing messages from their own mailboxes.
+This is the single most important difference between actors and other concurrency styles.
+Actors communicate by sending messages to each other's mailboxes, and processing messages from their own mailboxes.
 
 This abstraction is very powerful and enables all core features of actors, namely:
 
-* handling concurrency without the need of thinking about threads or specific queues -- one only has to think about sending messages to specific identities;
-  ** Same as in real life: we only need to care about whom to send that important email, and not worry about all the details on how to safely get that email delivered to them!
-* being able to send messages to actors _the same way_, regardless if they are located on the same machine, on another clustered node, or potentially even somewhere completely different.
-  ** This is sometimes referred to as "location transparency," as we do not need to know about the physical location of the actor, as long as we have a reference to it.
+* Handling concurrency without the need of thinking about threads or specific queues -- one only has to think about sending messages to specific identities.
+** Same as in real life: we only need to care about whom to send that important email, and not worry about all the details on how to safely get that email delivered to them!
+* Being able to send messages to actors _the same way_, regardless if they are located on the same machine, on another clustered node, or potentially even somewhere completely different.
+** This is sometimes referred to as "location transparency," as we do not need to know about the physical location of the actor as long as we have a reference to it.
 
 > **Rule 2: Actors can change their behavior in reaction to a message**.
 
 An Actor's _raison d'être_ can be formulated as: encapsulating state and protecting it from the complicated concurrent world out there.
-Actors enable us to write advanced concurrent and distributed applications by offering us a simple mental model: an
-actor processes a message, and the next time it receives a message, it may react differently than before , since the previous message
-has changed its behavior. It is perhaps easier explained if we think about changing state. If an incoming message changed an actor's
-state, such as a counter, the next message would be handled depending on the new counter's state. In other words, state changes manifest
-as changes in an actor's behavior.
+Actors enable us to write advanced concurrent and distributed applications by offering us a simple mental model: an actor processes a message, and the next time it receives a message, it may react differently than before , since the previous message has changed its behavior.
+It is perhaps easier explained if we think about changing state.
+If an incoming message changed an actor's state, such as a counter, the next message would be handled depending on the new counter's state.
+In other words, state changes manifest as changes in an actor's behavior.
 
-In Swift Distributed Actors we model Behaviors explicitly, as they are not only state changes, but also runtime affecting behaviors, such as
-stopping or suspending the actor, ignoring, dropping or combining message handlers as "the next behavior." We will learn more about
-behaviors in the following sections.
+In Swift Distributed Actors we model Behaviors explicitly, as they are not only state changes but also runtime affecting behaviors, such as stopping or suspending the actor, ignoring, dropping or combining message handlers as "the next behavior."
+We will learn more about behaviors in the following sections.
 
 > **Rule 3: Actors can `spawn` other actors**
 
-Similarly to threads, processes, isolates or other isolation mechanisms, actors can create (or "spawn" in actor terminology)
-other actors. This is a very useful capability as a single actor does not by itself give any parallelism to processing of messages,
-as it always processes one message at a time. In order to distribute work to be processed in parallel we want to use multiple actors,
-with each working on a piece or chunk of a lager work item. Or another way to view this is that if we represent users of our system
-by an actor each -- we get parallelism in processing across all the users/actors, however each user/actor, is going to process
-its own pieces of work in a linear fashion.
+Similarly to threads, processes, isolates or other isolation mechanisms, actors can create (or "spawn" in actor terminology) other actors.
+This is a very useful capability as a single actor by itself does not give any parallelism to processing of messages as it always processes one message at a time.
+In order to distribute work to be processed in parallel we want to use multiple actors, with each working on a piece or chunk of a lager work item.
+Another way to view this is that if we represent each user of our system by an actor -- we get parallelism in processing across all the users/actors, however each user/actor is going to process its own pieces of work in a linear fashion.
 
-A typical example where spawning _child_ actors comes in handy is splitting up a bigger piece of work into smaller ones and having the parent coordinate this work being done. Examples of such tasks include simulations, rendering tasks or simply tasks which consist of many smaller tasks. Actors also fit very well for modeling anything that has identity and makes some independent decisions based on the outside world's signals, like for example units and CPU "players" in games.
+A typical example where spawning _child_ actors comes in handy is splitting up a bigger piece of work into smaller ones and having the parent coordinate this work being done.
+Examples of such tasks include simulations, rendering tasks, or simply tasks which consist of many smaller tasks.
+Actors also fit very well for modeling anything that has identity and makes some independent decisions based on the outside world's signals, for example units and CPU "players" in games.
 
-Another typical use case for being able to spawn millions of actors on a single machine, as opposed to threads,
-is the ability to use them to map real world identities, such as devices, measurements or people to their actor "counterpart,"
-inside of our actor application. This helps understandability and traceability when "things go wrong," as we can more easily
-trace back faults to perhaps a given user's dataset or message sequence that caused a crash.
+Another typical use case for being able to spawn millions of actors on a single machine, as opposed to threads, is the ability to use them to map real world identities such as devices, measurements, or people to their actor "counterpart" inside of our actor application.
+This helps understandability and traceability when "things go wrong," as we can more easily trace back faults to perhaps a given user's dataset or message sequence that caused a crash.
 
 ==== What Actors are **_not_**?
 
 Actors are not aimed to solve _all_ concurrency tasks, nor do they replace Futures or async/await based models.
 
-In fact, they complement them -- as Futures or async/await are excellent ways to model the flow of data or avoid callbacks,
-however, they do not provide addressable identities which are able to _keep state_ and communicate over the network -- and this is where actors excel at.
+In fact, they complement them -- Futures or async/await are excellent ways to model the flow of data or avoid callbacks, however, they do not provide addressable identities which are able to _keep state_ and communicate over the network -- and this is where actors excel at.
 
 In other words: actors are focused on identity, state, and distribution thereof.
-
 
 ==== Design for Failure
 
@@ -76,24 +68,21 @@ In other words: actors are focused on identity, state, and distribution thereof.
 
 Take care to not fall into the "every single thing must be an actor" fallacy while learning and using actors in your project.
 
-Actors have a specific purpose, and much like not every single operation in your program is starting new threads and performing work asynchronously,
-not all things have to be expressed as actor messages.
+Actors have a specific purpose, and much like not every single operation in your program is starting new threads and performing work asynchronously, not all things have to be expressed as actor messages.
 
 Consider the following situation: an actor accepting a `SummarizeBill` message, which will cause the actor to calculate the total amount.
 
 === Defining Messages
 
-Before we dive head-first into defining our actors, let's focus for a second what in reality might be the most
-important aspect of working with them, to begin with: defining message protocols.
+Before we dive head-first into defining our actors, let's focus for a second what in reality might be the most important aspect of working with them to begin with: defining message protocols.
 
-While Swift Distributed Actors does not limit what types of messages you can send between actors, you should keep in mind that you are
-working with inherently concurrent entities, and as such care should be taken to _not_ share any mutable references inside
-your messages. In order of preference (from best to worst) you should try to define messages using the following style:
+While Swift Distributed Actors does not limit what types of messages you can send between actors, you should keep in mind that you are working with inherently concurrent entities, and as such you should take care to _not_ share any mutable references inside your messages.
+In order of preference (from best to worst) you should try to define messages using the following style:
 
-- as (deeply immutable) value types ^(best)^ -- e.g. as structs or enums which contains only other value types,
-- as value types -- which do contain references to non-value types, however, those are either immutable, or thread-safe to access,
-- as immutable reference types -- as even if it is a reference type, you still guarantee that they won't be mutated accidentally by multiple actors at the same time,
-- as general reference types ^(worst;^ ^highly^ ^error^ ^prone)^ -- this is best avoided, as it can easily lead to accidentally sharing mutable references which may lead to concurrent access to those fields by multiple actors.
+As (deeply immutable) value types ^(best)^:: For example, structs or enums which contains only other value types.
+As value types:: Which do contain references to non-value types, however, those are either immutable, or thread-safe to access.
+As immutable reference types:: Even if it is a reference type, you still guarantee that they won't be mutated accidentally by multiple actors at the same time,
+As general reference types ^(worst;^ ^highly^ ^error^ ^prone)^:: This is best avoided as it can easily lead to accidentally sharing mutable references, which may lead to concurrent access to those fields by multiple actors.
 
 In general, it is best to keep messages sent between actors just that: plain messages.
 Avoid sending closures as part of messages, as you may accidentally introduce race conditions by means of closing over some shared mutable reference in such closure.

--- a/Docs/behaviors.adoc
+++ b/Docs/behaviors.adoc
@@ -6,8 +6,7 @@
 
 Actors at their heart are the sum of their behaviors (which may capture state), and a mailbox that is executed by the runtime.
 
-This chapter introduces the low-level api:Behavior[struct] API which allows for building powerful and dynamic behaviors,
-which may encapsulate and enable advanced patterns such as backoff, suspending and others.
+This chapter introduces the low-level api:Behavior[struct] API which allows for building powerful and dynamic behaviors, which may encapsulate and enable advanced patterns such as backoff, suspending and others.
 
 TIP: For the majority of use-cases building applications, it is recommended to use the <<actorable, Actorable>> APIs instead.
 
@@ -15,21 +14,14 @@ TIP: For the majority of use-cases building applications, it is recommended to u
 
 Actors are _always_ defined by the api:Behavior[struct] that they are running (or "acting out" if you want to take the actor analogy one step further).
 
-Two main "styles" of defining actor behaviors are available:
-  - one being "class-oriented" in which mutable state is stored within an actor's behavior `class`
+Two main "styles" of defining actor behaviors are available: one being "class-oriented" in which mutable state is stored within an actor's behavior `class`, and the other being "function-oriented" in which state is organized around discrete behaviors.
 
-Generally speaking the functional style is recommended as it allows for cleaner designs and forces the definition of more
-understandable state _named_ transitions, rather than protecting a "bunch of state" with the actor message handling mechanisms.
+TIP: The function-oriented style is preferable as it leads to cleaner, smaller single-purpose behaviors, which are combined into small state machine-like constructs by becoming another behavior whenever the actors state needs to change. It also forces the definition of more understandable state _named_ transitions, rather than protecting a "bunch of state" with the actor message handling mechanisms.
 
-TIP: The function-oriented style is preferable as it leads to cleaner, smaller single-purpose behaviors,
-     which are combined into small state machine-like constructs by becoming another behavior whenever the actors state needs to change.
+For some actors (or teams) the class-oriented style may however feel more natural, and while we recommend the more functional style, either styles can be successfully used to build distributed applications.
 
-For some actors (or teams) the class-oriented style may however feel more natural, and while we recommend the more functional style,
-either styles can be successfully used to build distributed applications.
-
-NOTE: It _is_ possible to mix and match behaviors defined in either styles, even the same actor may become a class-oriented
-      behavior from a functional-style one and vice versa. This may come in handy for some states in an actor's lifecycle
-      which can be nicely expressed in one of the styles, but not necessarily the other.
+NOTE: It _is_ possible to mix and match behaviors defined in either styles, even the same actor may become a class-oriented behavior from a functional-style one and vice versa.
+This may come in handy for some states in an actor's lifecycle which can be nicely expressed in one of the styles, but not necessarily the other.
 
 You might be surprised to find out that there is no "Actor" class to extend from in Swift Distributed Actors. #TODO fixme wording here..#
 This is because conceptually and Actor is the sum of three parts:
@@ -40,51 +32,48 @@ This is because conceptually and Actor is the sum of three parts:
 
 ==== Behaviors
 
-Those three elements together form one functioning actor. In other words, an actor is a behavior that is able to be run
-with messages from a mailbox. It is by design that the actor itself cannot be seen nor reached from user code, this
-allows Swift Distributed Actors to provide the memory isolation safety that actors are known for -- i.e. there is
+Those three elements together form one functioning actor.
+In other words, an actor is a behavior that is able to be run with messages from a mailbox.
+It is by design that the actor itself cannot be seen nor reached from user code, this allows Swift Distributed Actors to provide the memory isolation safety that actors are known for.
 
-Another reason is, that semantically, it is not possible to "combine actors" as they are their own individual entities
-and always have to guarantee isolation from any 3rd parties. However, it is possible and tremendously useful to combine
-actor `Behaviors`.
+Another reason is that, semantically, it is not possible to "combine actors" as they are their own individual entities and always have to guarantee isolation from any 3rd parties.
+It is, however, possible and tremendously useful to combine actor `Behaviors`.
 
 TIP: All actors are defined in terms of their api:Behavior[struct].
 
-For getting started, we'll focus on the most important behavior group, the `receive` functions, as they allow an
-actor to react to messages. The `receive` behavior comes in a few different flavors. Firstly, the `receiveMessage`
-is one of the more useful versions as it allows us to simply react on a message, and return the next behavior that the
-actor should _become_:
+For getting started, we'll focus on the most important behavior group, the `receive` functions, as they allow an actor to react to messages.
+The `receive` behavior comes in a few different flavors.
+Firstly, the `receiveMessage` is one of the more useful versions as it allows us to simply react on a message, and return the next behavior that the actor should _become_:
 
 [source]
 ----
 include::{dir_sact_doc_tests}/ActorDocExamples.swift[tag=receiveMessage_behavior]
 ----
-<1> Defines a reusable behavior that can receive `Greetings` messages. You can `spawn` multiple actors of the same behavior after all.
+<1> Defines a reusable behavior that can receive `Greetings` messages -- you can `spawn` multiple actors of the same behavior after all.
 <2> We do something with the message; here we only print it, but things will soon be much more exciting.
 <3> Lastly we return the "next behavior", since all behaviors are small state machines.
 
-As you can see, this already defines a mini state machine, albeit not a very interesting one, as the behavior will
-continuously become the `.same` one.
-
+As you can see, this already defines a mini state machine, albeit not a very interesting one, as the behavior will continuously become the `.same` one.
 
 You might be curious how the message type looks like, now that we've seen a behavior to handle them.
-In our example we do not yet worry about the serialization of the messages, so it can be in fact any type,
-however we strongly recommend
+In our example we do not yet worry about the serialization of the messages, so it can be in fact any type, however we strongly recommend
 
 [[spawning_actors]]
 [[spawning_behaviors]]
 === Spawning Actors
 
-TIP: Starting actors is referred to as "spawning" them. In the same way one refers to spawning new threads by a thread pool or operating system.
-
+TIP: Starting actors is referred to as "spawning" them.
+In the same way one refers to spawning new threads by a thread pool or operating system.
 
 [source]
 ----
 include::{dir_sact_doc_tests}/ActorDocExamples.swift[tag=spawn]
 ----
 <1> All Actors "live" within an `ActorSystem`, so in order to work with actors we need to first start a system.
-<2> An actor's "Behavior" contains all the logic and state that it will work with. There are numerous ways to define one, we'll learn about them very soon.
-<3> We `spawn` our actor using the `behavior` and we give it a `name` while we are at it as well. Names are tremendously helpful for understanding and debugging your application.
+<2> An actor's "Behavior" contains all the logic and state that it will work with.
+    There are numerous ways to define one, we'll learn about them very soon.
+<3> We `spawn` our actor using the `behavior` and we give it a `name` while we are at it as well.
+Names are tremendously helpful for understanding and debugging your application.
 
 === Sending messages
 
@@ -94,35 +83,32 @@ Sending messages to actors is straight forward and can be done thanks to the api
 
 #TODO: ActorRef link should be ActorRef<Message>#
 
-For example, now that we have obtained a reference to
+For example, now that we have obtained a reference to `greeterBehavior`, we can call it like:
 
 [source]
 ----
 include::{dir_sact_doc_tests}/ActorDocExamples.swift[tag=tell_1]
 ----
-<1> We _tell_ our actor our name, so that it can greet us. This is an asynchronous fire-and-forget message sent to the actor.
+<1> We _tell_ our actor our name, so that it can greet us.
+    This is an asynchronous fire-and-forget message sent to the actor.
 
-TIP: Sending messages to actors always has the same form, regardless if they are local or remote.
-     (This is one of the ways the _location transparency_ property surfaces in the APIs.)
+TIP: Sending messages to actors always has the same form, regardless if they are local or remote (This is one of the ways the _location transparency_ property surfaces in the APIs).
 
 #TODO: complete this section#
 
 ==== Sending questions using `ask` (request-reply)
 
-While `tell` should be preferred for most actor-to-actor communication, an alternative, focused on request-reply interactions,
-method exists to send "questions" to other actors, expecting a reply back.
+While `tell` should be preferred for most actor-to-actor communication, an alternative method focused on request-reply interactions exists to send "questions" to other actors, expecting a reply back.
 
-Using the `ref.ask(for:timeout:makeQuestion:)` method, we send a message to the target actor and expect that it will reply to
-a special ask-actor, which in turn completes the returned `AskResponse<ResponseType>` (similar to how completing a `Promise`
-would complete a `Future`, although by using messaging -- meaning that the reply can come from any actor in a cluster, also a remote one).
+Using the `ref.ask(for:timeout:makeQuestion:)` method, we send a message to the target actor and expect that it will reply to a special ask-actor, which in turn completes the returned `AskResponse<ResponseType>`.
+This is similar to how completing a `Promise` would complete a `Future`, although by using messaging the reply can come from any actor in a cluster, including a remote one.
 
 An api:AskResponse[enum] can also be handled from outside of actor code, making it an useful integration pattern between actor and non-actor code.
 
-Note that providing a `timeout` is _not_ optional, as in order to avoid potential deadlocks if a question was sent to an already dead actor.
-If no response is received within the specified `timeout`, the ask-response will fail with a `api:TimeoutError[struct]`.
+Note that providing a `timeout` is _not_ optional.
+In order to avoid potential deadlocks if a question was sent to an already dead actor, if no response is received within the specified `timeout`, the ask-response will fail with a `api:TimeoutError[struct]`.
 
-NOTE: `ask` is also useful when interacting with actors from "outside" (i.e. from not-actors), since the returned value
-      can be acted on asynchronously whenever it gets completed -- like a `Future`.
+NOTE: `ask` is also useful when interacting with actors from "outside" (i.e. from not-actors), since the returned value can be acted on asynchronously whenever it gets completed -- like a `Future`.
 
 The following example shows a simple "from outside" question being asked to an actor:
 
@@ -130,74 +116,71 @@ The following example shows a simple "from outside" question being asked to an a
 ----
 include::{dir_sact_doc_tests}/ActorDocExamples.swift[tag=ask_outside]
 ----
-<1> `replyTo` is an actor ref of the type specified with the `for` parameter of ask and is used to receive the response
+<1> `replyTo` is an actor ref of the type specified with the `for` parameter of `ask`, and is used to receive the response
 <2> Create the message that will be sent to the ref that `ask` is called on
 <3> Retrieve the result from the `api:AskResponse[enum]`.
 
 WARNING: _Never_ invoke any kind of blocking operation such as `future.wait()` inside of an actor!
-         Same as blocking an event loop, blocking inside actors will cause starvation for other actors sharing the same dispatcher.
-         Rather than blocking, consider using one of the built-in functions for asynchronous values inter-op documented below.
+Same as blocking an event loop, blocking inside actors will cause starvation for other actors sharing the same dispatcher.
+Rather than blocking, consider using one of the built-in functions for asynchronous values inter-op documented below.
 
-It is also possible to use `ask` from within actors, for simple request-response interactions with other actors,
-which may not want to be encoded in the asking-actors message protocol. Since sometimes, especially during initialization,
-an actor may need to "wait" until an asynchronous response to arrives, it is possible to use the `context.onResultAsync`
-as well as `context.awaitResult` functions to suspend the actor _without blocking the thread_ until the response arrives:
+It is also possible to use `ask` from within actors for simple request-response interactions with other actors which may not want to be encoded in the asking-actors message protocol.
+
+Sometimes, especially during initialization, an actor may need to "wait" until an asynchronous response to arrives.
+In these cases the `context.onResultAsync` and `context.awaitResult` functions may be used to suspend the actor _without blocking the thread_ until the response arrives:
 
 [source]
 ----
 include::{dir_sact_doc_tests}/ActorDocExamples.swift[tag=ask_inside]
 ----
-<1> First thing the `caplin` actor does, is to `ask` the `greeter` for a greeting,
-<2> Since it depends on that greeting to become the `greeted` state, it awaits on the reply using `context.awaitResultThrowing`,
-    which will either invoke the callback with the received reply, or throw if the timeout is exceeded.
-<3> Once the question is replied to, caplin will wake up from its suspended state and execute the callback, logging the greeting and becoming the `greeted()` behavior.
+<1> First thing the `caplin` actor does is to `ask` the `greeter` for a greeting.
+<2> It depends on that greeting to become the `greeted` state, and it awaits the reply using `context.awaitResultThrowing`.
+    This will either invoke the callback with the received reply, or throw if the timeout is exceeded.
+<3> Once the question is replied to, `caplin` will wake up from its suspended state and execute the callback, logging the greeting and becoming the `greeted()` behavior.
 
-Worth noting here is that `caplin` itself was never able to receive _any_ messages -- its `Message` type was bound to `Never` after all,
-which is a way of expressing that an actor cannot receive any messages. Yet at the same time, thanks to using the `ask` mechanism,
-it was able to communicate in a request-response fashion with the `greeter`.
+Worth noting here is that `caplin` itself was never able to receive _any_ messages -- its `Message` type was bound to `Never` after all, which is a way of expressing that an actor cannot receive any messages.
+Yet at the same time, thanks to using the `ask` mechanism, it was able to communicate in a request-response fashion with the `greeter`.
 
+To learn more about the semantics of these asynchronous result inter-op behaviors, refer to their respective documentation sections:
 
-To learn more about the semantics of these asynchronous result inter-op behaviors you want to refer to their respective documentation sections:
-
-- <<onResultAsync>> for non-awaiting safe executing of callbacks on the Actor using `context.onResultAsync`,
-- and <<awaitResult>> for awaiting for a value before becoming another behavior using `context.awaitResult`.
+* <<onResultAsync>> for non-awaiting safe executing of callbacks on the Actor using `context.onResultAsync`.
+* <<awaitResult>> for awaiting for a value before becoming another behavior using `context.awaitResult`.
 
 === Actor Lifecycle
 
 Each actor follows a well-defined lifecycle from the moment it is spawned until the moment it terminates.
 
-The following diagram illustrates lifecycle transitions and signals which are delivered to an actor as it undergoes these
-transitions. Note that in normal situations, i.e. without faulty behaviors, the diagram is a simple linear transition from
-`Running` through `Stopped` to `Terminated`. All other states and transitions come into play only in face of faulty behaviors.
+The following diagram illustrates lifecycle transitions and signals which are delivered to an actor as it undergoes these transitions.
+Note that in normal situations, i.e. without faulty behaviors, the diagram is a simple linear transition from `Running` through `Stopped` to `Terminated`.
+All other states and transitions come into play only in face of faulty behaviors.
 
 image::actor_lifecycle.png[Actor Lifecycle]
 
-1. Start: Upon spawning, a special internal `Start` signal is interpreted by the actor, causing it to execute all nested `.setup` behaviors.
-2. Stop Myself: An actor may decide to stop itself by returning a api:Behavior[struct,alias='Behavior.stop'], causing it to transition to `Stopped`.
+1. *Start*: Upon spawning, a special internal `Start` signal is interpreted by the actor, causing it to execute all nested `.setup` behaviors.
+2. *Stop Myself*: An actor may decide to stop itself by returning a api:Behavior[struct,alias='Behavior.stop'], causing it to transition to `Stopped`.
     See also <<Stopping the Current Actor (Myself)>>.
-3. Stop by Parent: Alternatively, the current actor's parent parent could send a stop signal (using `context.stop(childRef)`), which the actor would have to abide to.
-    Such stop signal _cannot_ be ignored by the child, and will take effect as soon as it is received by the child. See also <<Stopping Child Actors>>.
-4. PostStop: Once the actor has `Stopped` and drained its mailbox (to dead letters), it will process one last signal: `PostStop` which may be handled.
-    However, regardless of the next behavior returned by handling this signal, the actor will always proceed to the `Terminated` state.
-    Once `Terminated`, the actor will never again wake up nor process any more messages nor signals.
-5. Supervision: If an actor throws an error or causes a fault it will transition to Failing 🔥, and invoke its supervisor will be invoked, to see if the actor should be restated or not.
+3. *Stop by Parent*: Alternatively, the current actor's parent parent could send a stop signal (using `context.stop(childRef)`), which the actor _cannot_ ignore, and will take effect as soon as it is received.
+    See also <<Stopping Child Actors>>.
+4. *PostStop*: Once the actor has `Stopped` and drained its mailbox (sending any remaining messages to to dead letters), it will process the `PostStop` signal, which may be handled.
+    Regardless of the next behavior returned by handling this signal, the actor will always proceed to the `Terminated` state.
+    Once `Terminated`, the actor will never again wake up nor process any more messages or signals.
+5. *Supervision*: If an actor throws an error or causes a fault it will transition to Failing 🔥, and its supervisor will be invoked to see if the actor should be restated or not.
     To learn more about <<Supervision>> and the various supervision strategies, refer to the <<Failure Handling>> chapter of the documentation.
-6. Supervision (restart): If the configured supervisor decides that the actor should be restarted (now, or upon a delay), an :api:Signals[enum,alias='Signals.PreRestart'] signal will be delivered to the _current (failing) behavior_,
-    before a new instance of the _initial behavior_ will be created to replace the faulty one. This means that any state kept enclosed by the faulty behavior will be lost – and the actor can resume operations
-    from a clean slate, however _while preserving its mailbox and identity_.
-7. Supervision (fail): If the supervisor decides that the actor should _not_ be restarted (e.g. because it exhausted its permitted restart count, or the fault captured is too serious to ignore),
-    the actor will transition to `Stopped` and `Terminated`, similar to how it would behave if it were stopping itself manually. #TODO: I think we want to signal in PostStop that this is because we failed, and not a manual stop#
+6. *Supervision (restart)*: If the configured supervisor decides that the actor should be restarted (now, or upon a delay), an :api:Signals[enum,alias='Signals.PreRestart'] signal will be delivered to the _current (failing) behavior_, and a new instance of the _initial behavior_ will be created to replace the faulty one.
+    This means that any state kept enclosed by the faulty behavior will be lost and the actor can resume operations from a clean slate _while preserving its mailbox and identity_.
+7. *Supervision (fail)*: If the supervisor decides that the actor should _not_ be restarted, e.g. because it exhausted its permitted restart count or the fault captured is too serious to ignore, the actor will transition to `Stopped` and `Terminated`, similar to how it would behave if it were stopping itself manually.
+    #TODO: I think we want to signal in `PostStop` that this is because we failed, and not a manual stop#
 
 === Stopping Actors
 
-An actor can be stopped either by its own decision to do so, a failure occurring, or its parent sending it a stop signal which the actor must abide to.
+An actor can be stopped either by its own decision to do so, a failure occurring, or its parent sending it a stop signal which the actor must obey.
 
 ==== Stopping the Current Actor (Myself)
 
-While an actor is running there exist only two ways in which it may decide to end up _stopping itself_, either by:
+While an actor is running there exist only two ways in which it may decide to end up _stopping itself_:
 
-- **stopping** – returning a api:Behavior[struct,alias='Behavior.stop'] as the next behavior.
-- **crashing** – by throwing an `Error` or causing a fault.
+* **Stopping** – returning a api:Behavior[struct,alias='Behavior.stop'] as the next behavior.
+* **Crashing** – by throwing an `Error` or causing a fault.
 ** In which case <<supervision>> will handle the failure and determine what to do about it. The default is stopping the actor.
 
 To see this in a more realistic example let's have a look at the following snippet:
@@ -210,7 +193,7 @@ include::{dir_sact_doc_tests}/ActorDocExamples.swift[tag=stop_myself_1]
 <2> We interpret the terminal data chunk to mean that we should now stop, and do so by returning a api:Behavior[struct,alias='Behavior.stop'].
 
 This example also showcases that we do not necessarily have to bind the business logic to the fact that it is being executed inside an actor.
-As shown in the snippet, we can interpret states returned by the underlying logic as states the actor should transition in its lifecycle.
+As shown in the snippet, we can interpret states returned by the underlying logic as states the actor should transition to in its lifecycle.
 
 In practice such snippets would often be extracted into their own functions or extensions onto the domain objects, for example:
 
@@ -219,24 +202,21 @@ In practice such snippets would often be extracted into their own functions or e
 include::{dir_sact_doc_tests}/ActorDocExamples.swift[tag=stop_myself_refactored]
 ----
 
-Note that returning `.stop` also _guarantees_ that no further messages will be processed after the stopped behavior
-has been returned. You may also use the `.stop(postStop:)` overloads to perform cleanup operations, or even store your
-own "stopped" that would perform some cleanup logic if there was a need to do the similar cleanup for various actors in
-your system.
+Note that returning `.stop` also _guarantees_ that no further messages will be processed after the stopped behavior has been returned.
+You may also use the `.stop(postStop:)` overloads to perform cleanup operations, or even store your own "stopped" that would perform some cleanup logic if there was a need to do similar cleanup for various actors in your system.
 
-NOTE: It is NOT possible to stop yourself by calling the `context.stop(child:)` function to stop `myself`.
-      This is to not encourage another way of doing the same thing, and make stopping easier to track -- as it should always result from a `return .stop` or a failure. This makes analyzing existing code bases simpler, as there are only the two cases to look for.
+NOTE: It is **NOT** possible to stop yourself by calling the `context.stop(child:)` function to stop `myself`.
+This is to not encourage another way of doing the same thing, and make stopping easier to track, as it should always result from a `return .stop` or a failure.
+This makes analyzing existing code bases simpler, as there are only two cases to look for.
 
 ==== Stopping Child Actors
 
-A parent actor may stop _its own_ child actors by using `context.stop(child:)` on them,
-which is implemented as a system message send asking the child to stop.
+A parent actor may stop _its own_ child actors by using `context.stop(child:)` on them, which is implemented as a system message asking the child to stop.
 
-WARN: Attempting to `ActorContext.stop(child:)` a reference that is _not_ a child of the current actor will result in an
-      `ActorContextError` being throw.
+WARNING: Attempting to `ActorContext.stop(child:)` a reference that is _not_ a child of the current actor will result in an `ActorContextError` being thrown.
 
-The child MAY NOT refuse such stop command and it is effective immediately once the message arrives at the child actor.
-Bear in mind though that this stopping operation, by virtue of being a message send, is an asynchronous operation.
+The child **MAY NOT** refuse such stop command and it is effective immediately once the message arrives at the child actor.
+Bear in mind that this stopping operation, by virtue of being a message send, is an asynchronous operation.
 
 #TODO: complete this section#
 
@@ -244,46 +224,44 @@ Bear in mind though that this stopping operation, by virtue of being a message s
 
 For a given actor, the following is guaranteed:
 
-- if an actor returns the `.stop` behavior, no further messages will be delivered to its message (or signal) receive blocks,
-  - with the single exception of the :api:Signals[enum,alias='Signals.PostStop'] which is delivered once the actor has stopped and before it has completely Terminated.
-- if any other actors have been watching this actor, they will be informed about its termination using `.terminated` messages.
+* If an actor returns the `.stop` behavior, no further messages will be delivered to its message (or signal) receive blocks.
+**  The single exception is api:Signals[enum,alias='Signals.PostStop'], which is delivered once the actor has stopped and before it has completely Terminated.
+* If any other actors have been watching this actor, they will be informed about its termination using `.terminated` messages.
 
 Internal guarantees:
 
-- if the `.stop` behavior is returned during handling system messages, no further user messages shall be processed.
-- all pending (system) already enqueued to the actors mailboxes messages SHOULD be drained to dead letters or dropped.
-- once the `.stop` behavior is returned the actor should immediately be treated as `TERMINATING` yet it is not yet `CLOSED` (dead),
-  - during the time between `TERMINATING` and `CLOSED` the actor performs shut down logic, such as notifying the parent actor or any watchers about its death.
-  - all incoming messages, which hit an "at-least-TERMINATING" actor shall be immediately be DROPPED, without being enqueued at all. This is to avoid waking up the actor infinitely.
-- resources (e.g. the held behavior) shall only be released once the CLOSED state has been reached.
+* If the `.stop` behavior is returned during handling system messages, no further user messages shall be processed.
+* All pending (system) messages already enqueued to the actors mailboxes SHOULD be drained to dead letters or dropped.
+* Once the `.stop` behavior is returned the actor should immediately be treated as `TERMINATING`, although it is not yet `CLOSED` (dead).
+** During the time between `TERMINATING` and `CLOSED` the actor performs shut down logic, such as notifying the parent actor or any watchers about its death.
+** All incoming messages, which hit an "at-least-TERMINATING" actor shall immediately be DROPPED, without being enqueued at all.
+    This is to avoid waking up the actor infinitely.
+* Resources (e.g. the held behavior) shall only be released once the CLOSED state has been reached.
 
 Parent-child relationships add a few more guarantees:
 
-- a parent is always notified about its child's failures
-  - these DO NOT cause it to kill itself
-- if the parent spawns AND watches the child though, the same death pact principles apply,
-  and a failing child WILL cause the parent to terminate as well.
+* A parent is always notified about its child's failures.
+** These **DO NOT** cause it to kill itself
+* If the parent spawns **AND** watches the child, the same death pact principles apply, and a failing child **WILL** cause the parent to terminate as well.
 
 [[props]]
 === Configuring Actors with Props
 
-api:Props[struct] can be seen as accompanying data to an actors behavior, that is used by Swift Distributed Actors to configure or
-apply special handling to the actor once it is started.
+api:Props[struct] can be seen as accompanying data to an actors behavior, to be used by Swift Distributed Actors to configure or apply special handling to the actor once it is started.
 
-TIP: "Props" are what an theater actor may use during a performance. For example, a skull would be a classic example of
-     a "prop" used while performing the William Shakespeare's Hamlet Act III, scene 1, saying _"To be, or not to be, that is the question: [...]."_
-     In the same sense, api:Props[struct] for Swift Distributed Actors are accompanying objects/settings, which help the actor perform its duties.
+TIP: "Props" are what an theater actor may use during a performance.
+For example, a skull would be a classic example of a "prop" used while performing William Shakespeare's Hamlet Act III, scene 1, saying _"To be, or not to be, that is the question: [...]."_
+In the same sense api:Props[struct] for Swift Distributed Actors are accompanying objects/settings which help the actor perform its duties.
 
 Props can be defined once and used for starting any number of actors (as they are effectively only immutable "settings").
-You can change props by using by mutating the value type
+You can change props by mutating the value type.
 
 [source]
 ----
 include::{dir_sact_doc_tests}/ActorDocExamples.swift[tag=props_example]
 ----
 
-Most commonly one would use `Props` to configure an actor's supervision strategy (which is described in more detail in the <<failure_handling>>
-section of the guide), or its `dispatcher`.
+Most commonly one would use `Props` to configure an actor's supervision strategy (which is described in more detail in the <<Failure Handling>> section of the guide), or its `dispatcher`.
 
 
 [[suggested_props_pattern]]
@@ -291,23 +269,19 @@ section of the guide), or its `dispatcher`.
 
 #TODO: deprecate this and replace with "shell" pattern I guess?#
 
-Sometimes when implementing behaviors which may be spawned by other users, it may be useful to centralize the props creation
-along with its default "suggested" settings. The _Suggested Props_ pattern explains a common style in which this can be solved.
+Sometimes when implementing behaviors which may be spawned by other users, it may be useful to centralize the props creation along with its default "suggested" settings.
+The _Suggested Props_ pattern explains a common style in which this can be solved.
 
-The pattern involves exposing, along with a behavior that users may spawn also an api:Props[struct] instance with
-pre-configured dispatcher, supervision or other settings.
+The pattern involves exposing supervision or other settings, along with a behavior that users may spawn as a api:Props[struct] instance with pre-configured dispatcher.
 
 [source]
 ----
 include::{dir_sact_doc_tests}/ActorDocExamples.swift[tag=suggested_props_pattern]
 ----
 
-Having that said, this pattern puts more burden on the spawner and specifically should not be used to abuse supervision
-as replacement for classical do/catch `Error` handling. If it is known that an actor may encounter some Error it is very
-likely more appropriate to handle this using traditional `do/catch` blocks inside the actor, rather than relying on supervision.
-Worth pointing out here is that supervision only allows to either restart or stop the actor; no "ignore this error,
-everything is actually fine" is allowed, yet such strategy can be implemented using a classical `do/catch` where in the
-catch one could log a warning about the "harmless" error having occurred.
+Having that said, this pattern puts more burden on the spawner and specifically should not be used to abuse supervision as replacement for classical do/catch `Error` handling.
+If it is known that an actor may encounter some Error it is very likely more appropriate to handle this using traditional `do/catch` blocks inside the actor rather than relying on supervision.
+Worth pointing out here is that supervision only allows restarting or stopping the actor; no "ignore this error, everything is actually fine" is allowed, yet such strategy can be implemented using a classical `do/catch` where in the catch one could log a warning about the "harmless" error having occurred.
 
 === Actor Paths and Hierarchy
 
@@ -319,41 +293,41 @@ Similar to real life, one can only send messages to an actor or friend if we kno
 The "sending" capability is expressed by obtaining an api:ActorRef[struct], which also contains the actor's address.
 There can be many references (even on different nodes in a cluster) to the same actor, however its address remains the same.
 
-The address contains a UID which is sometimes referred to as the "Incarnation" ID. This UID is used to clarify identity in
-the following situation:
+The address contains a UID, which is sometimes referred to as the "Incarnation" ID.
+This UID is used to clarify identity in the following situation:
 
-- an actor is spawned under the `/user/animal/caplin` path;
-  - it gains a unique identifier which is appended to its path like this automatically: `/user/animal/caplin#34535`.
-- the actor hands out a few references to itself to other actors for future use.
-- the actor decides it has performed its task and should now stop itself.
-- after the actor stops, the `/user/animal` parent decides that another `caplin` should be spawned, to perform some tasks that Caplins are good at.
-  - another _new_ actor is spawned under the _same path_ `/user/animal/caplin` and most likely will perform the same kind of work as the "previous Caplin"
-- the new actor resides on the _same path_ however has a _different identity_ (and UID, which represents it)!
-- meanwhile, actors who were told about the original Caplin's `ActorRef` decide to send a message to it.
-- thanks to the different UID the system knows that these messages are _not_ intended for the _current_ Caplin -- as it has a different identity.
-  - note that this matters mostly for distributed systems, since in local systems the identity issue is resolved by simply
-    holding references to actor mailboxes; however semantically the model is exactly the same: the "old incarnation" is now gone.
-- messages sent to the "old" api:ActorRef[struct] are instead piped to the `/system/deadLetters` queue and may be logged for diagnosing potential control flow issues in the application.
+* An actor is spawned under the `/user/animal/caplin` path.
+** It gains a unique identifier which is appended to its path like this automatically: `/user/animal/caplin#34535`.
+* The actor hands out a few references to itself to other actors for future use.
+* The actor decides it has performed its task and should now stop itself.
+* After the actor stops, the `/user/animal` parent decides that another `caplin` should be spawned, to perform some tasks that Caplins are good at.
+** A _new_ actor is spawned under the _same `/user/animal/caplin` path_, and most likely will perform the same kind of work as the "previous Caplin".
+* The new actor resides on the _same path_, however it has a _different identity_ (and UID, which represents it)!
+* Meanwhile, actors who were told about the original Caplin's `ActorRef` decide to send a message to it.
+** Thanks to the different UID the system knows that these messages are _not_ intended for the _current_ Caplin as it has a different identity.
+** Note that this matters mostly for distributed systems, since in local systems the identity issue is resolved by simply holding references to actor mailboxes.
+    Semantically, however, the model is exactly the same: the "old incarnation" is now gone.
+* Messages sent to the "old" api:ActorRef[struct] are instead piped to the `/system/deadLetters` queue and may be logged for diagnosing potential control flow issues in the application.
 
 [[receptionist]]
 === Locating Actors using the Receptionist
 
-The receptionist is a system actor that allows users to register actors under a api:Receptionist[enum,alias='Receptionist.RegistrationKey'] so that
-it can be looked up in other parts of the system. Usually actor references should be passed around to allow actors to communicate,
-but there are cases where this is not convenient or possible. One such example is communication in a cluster. To share a reference
-with another node in the cluster, we have to send that reference to it, but that is only possible, if we already have a reference
-to an actor on that node. So by registering the actors we want to make accessible from other nodes in the cluster, we have a way
-of sharing them by communicating with a local ref only. The registered actors will then automatically be made available on all
-nodes in the cluster and can be looked up by sending a message to the local receptionist.
+The receptionist is a system actor that allows users to register actors under a api:Receptionist[struct,alias='Receptionist.RegistrationKey'] so that it can be looked up in other parts of the system.
+Usually actor references should be passed around to allow actors to communicate, but there are cases where this is not convenient or possible -- communication in a cluster, for example.
+To share a reference with another node in the cluster we have to send that reference to it, but that is only possible if we already have a reference to an actor on that node.
+By registering the actors we want to make accessible from other nodes in the cluster, we have a way
+of sharing them by communicating only with a local ref.
+The registered actors will then automatically be made available on all nodes in the cluster and can be looked up by sending a message to the local receptionist.
 
-First we need to register the actor on the node it lives on. This is usually done in the `.setup` behavior.
+First we need to register the actor on the node it lives on.
+This is usually done in the `.setup` behavior.
 
 [source]
 ----
 include::{dir_sact_doc_tests}/ActorDocExamples.swift[tag=receptionist_register]
 ----
-<1> Create the key under which the actor will be registered (can be re-used between calls)
-<2> Send a api:Receptionist[enum,alias='register'] message to receptionist to register the actor under given `key`
+<1> Create the key under which the actor will be registered (can be re-used between calls).
+<2> Send a api:Receptionist[struct,alias='register'] message to receptionist to register the actor under given `key`.
 
 Now we can lookup all actors that are registered under that key.
 
@@ -361,53 +335,48 @@ Now we can lookup all actors that are registered under that key.
 ----
 include::{dir_sact_doc_tests}/ActorDocExamples.swift[tag=receptionist_lookup]
 ----
-<1> Send `api:Receptionist[enum,alias='Receptionist.Lookup']` message to receptionist to get a `api:Receptionist[enum,alias='Receptionist.Listing']` with all registered actors for the key
+<1> Send a `api:Receptionist[struct,alias='Receptionist.Lookup']` message to receptionist to get a `api:Receptionist[struct,alias='Receptionist.Listing']` with all registered actors for the key.
 
-If we are interested in changes to the registration, e.g. when a registered actor gets unregistered, because it terminated,
-or a new one was added, we can subscribe to those changes.
+If we are interested in changes to the registration, e.g. when a registered actor gets unregistered, because it terminated, or a new one was added, we can subscribe to those changes.
 
 [source]
 ----
 include::{dir_sact_doc_tests}/ActorDocExamples.swift[tag=receptionist_subscribe]
 ----
-<1> Send `api:Receptionist[enum,alias='Receptionist.Subscribe']` message to receptionist to receive an updated `api:Receptionist[enum,alias='Receptionist.Listing']` on every change to the registrations under the key
+<1> Send a `api:Receptionist[struct,alias='Receptionist.Subscribe']` message to receptionist to receive an updated `api:Receptionist[struct,alias='Receptionist.Listing']` on every change to the registrations under the key.
 
 === Interop with non-actor code
 
-In any reasonably complex system, different libraries will be used and we need to find ways to make them interact with each other.
-Actors are no exception to this. In this chapter we will look at ways to integrate actors nicely with non-actor code, so that
-we can use existing APIs from actors and also receive and process responses from actors outside of actor code.
+In any reasonably complex system, different libraries will be used and we need to find ways to make them interact with each other, and Actors are no exception to this.
+In this chapter we will look at ways to integrate actors nicely with non-actor code so that actors can use existing APIs, and we can also receive and process responses from actors outside of actor code.
 
 ==== Sending results of asynchronous operations to actors
 
 Our code often has to interact with external systems like databases or other services.
-Those calls are usually being executed asynchronously and the result is being made available either as an asynchronous result type,
-like a future, or as parameter to a callback that needs to be passed in when calling an asynchronous API. Once we have the result,
-we can send it to an actor, alternatively converting it to a message that the actor understands beforehand.
+Those calls are usually being executed asynchronously and the result is being made available either as an asynchronous result type, like a future, or as parameter to a callback that needs to be passed in when calling an asynchronous API.
+Once we have the result we can send it to an actor, alternatively converting it to a message that the actor understands beforehand.
 
 [source]
 ----
 include::{dir_sact_doc_tests}/InteropDocExamples.swift[tag=asyncOp_sendResult_dispatch]
 ----
-<1> An actor that expects to receive the result of some asynchronous computation
-<2> Computation is being sent to a DispatchQueue
-<3> Execute computation
-<4> Wrap result in a message and send it to the actor
+<1> An actor that expects to receive the result of some asynchronous computation.
+<2> Computation is being sent to a `DispatchQueue`.
+<3> Execute computation.
+<4> Wrap result in a message and send it to the actor.
 
-Another example is calling an asynchronous API from within an actor. We can't modify the internal actor state from within
-asynchronous callbacks, because that would create a race condition and also violate the actor model concept of communicating
-only through message passing, so instead we have to send a message to the actor from the callback.
+Another example is calling an asynchronous API from within an actor.
+We can't modify the internal actor state from within asynchronous callbacks, because that would create a race condition and also violate the actor model concept of communicating only through message passing, so instead we have to send a message to the actor from the callback.
 
 [source]
 ----
 include::{dir_sact_doc_tests}/InteropDocExamples.swift[tag=asyncOp_sendResult_insideActor]
 ----
-<1> Execute asynchronous call with callback
-<2> Wrap result in a message and send it to the actor
-<3> Handle the result in inside the actor
+<1> Execute asynchronous call with callback.
+<2> Wrap result in a message and send it to the actor.
+<3> Handle the result in inside the actor.
 
-While this is quite convenient, it also means that the response has to be included in the `Message` type the actor understands,
-so anyone who holds a reference to that actor can send this message to it.
+While this is quite convenient, it also means that the response has to be included in the `Message` type the actor understands, so anyone who holds a reference to that actor can send this message to it.
 
 [source]
 ----
@@ -419,15 +388,11 @@ include::{dir_sact_doc_tests}/InteropDocExamples.swift[tag=asyncOp_sendResult_in
 
 #TODO: Add better description of what problem are we facing and then how to solve it#
 
-In order to avoid having to add internal messages to the public message type, actors offer functionality to process asynchronous results
-as a continuation within the actor itself, so it will be executed within the same context and in sequence with all the
-other messages.
+In order to avoid having to add internal messages to the public message type, actors offer functionality to process asynchronous results as a continuation within the actor itself, so it will be executed within the same context and in sequence with all the other messages.
 
-We can handle asynchronous results by providing a continuation, that will be run after the result is available, to `onResultAsync` or
-`onResultAsyncThrowing` on `api:ActorContext[class]`. This will ensure that the continuations are run within the same actor context
-to ensure the message processing guarantees are not violated and avoid data races. All messages that are received while the
-async result is not completed will be processed as usual, so the actor should not depend on the result to make progress (we will
-explain how to handle that case later in this document).
+We can handle asynchronous results by providing a continuation, which will be run after the result is available, to `onResultAsync` or `onResultAsyncThrowing` on `api:ActorContext[class]`.
+This will ensure that the continuations are run within the same actor context so that message processing guarantees are not violated, and data races are avoided.
+All messages that are received while the async result is not completed will be processed as usual, so the actor should not depend on the result to make progress (we will explain how to handle that case later in this document).
 
 Assume we have an actor that asynchronously fetches data from a database and caches the results for some time.
 
@@ -444,40 +409,39 @@ We can implement the actor as follows:
 ----
 include::{dir_sact_doc_tests}/InteropDocExamples.swift[tag=asyncOp_onResultAsync]
 ----
-<1> We create a cache that store users we have fetched for 30 seconds
-<2> If we have have the user cached, we return the cached value
-<3> Otherwise we fetch it from the database
-<4> Now we register the continuation to run when the result is available
-<5> If the request was successful, we store the user in the cache and send it to the `replyTo` ref
-<6> If we could not find the user in the database either, we response with `.unknownUser`
-<7> If the request failed, we respond with `lookupFailed`
+<1> We create a cache that stores users we have fetched for 30 seconds.
+<2> If we have have the user cached, we return the cached value.
+<3> Otherwise we fetch it from the database.
+<4> Now we register the continuation to run when the result is available.
+<5> If the request was successful, we store the user in the cache and send it to the `replyTo` ref.
+<6> If we could not find the user in the database either, we response with `.unknownUser`.
+<7> If the request failed, we respond with `lookupFailed`.
 
 [[awaitResult]]
-==== Awaiting on asynchronous results on Behavior transitions
+==== Waiting for asynchronous results on Behavior transitions
 
-Some actors need to fetch initial state before they can start processing other messages or need to wait for an asynchronous
-result before resuming to process user messages. This can be achieved with the `awaitResult` and `awaitResultThrowing` calls
-on `api:ActorContext[class]`. They create a behavior that suspends processing of user messages until the asynchronous result has been
-received, or the timeout has expired.
+Some actors need to fetch initial state before they can start processing other messages or need to wait for an asynchronous result before resuming user message processing.
+This can be achieved with the `awaitResult` and `awaitResultThrowing` calls on `api:ActorContext[class]`.
+They create a behavior that suspends processing of user messages until the asynchronous result has been
+received or the timeout has expired.
 
-Imagine an actor that understands following message protocol, that allows a user to request adding a prefix to a string:
+Imagine an actor that understands following message protocol, which allows a user to request adding a prefix to a string:
 
 [source]
 ----
 include::{dir_sact_doc_tests}/InteropDocExamples.swift[tag=asyncOp_awaitResult_enum_Messages]
 ----
 
-Now if we have that prefix stored in a database, we need to fetch it before we can prefix any strings, but we don't want users to be able to change
-the prefix, so we can't add it to the message protocol, but we also can't block inside the actor. Using `awaitResult`, we can fetch the data
-asynchronously and after receiving the result, start processing the user requests.
+Now if we have that prefix stored in a database we need to fetch it before we can prefix any strings, but we don't want users to be able to change the prefix so we can't add it to the message protocol, but we also can't block inside the actor.
+Using `awaitResult` we can fetch the data asynchronously, and after receiving the result start processing the user requests.
 
 [source]
 ----
 include::{dir_sact_doc_tests}/InteropDocExamples.swift[tag=asyncOp_awaitResult]
 ----
-<1> Call operation that returns a `NIO.EventLoopFuture`
-<2> Awaiting the result causes the actor to suspend user message processing, but it keeps processing system messages. So e.g. stopping a suspended actor is still possible.
-<3> After successfully retrieving the prefix from the database we can start processing the requests
+<1> Call operation that returns a `NIO.EventLoopFuture`.
+<2> Awaiting the result causes the actor to suspend user message processing, but it keeps processing system messages, so stopping a suspended actor is still possible, for example.
+<3> After successfully retrieving the prefix from the database we can start processing the requests.
 <4> In case the asynchronous operation fails, we can throw the produced error which will be treated like any error that occurs in the actor.
 
 Most of the time when facing situations where the actor needs the result of an async operation to proceed, failure of the async operation should also crash the actor.
@@ -489,9 +453,7 @@ include::{dir_sact_doc_tests}/InteropDocExamples.swift[tag=asyncOp_awaitResultTh
 ----
 
 CAUTION: `awaitResult` and `awaitResultThrowing` cause the actor to suspend, meaning it won't process any user messages until it is resumed.
-This will lead to growth of the mailbox and can cause significant delays in message processing. Therefore these functions should be
-used with caution and only when absolutely necessary and with reasonably small timeouts to avoid problems caused by unresponsive
-services.
+This will lead to growth of the mailbox and can cause significant delays in message processing, therefore these functions should be used with caution and only when absolutely necessary, and with reasonably small timeouts to avoid problems caused by unresponsive services.
 
 [[event_stream]]
 === EventStream
@@ -505,10 +467,10 @@ Usage:
 ----
 include::{dir_sact_doc_tests}/ActorDocExamples.swift[tag=eventStream]
 ----
-<1> Create an `EventStream` that publishes events of type `Event`
-<2> Subscribe `ref` to receive events from the stream
-<3> Publish on event to all subscribers
-<4> Unsubscribe `ref` from the event stream
+<1> Create an `EventStream` that publishes events of type `Event`.
+<2> Subscribe `ref` to receive events from the stream.
+<3> Publish an event to all subscribers.
+<4> Unsubscribe `ref` from the event stream.
 
 [[subreceive]]
 === SubReceive

--- a/Docs/clustering.adoc
+++ b/Docs/clustering.adoc
@@ -4,38 +4,39 @@
 
 > One actor is no actor, they come in systems.
 
-By connecting several nodes into a cluster you gain the ability to _transparently_ send and receive messages from actors
-located on other nodes. Along with this, advanced failure detection and mitigation mechanisms are also enabled by default.
+By connecting several nodes into a cluster you gain the ability to _transparently_ send and receive messages from actors located on other nodes.
+Along with this, advanced failure detection and mitigation mechanisms are also enabled by default.
 
 [[cluster_quickstart]]
 === Cluster QuickStart
 
 ==== Step 1: Start nodes and join them
 
-In this section we'll provide a quick guide on setting up your first cluster. It is recommended to continue reading this
-documentation page to better understand the various steps and configurable pieces involved.
+In this section we'll provide a quick guide on setting up your first cluster.
+It is recommended to continue reading this documentation page to better understand the various steps and configurable pieces involved.
 
 [source]
 ----
 include::{dir_sact_samples}/SampleCluster/main.swift[tag=cluster-sample]
 ----
-<1> To send custom types across the wire, we have to register them with <<serialization>> #TODO: This will be simplified soon#
-<2> When a `host:port` was passed in as well, we join that node and form a cluster. Alternatively we could use automatic <<node_discovery, Service Discovery>>
-<3> When ready, we can <<spawning_actors, spawn actors>> (and <<actorable, actorables>>) and look up other node's actors using the <<receptionist, Receptionist>>
+<1> To send custom types across the wire, we have to register them with <<serialization>>.
+    #TODO: This will be simplified soon#
+<2> If a `host:port` was passed in, we join that node and form a cluster.
+    Alternatively we could use automatic <<node_discovery, Service Discovery>>.
+<3> When ready, we can <<spawning_actors, spawn actors>> (and <<actorable, actorables>>) and look up other nodes' actors using the <<receptionist, Receptionist>>.
 
 With that, we are ready to start a few instances of the application (using plain old `swift run ...`), like so:
 
-- `swift run MySampleCluster 7337` (starts the first node)
-- `swift run MySampleCluster 8228 7337` (which makes the second node join the first).
+* `swift run MySampleCluster 7337` (starts the first node)
+* `swift run MySampleCluster 8228 7337` (which makes the second node join the first).
 
-The system is not doing much though--the nodes have formed a cluster, and you could observe their metrics and gossip (on verbose logging settings).
-However let's spice it up a little bit by spawning an actor to listen to api:Cluster.Event[enum]s:
+The system is not doing much yet, but the nodes have formed a cluster and you could observe their metrics and gossip (on verbose logging settings).
+However, let's spice it up a little bit by spawning an actor to listen to api:Cluster.Event[enum]s.
 
 ==== Optional Step: Listen for Cluster Events
 
 Cluster events are published whenever the membership of the cluster changes, e.g. when new nodes join or leave the cluster.
-Many of the built-in actors operate by listening for these events and acting upon them, for example by moving workloads off leaving
-members of the cluster etc.
+Many of the built-in actors operate by listening for these events and acting upon them, for example by moving workloads off leaving members of the cluster, etc.
 
 For the purposes of the quick start example, we are only interested in learning how to subscribe to these events, which we can do like this:
 
@@ -43,109 +44,100 @@ For the purposes of the quick start example, we are only interested in learning 
 ----
 include::{dir_sact_samples}/SampleCluster/main.swift[tag=cluster-sample-event-listener]
 ----
-<1> <<spawning_behaviors, Spawn>> an actor that will receive and log cluster events
-<2> Subscribe the actor to the `cluster.events` stream
+<1> <<spawning_behaviors, Spawn>> an actor that will receive and log cluster events.
+<2> Subscribe the actor to the `cluster.events` stream.
 
 To learn more about working effectively with cluster events, refer to <<cluster_events>>.
 
 ==== Step 2: Start and Discover Actors Across Nodes
 
-Finally, we should actually start some actors, and also have them discover their counterparts running on other members of the cluster.
-To do this, we'll use the built-in <<receptionist, Receptionist>> actor, which handles the discovery of actors across clustered
-members in a type-safe and efficient way.
+Finally, we should actually start some actors and have them discover their counterparts running on other members of the cluster.
+To do this we'll use the built-in <<receptionist, Receptionist>> actor, which handles the discovery of actors across clustered members in a type-safe and efficient way.
 
-The receptionist only knows about actors explicitly register with it. We can do this in a number of ways.
-A good pattern to apply here is to let the actor _itself_ register with the receptionist when it starts, which can be done
-in a `.setup{}` api:Behavior[struct], or `preStart` callback of an <<actorable, Actorable>>. However, for our example to keep things short
-we'll use the method of the spawner performing the registration. We'll register it in a specific `"chat-room"`, and later
-spawn another "greeter" actor (though only on one of the nodes), which will act as the "owner" of the chat room, being able to
-send everyone announcements and more complex things in later steps of this guide.
+The receptionist only knows about actors explicitly register with it, which we can do in a number of ways.
+A good pattern to apply here is to let the actor _itself_ register with the receptionist when it starts, which can be done in a `.setup{}` api:Behavior[struct], or `preStart` callback of an <<actorable, Actorable>>.
+However, for our example to keep things short we'll use the method of the spawner performing the registration.
+We'll register it in a specific `"chat-room"`, and later spawn another "greeter" actor (though only on one of the nodes), which will act as the "owner" of the chat room, being able to send everyone announcements and more complex things in later steps of this guide.
 
 [source]
 ----
 include::{dir_sact_samples}/SampleCluster/main.swift[tag=cluster-sample-actors-discover-and-chat]
 ----
-<1> Once the `chatter` is spawned, we register it with our receptionist, making it available for discovery by other cluster members
+<1> Once the `chatter` is spawned, we register it with our receptionist, making it available for discovery by other cluster members.
 <2> For brevity in the quickstart, we pick a simple way to spawn the `greeter` only once: only on the node which has the default port.
-    In reality, we would use the <<actor_singleton>> mechanism, or check membership for being the leader. We will cover these patterns shortly.
-<3> We spawn the `greeter` and `receptionist.subscribe` to the key under which our `chatter`s are being registered. It will receive their api:Receptionist.Listing[enum] whenever it changes.
+    In reality, we would use the <<actor_singleton>> mechanism, or check membership for being the leader.
+    We will cover these patterns shortly.
+<3> We spawn the `greeter` and `receptionist.subscribe` to the key under which our `chatter`s are being registered.
+    It will receive their api:Receptionist.Listing[enum] whenever it changes.
 <4> Whenever we receive a new listing, we tell all actors about the current number of chatters in this room.
 
-To continue learning in depth about using the api:Receptionist[enum], continue to <<receptionist_cluster>> in the context of clustering,
-and to <<receptionist>> for a detailed discussion of it's API and use-cases.
+To continue learning in depth about using the api:Receptionist[enum] in the context of clustering, continue to <<receptionist_cluster>>, and to <<receptionist>> for a detailed discussion of its API and use-cases.
 
 ==== Extra Step: "Let them chat!", using Serialized ChatMessages
 
-#TODO: the last step to make this example fun would be to introduce `ChatMessage` rather than the string, register it with serialization and this way learn about that,
-the server can connect random chatters and they can talk to each other, completing our fun little example.#
+#TODO: the last step to make this example fun would be to introduce `ChatMessage` rather than the string, register it with serialization and this way learn about that.
+The server can connect random chatters and they can talk to each other, completing our fun little example.#
 
 #TODO: here we'd cover <<serialization>>#
 
 [[cluster_member_lifecycle]]
 === Cluster Member Lifecycle
 
-Multiple nodes can join each other to form a cluster. Nodes within a cluster are referred to as members
-and follow a specific lifecycle along their api:Cluster.MemberStatus[enum] as outlined on the diagram below:
+Multiple nodes can join each other to form a cluster.
+Nodes within a cluster are referred to as members and follow a specific lifecycle along their api:Cluster.MemberStatus[enum] as outlined on the diagram below:
 
 image::cluster_lifecycle.svg[Cluster Member Lifecycle]
 
-Each api:Cluster.Member[enum] initially starts in `.joining` state and may proceed through next phases of the lifecycle
-it is able to. Note that a member's status can never "go back," i.e. it may only move forward across the `.joining
-[ -> .leaving] -> .up -> .down -> .removed` lifecycle. Refer to api:Cluster.MemberStatus[enum] for detailed discussion of the statuses.
+Each api:Cluster.Member[enum] initially starts in `.joining` state and may proceed through next phases of the lifecycle it is able to.
+Note that a member's status can never "go back," it may only move forward across the `.joining
+[ -> .leaving] -> .up -> .down -> .removed` lifecycle.
+Refer to api:Cluster.MemberStatus[enum] for detailed discussion of the statuses.
 
 In addition to the specific statuses carrying meaning with them, there are a few additional things to dive into in the above diagram:
 
-*Leader actions*: Some changes may only be decided upon by the cluster's <<leadership, leader>>, such as moving a node from `.joining` to
-`.up`, or completely _removing_  a node from the observable membership list; as those status changes are important to
-be made consistently (i.e. when the cluster membership views are "converged", meaning that all cluster members have the same
-"view" of the membership).
+Leader actions:: Some changes may only be decided upon by the cluster's <<leadership, leader>>, such as moving a node from `.joining` to `.up`, or completely _removing_  a node from the observable membership list, as those status changes are important to be made consistently (i.e. when the cluster membership views are "converged", meaning that all cluster members have the same "view" of the membership).
 
-*Reachability*: While outside of the progress along the lifecycle timeline of a member, another important part of membership information
-is _reachability_. A built-in distributed failure detection mechanism allows the cluster to determine if a node is unresponsive,
-and potentially should become down. These suspicions are surfaced from the failure detector as api:Cluster.ReachabilityChange[enum]s,
-and may be used by end users or an automatic api:DowningStrategy[protocol] to decide when to mark a node as `.down`.
+Reachability:: While outside of the progress along the lifecycle timeline of a member, another important part of membership information is _reachability_.
+A built-in distributed failure detection mechanism allows the cluster to determine if a node is unresponsive, and potentially should be marked down.
+These suspicions are surfaced from the failure detector as api:Cluster.ReachabilityChange[enum]s, and may be used by end users or an automatic api:DowningStrategy[protocol] to decide when to mark a node as `.down`.
 
-*Failure Detector*: The cluster provides a built-in distributed failure detector implementation, based on the SWIM membership protocol.
+Failure Detector:: The cluster provides a built-in distributed failure detector implementation, based on the SWIM membership protocol.
 It is responsible for issuing reachability events, which then may be acted upon in order to down and terminate nodes of a cluster.
 Refer to <<swim>> for an in-depth discussion of this failure detection mechanism.
 
-*Downing Strategy*: The final piece of the automatic lifecycle management chain are implementations of api:DowningStrategy[protocol].
+Downing Strategy:: The final piece of the automatic lifecycle management chain are implementations of api:DowningStrategy[protocol].
 Refer to <<downing_strategies>> for a detailed discussion.
 
-*Leaders*: Some of the member status changes may only be performed by the cluster's leader. A <<leadership, leader>> member
-is a node which is elected among a sub-set of the membership. It then is tasked to perform leader duties until another leader is elected.
-See <<leadership>> to learn more about how leaders are elected and what guarantees are associated with them. Note that there
-are multiple ways of electing leaders and you may adjust it depending on your system's requirements or run more instances
-of elections independently, to decide leaders for various tasks independently.
+Leaders:: Some of the member status changes may only be performed by the cluster's leader.
+A <<leadership, leader>> member is a node which is elected among a sub-set of the membership.
+It then is tasked to perform leader duties until another leader is elected.
+See <<leadership>> to learn more about how leaders are elected and what guarantees are associated with them.
+Note that there are multiple ways of electing leaders and you may adjust it depending on your system's requirements or run more elections independently to decide leaders for various tasks individually.
 
-*Cluster.MemberStatus*: Each cluster member is associated with a specific status at any given time. This information is
-spread throughout the cluster via a gossip protocol. Refer to api:Cluster.MemberStatus[enum] for a detailed description of each state.
-Generally, a node should be considered "ready" to perform tasks when it is marked as `.up`, and not ready, or incapable of doing so
-in any other status.
+Cluster.MemberStatus:: Each cluster member is associated with a specific status at any given time.
+This information is spread throughout the cluster via a gossip protocol.
+Refer to api:Cluster.MemberStatus[enum] for a detailed description of each state.
+Generally, a node should be considered "ready" to perform tasks when it is marked as `.up`, and not ready, or incapable of doing so in any other status.
 
 === Bootstrapping Clusters
 
-Bootstrapping new clusters involves notifying each node about _at least one_ other node that it either should _form a cluster with_
-or _join an existing cluster_. Note that it is _not_ necessary to provide all nodes of a cluster to the join process.
-As long as a node is able to join at least _one_ member of an existing cluster, it becomes part of that cluster, and will
-receive information about all other members of it via gossip, that all member nodes exchange periodically.
+Bootstrapping new clusters involves notifying each node about _at least one_ other node that it should either _form a cluster with_ or _contact to join an existing cluster_.
+Note that it is _not_ necessary to provide all nodes of a cluster to the join process.
+As long as a node is able to join with at least _one_ member of an existing cluster, it becomes part of that cluster, and will receive information about all other members of it via gossip, which all member nodes exchange periodically.
 
-WARNING: Caution should be taken for initiating new clusters -- when starting new clusters, always ensure that
-all nodes of a cluster eventually will communicate. E.g. by using a majority (or all) of the nodes, or a "stable node"
-as the initial contact point. +
+WARNING: Caution should be taken for initiating new clusters -- when starting new clusters, always ensure that all nodes of a cluster will eventually communicate, e.g. by using a majority (or all) of the nodes, or a "stable node" as the initial contact point. +
  +
-Otherwise the following troublesome situation may happen: Given 4 nodes: A, B, C, D, and by only telling: A about [A,B],
-B about [A,B], C about [C,D], D about [C,D]. Given such bootstrapping, there would be two clusters formed (!). While this
-seems trivial to spot on paper, it happens sometimes if no caution is taken during configuring of the initial contacts / discovery. +
+Otherwise the following troublesome situation may happen: Given 4 nodes, A, B, C, D, bootstrap them by telling A about [A,B], B about [A,B], C about [C,D], and D about [C,D].
+Given this bootstrapping, there would be two clusters formed (!).
+While this seems trivial to spot on paper, it can happen if no caution is taken during configuring of the initial contacts / discovery. +
  +
-*Solution*: Always ensure that when deploying many nodes, attempts are made to join at least `N/2+1` nodes by any joining node,
-this way it is ensured that there is at least one node "overlap" and the two clusters situation would not happen. Alternatively (and simpler),
-it is also possible to simply issue `join()` towards all nodes discovered via service discovery.
+*Solution*: Always ensure that when deploying many nodes, attempts are made to join at least `N/2+1` nodes by any joining node, this way it is ensured that there is at least one node "overlap" and the two clusters situation will not happen.
+Alternatively (and simpler), it is also possible to simply issue `join()` towards all nodes discovered via service discovery.
 
 [[joining_nodes]]
 ==== Joining nodes (manually)
 
-In order for actors to be able to communicate across nodes, the nodes have to form a cluster (except alternative transports, which we do not discuss in this chapter).
+In order for actors to be able to communicate across nodes, the nodes have to form a cluster (except in the case of alternative transports, which we do not discuss in this chapter).
 
 Joining nodes is fairly simple and can be performed at any time by by issuing a `system.cluster.join` command:
 
@@ -154,96 +146,81 @@ Joining nodes is fairly simple and can be performed at any time by by issuing a 
 include::{dir_sact_doc_tests}/ClusterDocExamples.swift[tag=joining]
 ----
 <1> Enable clustering (so the node binds to a local port and begins listening for connections), and optionally change which address to bind to.
-<2> Join the other node, forming a 2-node cluster. The address could be discovered using some mechanism, or known up front and configured into the app.
+<2> Join the other node, forming a 2-node cluster.
+    The address could be discovered using some mechanism, or known up front and configured into the app.
 
 Once the nodes have established connections, you are ready to transparently send messages across the network.
 Joining nodes also means that they will participate in health checking using the configured failure detector.
 
 Some additional things to consider about joining nodes:
 
-- *Node replacements*: it is possible for a node to crash, get restarted (and thus share the _same exact_ host and port as its previous incarnation),
-and attempt connecting to the cluster in which its previous "incarnation" was already known. This results in the previous incarnation being forcefully
-and immediately marked `.down` and being _replaced_ by the new node. The assumption here is that since the node shares the exact same address, however
-it has a different internal unique identifier, the old one must have crashed, but we have not detected that crash yet. By allowing this node to join
-as a _replacement_ we speed up recovery of the cluster, by not having to wait for the previous node to be detected as failed and removed slowly first.
+- *Node replacements*: it is possible for a node to crash, get restarted (thus sharing the _same exact_ host and port as its previous incarnation), and attempt connecting to the cluster in which its previous "incarnation" was already known.
+This results in the previous incarnation being forcefully and immediately marked `.down` and being _replaced_ by the new node.
+The assumption here is that since the node shares the exact same address but has a different internal unique identifier, the old one must have crashed but we have not detected that crash yet.
+By allowing this node to join as a _replacement_ we speed up recovery of the cluster by not having to wait for the previous node to be detected as failed and removed slowly first.
 
 [[node_discovery]]
 [[service_discovery]]
 ==== Automated node joining using Service Discovery
 
-It is also possible to make use of https://github.com/apple/swift-service-discovery[Swift Service Discovery] to automatically
-locate and `join` cluster nodes.
+It is also possible to make use of https://github.com/apple/swift-service-discovery[Swift Service Discovery] to automatically locate and `join` cluster nodes.
 
-Thanks to the Service Discovery API having various implementations, you should be able to pick an existing
-implementation to suit your project's needs. The seed node discovery can be enabled by configuring the system's
-api:ServiceDiscoverySettings[struct], as follows:
+Thanks to the Service Discovery API having various implementations, you should be able to pick an existing implementation to suit your project's needs.
+The seed node discovery can be enabled by configuring the system's api:ServiceDiscoverySettings[struct], as follows, if the `ServiceDiscovery` is compatible with `ServiceDiscovery.Instance = DistributedActors.Node`:
 
 [source]
 ----
 include::{dir_sact_doc_tests}/ClusterDocExamples.swift[tag=discovery-joining-config]
 ----
 
-If the `ServiceDiscovery` is compatible with `ServiceDiscovery.Instance = DistributedActors.Node`,
-or the following if a mapping has to be performed from the looked up Instance type to the Node type
-which the actor runtime can use to perform join actions:
+If a mapping has to be performed from the looked-up `Instance` type to the `Node` type which the actor runtime can use to perform join actions, use the following instead:
 
 [source]
 ----
 include::{dir_sact_doc_tests}/ClusterDocExamples.swift[tag=discovery-joining-config-2]
 ----
-<1> This discovery mechanism uses a type specific to its implementation for instances (e.g. `Instance = SomeGenericNode`)
-<2> We need to perform a mapping from that type, which is unknown to the actors library to api:Node[struct] which the library can handle and perform a `join` with.
+<1> This discovery mechanism uses a type specific to its implementation for instances (e.g. `Instance = SomeGenericNode`).
+<2> We need to perform a mapping from that type, which is unknown to the actors library, to api:Node[struct] which the library can handle and perform a `join` with.
 
-How the polling or being notified dynamically about changes in the discovery mechanism is performed depends on the selected discovery mechanism.
-For example, a DNS discovery implementation is likely to resort to periodically polling for SRV records or similar, while other mechanisms may
-receive pushed information whenever the membership changes.
+How the polling or dynamic notification about changes in the discovery mechanism is performed depends on the selected discovery mechanism.
+For example, a DNS discovery implementation is likely to resort to periodically polling for SRV records or similar, while other mechanisms may receive pushed information whenever the membership changes.
 
-NOTE: Note that discovery is not the same as issuing `.down`, and the removal of a node from the discovery service will _not_
-  automatically remove it from the cluster. +
-  +
-  You _can_ however configure your actor system to do this, by issuing `system.cluster.down(node)` whenever a node is noticed to be removed
-  from service discovery. If you would like to take this approach, you may want implement a api:DowningStrategy[protocol],
-  in terms of the discovery mechanism of your choice, as well as consider if you want to keep or remove the membership
-  and failure detection mechanisms offered by the cluster by default (e.g. disabling the SWIM failure detector).
+NOTE: Discovery is not the same as issuing `.down`, and the removal of a node from the discovery service will _not_ automatically remove it from the cluster. +
+    +
+You _can_, however, configure your actor system to do this by issuing `system.cluster.down(node)` whenever a node is noticed to have been removed from service discovery.
+If you would like to take this approach, you may want implement a api:DowningStrategy[protocol], in terms of the discovery mechanism of your choice, as well as consider if you want to keep or remove the membership and failure detection mechanisms offered by the cluster by default i.e. disabling the SWIM failure detector.
 
 
 ==== Moving nodes from .joining to .up
 
 It is worth highlighting _when_ nodes get moved from their `.joining` states to `.up`.
 
-As discussed in <<cluster_member_lifecycle>>, moving members from joining to up status is a _leader action_, and thus
-the cluster will only be able to perform those moves when a leader is selected. Thankfully, <<leadership, leader election>>
-is automated and able to take care of this easily.
+As discussed in <<cluster_member_lifecycle>>, moving members from joining to up status is a _leader action_, and thus the cluster will only be able to perform those moves when a leader is selected.
+Thankfully, <<leadership, leader election>> is automated and able to take care of this easily.
 
-By default automatic leader election will select a leader once the cluster has _at least 2 nodes_, and thus only then
-will nodes be moved to `.up` state. In other words, when running a node with clustering enabled, it will assume there
-will be at least one other node joining, and thus not become "fully ready" (`.up`) until that node has joined.
+By default automatic leader election will select a leader once the cluster has _at least 2 nodes_, and thus only then will nodes be moved to `.up` state.
+In other words, when running a node with clustering enabled, it will assume there will be at least one other node joining, and thus not become "fully ready" (`.up`) until that node has joined.
 
-NOTE: When deploying larger clusters, consider if wetting the leader election's `minNumberOfMembers` to a number
-      closer (or equal) to the expected deployment member count. This allows for _less churn_ if the leader had to _move_
-      once new members are discovered. Refer to the <<leadership>> section for detailed discussion of defaults and trade-offs
-      of the leadership election schemes provided by the cluster. Note that automatic election is configured during system setup
-      using the `settings.cluster.autoLeaderElection` setting.
+NOTE: When deploying larger clusters, consider if setting the leader election's `minNumberOfMembers` to a number closer (or equal) to the expected member count.
+This allows for _less churn_ if the leader had to _move_ once new members are discovered.
+Refer to the <<leadership>> section for detailed discussion of defaults and trade-offs of the leadership election schemes provided by the cluster.
+Note that automatic election is configured during system setup using the `settings.cluster.autoLeaderElection` setting.
 
 [[receptionist_cluster]]
 === Discovering Distributed Actors (Receptionist)
 
-In order to locate and communicate with actors distributed in a cluster, we need a service discovery mechanism that
-fine tuned for the use cases of type-safe actors. Thankfully, such abstraction exists and is always available in the system.
-It is the api:Receptionist[enum].
+In order to locate and communicate with actors distributed in a cluster, we need a service discovery mechanism that is fine tuned for the use cases of type-safe actors.
+Thankfully, such abstraction exists and is always available in the system: the api:Receptionist[enum].
 
-While we discussed the <<receptionist, Receptionist>> APIs in depth in a <<receptionist, previous section>> already,
-it is worth discussing again in the context of clustered systems.
+While we discussed the <<receptionist, Receptionist>> APIs in depth in a <<receptionist, previous section>> already, it is worth discussing again in the context of clustered systems.
 
-The good news is, that there is nothing new to be learnt about the _distributed_ receptionist -- it works and offers
-the exact same capabilities as it does in a local setting. Actors can register with it, and lookup or subscribe
-for specific keys they are interested in. The receptionist takes care of watching and removing any actors that
-have terminated (including on remote nodes) from its listing, and offers updated listings to any of its subscribers.
+The good news is that there is nothing new to be learned about the _distributed_ receptionist -- it works and offers the exact same capabilities as it does in a local setting.
+Actors can register with it, and lookup or subscribe to specific keys they are interested in.
+The receptionist takes care of watching and removing any actors that have terminated (including on remote nodes) from its listing, and offers updated listings to its subscribers.
 
-NOTE: Each node in a system has its own receptionist, take care to always use "your node's" receptionist, and not pass
-references to the receptionist across to other nodes. While it would all still work, thanks to location transparency,
-it is a very bad idea from a performance and simplicity point of view. Always use your local receptionist, by reaching
-for it via: `system.receptionist` or `context.receptionist`.
+NOTE: Each node in a system has its own receptionist, take care to always use *your node's* receptionist, and not pass references to the receptionist across to other nodes.
+While it would all still work, thanks to location transparency, it is a very bad idea from a performance and simplicity point of view.
+Always use your local receptionist, by reaching for it via: `system.receptionist` or `context.receptionist`.
 
 ==== Some Internals about how it replicates information
 
@@ -252,46 +229,41 @@ for it via: `system.receptionist` or `context.receptionist`.
 [[cluster_events]]
 === Working with Cluster Events
 
-Cluster events are the way application actors are able to stay informed about the state of the cluster, and potentially
-act on those events. For example by not sending more work to an `.unreachable` node, or migrating workloads away from
-a member which has declared api:Cluster.MemberStatus[enum]
+Cluster events are the way application actors are able to stay informed about the state of the cluster, and potentially act on those events.
+For example, by not sending more work to an `.unreachable` node, or migrating workloads away from a member which has declared api:Cluster.MemberStatus[enum]
 
 There are four kinds of api:Cluster.Event[enum]:
 
-- `snapshot(` api:Cluster.Membership[enum] `)`
-- `membershipChange(` api:Cluster.MembershipChange[enum] `)`
-- `reachabilityChange(` api:Cluster.ReachabilityChange[enum] `)`
-- `leadershipChange(` api:Cluster.LeadershipChange[enum] `)`
+* `snapshot(` api:Cluster.Membership[enum] `)`
+* `membershipChange(` api:Cluster.MembershipChange[enum] `)`
+* `reachabilityChange(` api:Cluster.ReachabilityChange[enum] `)`
+* `leadershipChange(` api:Cluster.LeadershipChange[enum] `)`
 
-The way to subscribe to receive those events is to subscribe an actor to `system.cluster.events` which is a specialized
-<<event_stream, EventStream>>. It always publishes a `snapshot` of the current state of the membership first, and from there
-onwards publishes every change that is being applied to the membership.
+The way to subscribe to receive those events is to subscribe an actor to `system.cluster.events`, which is a specialized <<event_stream, EventStream>>.
+It always publishes a `snapshot` of the current state of the membership first, and from there onwards publishes every change that is being applied to the membership.
 
-The way to own an always up-to-date api:Cluster.Membership[enum,alias='Membership'] is to subscribe to the events,
-keep a local `var membership: Membership` and every time a new event is received `Membership.apply` it to the stored value, like this:
+The way to own an always up-to-date api:Cluster.Membership[enum,alias='Membership'] is to subscribe to the events, keep a local `var membership: Membership`, and every time a new event is received `Membership.apply` it to the stored value, like this:
 
 [source]
 ----
 include::{dir_sact_doc_tests}/ClusterDocExamples.swift[tag=subscribe-events-apply-general]
 ----
-<1> Store an initial, empty membership
-<2> Prepare a <<subreceive>> that will handle incoming `Cluster.Event` messages, regardless of the type of the owning `Behavior<Message>`
-<3> `apply` the incoming event to the stored membership, resulting in the membership being updated
-<4> Actually subscribe the subReceive (or actor itself if you prefer) to cluster events
+<1> Store an initial, empty membership.
+<2> Prepare a <<subreceive>> that will handle incoming `Cluster.Event` messages, regardless of the type of the owning `Behavior<Message>`.
+<3> `apply` the incoming event to the stored membership, resulting in the membership being updated.
+<4> Actually subscribe the subReceive (or actor itself if you prefer) to cluster events.
 
-Note that while the `apply` method is very convenient, it does not return "effective" changes which sometimes may be useful,
-when wanting to ensure an event triggers a specific action _exactly once_ e.g. only if a node was specifically "replaced."
+Note that while the `apply` method is very convenient, it does not return "effective" changes which sometimes may be useful when wanting to ensure an event triggers a specific action _exactly once_ e.g. only if a node was specifically "replaced."
 You can use the more specialized `applyMembershipChange` functions which take specific `...Change` types and return some additional information.
 
-Generally, the pattern around using membership information is based around performing some action on specific
-changes to the membership, e.g. starting timers when a member became unreachable, contacting an actor on a new member that
-had just joined the cluster etc. In these scenarios it is most useful to work with subscriptions and react to them accordingly.
+Generally, the pattern around using membership information is based around performing some action on specific changes to the membership, e.g. starting timers when a member became unreachable, contacting an actor on a new member that had just joined the cluster, etc.
+In these scenarios it is most useful to work with subscriptions and react to them accordingly.
 
 ==== Membership Snapshot
 
-Sometimes however, one just wants to perform a sanity check or printout without having to subscribe to the membership events
-actively. Note however that no strong guarantees are made about "how up to date" that value is, and even the moment after one has checked it, it may have already changed
-and e.g. now another member has become leader. Take this into consideration when opting to use this style of `Cluster.Membership` interaction.
+Sometimes however, one just wants to perform a sanity check or printout without having to subscribe to the membership events actively.
+Note, however, that no strong guarantees are made about "how up to date" that value is, and even the moment after one has checked it, it may have already changed, e.g. another member has become leader.
+Take this into consideration when opting to use this style of `Cluster.Membership` interaction.
 
 In order to obtain such "snapshot" of a membership, you can call the following:
 
@@ -300,49 +272,38 @@ In order to obtain such "snapshot" of a membership, you can call the following:
 include::{dir_sact_doc_tests}/ClusterDocExamples.swift[tag=membership-snapshot]
 ----
 
-
 [[downing_strategies]]
 === Downing Strategies
 
 Downing strategies are an automatic way to determine if a node should be marked as `.down` and thus eventually removed from the cluster.
-Marking nodes down is important, as only under this state certain types of workloads that those members were handling will be moved to other
-members.
+Marking nodes down is important, as only under this state will certain types of workloads that those nodes were handling will be moved to other members.
 
 Currently two trivial (automatic) downing strategies are provided:
 
-- `.none` - which does absolutely nothing,
-- `.timeout` - which listens for `.unreachable` cluster events, and after an additional grace period, escalates those to `.down` status of such member.
+* `.none` - which does absolutely nothing.
+* `.timeout` - which listens for `.unreachable` cluster events, and after an additional grace period, escalates those to `.down` status of the member in question.
 
 ==== Not Marking Members `.down` automatically
 
 The `.none` strategy is useful when one wants to take manual control over deploying/removing nodes in a cluster.
 
 It is also useful when one wants to implement their own decision making about when a member shall be removed from the cluster.
-For example, one might implement down decisions based on some external service discovery service -- if _and only if_ a
-node is not present in that service's listing, it should be assumed down, regardless if it _appears_ to be unreachable
-based on our failure detector's measurements. This technique is useful if one has a reliable source of truth regarding node
-health, however we still recommend making use of failure detectors in this case, as overall "health" of a node may not necessarily
-indicate if the connection between two given nodes remains valid.
+For example, one might implement down decisions based on some external service discovery service -- if, _and only if_, a node is not present in that service's listing, it should be assumed down, regardless if it _appears_ to be unreachable based on our failure detector's measurements.
+This technique is useful if one has a reliable source of truth regarding node health, however, we still recommend making use of failure detectors in this case as overall "health" of a node may not necessarily indicate if the connection between two given nodes remains valid.
 
-#TODO: also document if one wanted to disable failure detectors, would one do that#
+#TODO: also document if one wanted to disable failure detectors, how would one do that#
 
 ==== Marking Members `.down` upon `.unreachable`
 
-The `.timeout` / api:TimeoutBasedDowningStrategy[class] strategy is a good default for simple systems, which are run in
-a managed environment (e.g. Kubernetes), where nodes may get killed and replaced by a cluster orchestrator.
+The `.timeout` / api:TimeoutBasedDowningStrategy[class] strategy is a good default for simple systems, which are run in a managed environment, e.g. Kubernetes, where nodes may get killed and replaced by a cluster orchestrator.
 
-The timeout strategy serves only as an additional timeout between a node being seen as `.unreachable` detected as such by
-a <<swim, Failure Detector>>. In simple deployments or "playing around" scenarios, this is the recommended strategy, as
-it works well enough for simple systems, especially since it _only_ acts on reachability events, which are generated by
-the fairly confident <<swim>> failure detector.
+The timeout strategy serves only as an additional timeout between a node being seen as `.unreachable` as detected by a <<swim, Failure Detector>>.
+In simple deployments or "playing around" scenarios, this is the recommended strategy, as it works well enough for simple systems, especially since it _only_ acts on reachability events, which are generated by the fairly confident <<swim>> failure detector.
 
-WARNING: Beware of the so-called "split brain" (cluster partition) scenarios when using this method,
-         as it may potentially lead to declaring a healthy member as `.down`, however due to the
-         cluster's network partition, this decision never reaches that node, and as such it may continue to keep running
-         (and potentially even thinking that it is the "only survivor"). #TODO: we will provide strategies to deal with
-         these situations in the future, but you should also look at external methods of killing nodes in such split brain scenarios#.
+WARNING: Beware of the so-called "split brain" (cluster partition) scenarios when using this method, as it may potentially lead to declaring a healthy member as `.down`, but due to the cluster's network partition this decision never reaches that node, and it may continue to keep running (and potentially even thinking that it is the "only survivor").
+#TODO: we will provide strategies to deal with these situations in the future, but you should also look at external methods of killing nodes in such split brain scenarios.#
 
-#TODO: we will continue to invest in more advanced, e.g. quorum observations based downing methods etc#
+#TODO: we will continue to invest in more advanced, e.g. quorum observations based downing methods, etc.#
 
 === Secure Communication using TLS
 
@@ -352,16 +313,16 @@ Communication between nodes can be secured with TLS by adding the necessary conf
 ----
 include::{dir_sact_doc_tests}/ClusteringDocExamples.swift[tag=config_tls]
 ----
-<1> TLSConfiguration is contained in the NIOSSL module
-<2> We need to provide path to the certificate chain
-<3> And private key
-<4> Certificate verification is optional and can be set to `.none` for no verification
-<5> When using self signed certificates, set the trust to a certificate chain containing the certificates of all nodes that this node will be communicating with
+<1> TLSConfiguration is contained in the NIOSSL module.
+<2> We need to provide path to the certificate chain.
+<3> And private key.
+<4> Certificate verification is optional and can be set to `.none` for no verification.
+<5> When using self signed certificates, set the trust to a certificate chain containing the certificates of all nodes that this node will be communicating with.
 
 NOTE: The server side connection will use `.noHostnameVerification`, even when `.fullVerification` is configured, as we don't know which nodes we'll be communicating with.
 
-If the private key is protected with a passphrase, a passphrase callback has to be configured. The callback has a single parameter, that is the setter for the passphrase,
-which has to be called with the passphrase encoded as `[UInt8]`.
+If the private key is protected with a passphrase, a passphrase callback has to be configured.
+The callback has a single parameter, the setter for the passphrase, which has to be called with the passphrase encoded as `[UInt8]`.
 
 [source]
 ----
@@ -371,61 +332,51 @@ include::{dir_sact_doc_tests}/ClusteringDocExamples.swift[tag=config_tls_passphr
 [[leadership]]
 === Leadership and Leader Elections
 
-Leadership and leader nodes are a concept within actor clusters in which a specific node is taking on the role of a leader,
-for a certain period of time.
+Leadership and leader nodes are a concept within actor clusters in which a specific node is taking on the role of a leader, for a certain period of time.
 
-NOTE: The term leader DOES NOT imply that it is globally guaranteed to be unique in a cluster. In normal operations it
-      will be, however under cluster partitions each partition MAY have its own leader.
+NOTE: The term leader *DOES NOT* imply that it is globally guaranteed to be unique in a cluster.
+In normal operations it will be, however, under cluster partitions each partition *MAY* have its own leader.
 
-WARNING: If you require strong leadership, i.e. that a leader must be chosen only with the consensus of all (or quorum)
-         of all other nodes -- please reach out as this is a feature waiting to be implemented.
+WARNING: If you require strong leadership, i.e. that a leader must be chosen only with the consensus of all other nodes, or a quorum of all other nodes, please reach out as this is a feature waiting to be implemented.
 
 ==== `LowestReachableMember`
 
-The default api:Leadership.LowestReachableMember[struct] leader election strategy is fairly simple, however it has the
-benefit of being entirely predictable and coordination free (!). In other words, without coordinating but given the same
-membership view, all members will arrive at the same decision about which member is to be the leader.
+The default api:Leadership.LowestReachableMember[struct] leader election strategy is fairly simple, however it has the benefit of being entirely predictable and coordination free (!).
+In other words, without coordinating but given the same membership view, all members will arrive at the same decision about which member is to be the leader.
 
 NOTE: This leader election strategy for the cluster leader due to the properties of the leader tasks, and membership.
-It likely is not the kind of leader election one would want to use to perform strongly consistent actions within a cluster,
-we suggest using the <<actor_singleton>> or get in touch so we can implement a different election strategy for the use case.
+It likely is not the kind of leader election one would want to use to perform strongly consistent actions within a cluster, we suggest using the <<actor_singleton>> or get in touch so we can implement a different election strategy for the use case.
 
-The coordination-free part is very useful, as there is no need for additional consensus rounds when an existing leader dies,
-and all members need to decide on its replacement. Without coordination, yet thanks to being able to act on a resiliently
-eventually consistent replicated api:Cluster.Membership[enum].
+The coordination-free part is very useful -- there is no need for additional consensus rounds when an existing leader dies and all members need to decide on its replacement, thanks to being able to act on a resiliently eventually consistent replicated api:Cluster.Membership[enum].
 
 For details regarding the implementation, see the API docs for this type: api:Leadership.LowestReachableMember[struct].
 
 ==== Consensus based leadership elections
 
-#TODO: Likely useful as end-user tool, we'd like to offer it if someone has an use case for strong leadership in their system.#
+#TODO: Likely useful as end-user tool, we'd like to offer it if someone has a use case for strong leadership in their system.#
 
 === Failure detection in Clusters
 
-Failure detection in clusters enables receiving api:Signals.Terminated[enum] signals with regards to watched actors residing on nodes,
-which have entirely crashed.
+Failure detection in clusters enables receiving api:Signals.Terminated[enum] signals with regards to watched actors residing on nodes which have entirely crashed.
 
-Sadly, failure detection in distributed systems is always a trade-off between the time to signal a node failure,
-and potential false positives (where a node is detected as failed, however it was only "very slow to respond").
+Sadly, failure detection in distributed systems is always a trade-off between the time to signal a node failure and potential false positives (where a node is detected as failed, but it was only "very slow to respond").
 
 ==== Watching Remote Actors
 
-Watching remote actors works the same way as it does for local actors -- if the remote actor terminates and was watched,
-the watching actor gets a api:Signals.Terminated[enum] signal and may react to it.
+Watching remote actors works the same way as it does for local actors -- if the remote actor terminates and was watched, the watching actor gets a api:Signals.Terminated[enum] signal and may react to it.
 
-Additionally, not only individual actor failures are reported back, but also node failures.
-When a node hosting actors fails, all of the hosted actors are assumed to have terminated (upon the node's move to `.down`
-lifecycle state), upon this change local watchers receive a api:Signals.Terminated[enum] signal about actors that they have watched on
-given remote node. The following simplified diagram explains this mechanism:
+In addition to actor failures, node failures are also reported back to watchers.
+When a node hosting actors fails, all of the hosted actors are assumed to have terminated (upon the node's move to `.down` lifecycle state), and local watchers receive a api:Signals.Terminated[enum] signal about actors that they are watiching on the given remote node.
+The following simplified diagram explains this mechanism:
 
 [.center]
 image::remote_watch_terminated.png[Remote Watch, when remote node crashes]
 
 [unstyled]
-- ❶ The `A` actor watches a remote actor `R` on another node,
-- ❷ The node `B` crashes abruptly, without performing a graceful leave,
-- ❸ The failure detector on node `A` eventually realizes what happened,
-- ❹ And triggers a `Terminated()` signal for all actors on the remote (now `.down`) node, notifying our local actor `A` which had watched `R` before.
+- ❶ The `A` actor watches actor `R` on another node.
+- ❷ The node `B` crashes abruptly, without performing a graceful leave.
+- ❸ The failure detector on node `A` eventually realizes what happened.
+- ❹ And triggers a `Terminated()` signal for all actors on the remote (now `.down`) node, notifying our local actor `A`.
 
 
 // ==== SWIM -----------------------------------------------------------------------------------------------------------
@@ -433,49 +384,38 @@ image::remote_watch_terminated.png[Remote Watch, when remote node crashes]
 [[swim]]
 === Distributed Failure Detector (SWIM+Lifeguard)
 
-The cluster, by default, uses the https://github.com/apple/swift-cluster-membership[Swift Cluster Membership] provided
-SWIM protocol implementation as its underlying low-level failure detection mechanism.
+The cluster, by default, uses the https://github.com/apple/swift-cluster-membership[Swift Cluster Membership] provided SWIM protocol implementation as its underlying low-level failure detection mechanism.
 
-NOTE: Refer to https://github.com/apple/swift-cluster-membership and the relevant
-  https://www.cs.cornell.edu/projects/Quicksilver/public_pdfs/SWIM.pdf[SWIM: Scalable Weakly-consistent Infection-style Process Group Membership Protocol]
-  and https://arxiv.org/abs/1707.00788[Lifeguard: Local Health Awareness for More Accurate Failure Detection] whitepapers to understand
-  the failure detection mechanism in depth. Below we'll provide a high-level overview that is comprehensive enough to feel confident
-  running systems using the automatic failure detection in production.
+NOTE: Refer to https://github.com/apple/swift-cluster-membership and the relevant https://www.cs.cornell.edu/projects/Quicksilver/public_pdfs/SWIM.pdf[SWIM: Scalable Weakly-consistent Infection-style Process Group Membership Protocol] and https://arxiv.org/abs/1707.00788[Lifeguard: Local Health Awareness for More Accurate Failure Detection] whitepapers to understand the failure detection mechanism in depth.
+Below we'll provide a high-level overview that is comprehensive enough to feel confident running systems using the automatic failure detection in production.
 
-While SWIM is a complete membership protocol, the Actor Cluster also offers a more high-level membership view which provides
-stronger guarantees about peers moving through specific lifecycle steps. Generally, SWIM's membership and member states
-should be considered internal to the cluster and you should not interact with them directly in your application.
+While SWIM is a complete membership protocol, the Actor Cluster also offers a more high-level membership view which provides stronger guarantees about peers moving through specific lifecycle steps.
+Generally, SWIM's membership and member states should be considered internal to the cluster and you should not interact with them directly in your application.
 
-TIP: It is not necessary to interact with the SWIM-level membership and member statuses in an Actor Cluster,
-  instead always rely on the `Cluster.Membership` and related events, as they provide a higher level abstraction,
-  detached from failure detection mechanism while offering stronger consistency guarantees than the SWIM membership by itself.
+TIP: It is not necessary to interact with the SWIM-level membership and member statuses in an Actor Cluster, instead always rely on the `Cluster.Membership` and related events as they provide a higher level abstraction, detached from failure detection mechanism while offering stronger consistency guarantees than the SWIM membership by itself.
 
 NOTE: Refer to https://apple.github.io/swift-cluster-membership/docs/current/SWIM/Enums/SWIM.html for details of the SWIM implementation.
 
 ==== SWIM Failure Detection & Actor Cluster Membership
 
-The underlying SWIM implementation provides a weakly consistent view on the process group membership. In this context
-this means that we have some knowledge about the node, that was acquired by either communicating
-with the node directly, for example when initially connecting to the cluster, or because some other
-node shared information about it with us.
+The underlying SWIM implementation provides a weakly consistent view on the process group membership.
+In this context, this means that we have some knowledge about the node, acquired by either communicating with the node directly, for example when initially connecting to the cluster, or because some other node shared information about it with us.
 
-SWIM statuses are: `alive`, `suspect`, `unreachable` and `dead` (as seen in `SWIM.MemberStatus`). The `.unreachable` status is an extension to the protocol
-made in order to allow the high-level downing providers to participate in the downing decision. When a member is determined
-as should-be-dead by SWIM, an unreachability event is emitted by the SWIM subsystem. Such event is translated to a normal
-`Cluster.Event.reachabilityChange` event and emitted through the `cluster.events` api:EventStream[struct] where any actor
-can pick it up and react to it. One such actor is the downing provider which uses a <<downing_strategies, downing strategy>>
-to react to such membership changes. For example, a downing strategy may be configured to immediately trust such reachability change
-(to `.unreachable`) and announce such member as api:Cluster.MemberStatus[enum]`.down`.
+SWIM statuses are: `alive`, `suspect`, `unreachable` and `dead` (as seen in `SWIM.MemberStatus`).
+The `.unreachable` status is an extension to the protocol made in order to allow the high-level downing providers to participate in the downing decision.
+When a member is determined as should-be-dead by SWIM, an unreachability event is emitted by the SWIM subsystem.
+This event is translated to a normal `Cluster.Event.reachabilityChange` event and emitted through the `cluster.events` api:EventStream[struct] where any actor can pick it up and react to it.
+One such actor is the downing provider which uses a <<downing_strategies, downing strategy>> to react to such membership changes.
+For example, a downing strategy may be configured to immediately trust such reachability change (to `.unreachable`) and announce such member as api:Cluster.MemberStatus[enum]`.down`.
 
-Such "downing decision," is then propagated back to the SWIM implementation in the form of a `confirmDead(member:)` call,
-meaning that the member will now also be considered "dead" in SWIM terms and any attempts to communicate with it anymore will cease.
+The "downing decision" is then propagated back to the SWIM implementation in the form of a `confirmDead(member:)` call, meaning that the member will now also be considered "dead" in SWIM terms, and any attempts to communicate with it anymore will cease.
 
 In summary:
 
-- the SWIM implementation serves as a failure detector for the Actor Cluster,
-- `Cluster.Event` s allow actors to react in user-defined ways to changes of the cluster state,
-  - failure detectors emit `reachabilityChange` events which allow actors and downing strategies to act on them–regardless of what failure detector is being used.
-- configurable <<downing_strategies>> allow for taking high-level decisions about acting on failure detection provided information and performing `.down` actions,
-  - a downing strategy may also decide to _down itself_ when necessary, e.g. a strategy which opts for keeping a "larger reachable cluster part alive" etc.
+* The SWIM implementation serves as a failure detector for the Actor Cluster.
+* ``Cluster.Event``s allow actors to react in user-defined ways to changes of the cluster state.
+** Failure detectors emit `reachabilityChange` events which allow actors and downing strategies to act on them, regardless of the failure detector being used.
+* Configurable <<downing_strategies>> allow for taking high-level decisions about acting on failure detection provided information and performing `.down` actions.
+** A downing strategy may also decide to _down itself_ when necessary, e.g. a strategy which opts for keeping a "larger reachable cluster part alive," etc.
 
 All pieces of the system are user-configurable and can also be disabled and replaced with alternative implementations if necessary.

--- a/Docs/crdts.adoc
+++ b/Docs/crdts.adoc
@@ -2,79 +2,69 @@
 [[crdts]]
 == Distributed Data / CRDT
 
-> **C**onvergent **R**eplicated **D**ata **T**ypes are a category of data types that allow multiple peers to perform updates
-> concurrently, without coordination, yet guarantee that after merging the independently updated types, converge at a predictable end state.
+> **C**onvergent **R**eplicated **D**ata **T**ypes are a category of data types that allow multiple peers to perform updates concurrently, without coordination, yet guarantee that after merging the independently updated types, they converge at a predictable end state.
 
-Distributed Actors provides built-in <<crdt_types, data types>>, and <<direct_replication>> as well as <<gossip_replication>>
-mechanisms which simplify their use in an actor system by handling all their replication _transparently_.
+Distributed Actors provides built-in <<crdt_types, data types>>, and <<direct_replication>> as well as <<gossip_replication>> mechanisms which simplify their use in an actor system by handling all their replication _transparently_.
 
-CRDTs are a powerful building block for highly concurrent, distributed and--most interestingly--coordination-free systems.
-Using them it is possible to build offline-first client applications (which sync with CRDTs stored in backend systems or other devices),
-or coordination-free backend systems such that multiple servers can independently update data types without having to coordinate
-(e.g. via consensus protocols) whether or not an update is to be accepted or not.
+CRDTs are a powerful building block for highly concurrent, distributed and, most interestingly, coordination-free systems.
+Using them it is possible to build offline-first client applications (which sync with CRDTs stored in backend systems or other devices), or coordination-free backend systems such that multiple servers can independently update data types without having to coordinate (e.g. via consensus protocols) whether or not an update is to be accepted or not.
 
 CRDTs are https://en.wikipedia.org/wiki/Eventual_consistency[eventually consistent] meaning that they _eventually_ converge at a known expected result, intermediate states may be transiently globally inconsistent.
 This is a trade-off these data structures take - being the "flip side" of strongly consistent mechanisms such as distributed consensus algorithms (which do require the participation of a quorum of peers in order to accept writes).
 
-In other words, CRDTs are very useful in situations where eventual consistency, and perhaps offline/online and multiple-concurrent edits are to be permitted.
+In other words, CRDTs are very useful in situations where eventual consistency, and perhaps offline/online and multiple-concurrent edits, are to be permitted.
 
 TIP: For consistency-first use cases please reach out as we would like to provide implementations for consensus style Replicated State Machines in the future.
 
 WARNING: The current CRDT dissemination is only a stepping stone towards the real deal and still relies on full-state synchronization. +
 While correct, this incurs much more metadata and sending-known-data again than a fully delta-based replication engine. +
 Refer to <<crdt_caveats_limitations>> for more information on today's limitations and our plan moving forward. +
-Please do reach out if gossip / delta CRDT dissemination is of interest to you, and we'd prioritize this work.
-
-
+Please do reach out if gossip / delta CRDT dissemination is of interest to you, and we'll prioritize this work.
 
 === CRDT QuickStart
 
 TIP: QuickStarts are only a small "sneak peek" of a module.
-     For an in-depth discussion of the features, refer to the following documentation sections.
+For an in-depth discussion of the features, refer to the following documentation sections.
 
 ==== Step 0: CRDT types and semantics
 
-CRDTs are very useful category of data types in distributed systems. You may have already experienced them
-in action first hand, perhaps without even being aware of it.
+CRDTs are very useful category of data types in distributed systems.
+You may have already experienced them in action first hand, perhaps without even being aware of it.
 
 Refer to the <<crdt_types>> to understand more about the provided types and their semantics.
 
-For this quickstart, we'll use an "Observed Removed Set" api:CRDT.ORSet[enum], which is a fairly common CRDT
-and is already slightly more complex than the simplest datatype available (a Grow-only api:CRDT.GCounter[struct,nested_in=enum]).
+For this quickstart, we'll use an "Observed Removed Set" api:CRDT.ORSet[enum], which is a fairly common CRDT and is already slightly more complex than the simplest datatype available (a Grow-only api:CRDT.GCounter[struct,nested_in=enum]).
 
-An ORSet is able to handle additions and removals from the set, and in case a conflict is detected (i.e. multiple nodes
-performed an add and remove concurrently) the _add_ operation _wins_. These semantics are useful for situations when it is
-safer to err on keeping "more" information in the set than removing it.
+An ORSet is able to handle additions and removals from the set, and in case a conflict is detected (i.e. multiple nodes performed an add and remove concurrently) the _add_ operation _wins_.
+These semantics are useful for situations when it is safer to err on keeping "more" information in the set than removing it.
 
 ==== Step 1: "Owning" a CRDT
 
-In this example we'll build a _distributed shopping list_. Two actors will "own" (i.e. have a copy of) the shopping list
-and either may modify it by adding and checking off items from it as they go through the store buy the necessary things and perhaps remember what else they should buy.
+In this example we'll build a _distributed shopping list_.
+Two actors will "own" (i.e. have a copy of) the shopping list and either may modify it by adding and checking off items from it as they go through the store buying the necessary things and perhaps remember what else they should buy.
 
 In our example the actors could be thought of as actual _people_ doing their shopping in a store while updating their shopping list.
 As there may be many actors "sharing" the same shopping list CRDT there is a possibility that both of them perform updates to their copies of the shopping list "at the same time".
 Because they are shopping in different stores, and have not discussed with each other up-front whom should buy which items from the list, there is a possibility of overlapping updates.
 
-
 [source]
 ----
 include::{dir_sact_doc_tests}/CRDT/CRDTDocExamples.swift[tag=quickstart_owned_actorable]
 ----
-<1> Rather than creating a "plain" CRDT, we create an api:CRDT.ActorOwned[class,nested_in=enum] version of it,
-    which will handle all distribution aspects of writes and reads to it and its distributed counterparts.
+<1> Rather than creating a "plain" CRDT, we create an api:CRDT.ActorOwned[class,nested_in=enum] version of it, which will handle all distribution aspects of writes and reads to it and its distributed counterparts.
 
 ==== Step 2: Adding and "Checking off" items from the shopping list (Direct Replication)
 
-First, we'll need to populate our shopping list with some items. The actor can expose an actor function that when received
-will add given item to the list:
+First, we'll need to populate our shopping list with some items.
+The actor can expose an actor function that will add a given item to the list:
 
 [source]
 ----
 include::{dir_sact_doc_tests}/CRDT/CRDTDocExamples.swift[tag=quickstart_direct_write_add]
 ----
-<1> Similarity to a "normal" `Set`, we perform an `insert` operation on it.
+<1> Similar to a "normal" `Set`, we perform an `insert` operation on it.
 <2> Since the data type is distributed, we also specify to how many nodes the delta should be pushed immediately; here we picked "local" since we're simulating the offline and sync later case.
-<3> For _direct replication_ (which this operation is), we always specify an expected timeout, for when we expect all peers we write to to confirm those writes back.
+<3> For _direct replication_ (which this operation is), we always specify an expected timeout for when we expect all peers we write to to confirm those writes back.
 <4> Finally, the `insert` returned a write result that we can use to apply a callback to inspect if all targeted peers have confirmed the write or not (most useful in `.quorum` writes).
     🟢 _This callback is safe to access internal actor state._
 
@@ -85,18 +75,16 @@ The remove operation follows the same pattern:
 include::{dir_sact_doc_tests}/CRDT/CRDTDocExamples.swift[tag=quickstart_direct_write_remove]
 ----
 
-And similarity, we can provide `writeConsistency` which means to how many peer members in the cluster this write will be
-_directly_ ("right now") replicated to. To learn more about direct replication refer to the <<direct_replication>> section.
+And similarly, we can provide `writeConsistency` which means to how many peer members in the cluster this write will be _directly_ ("right now") replicated to.
+To learn more about direct replication refer to the <<direct_replication>> section.
 
 TIP: Such shopping list based on CRDTs will _not_ guarantee that the shoppers won't accidentally double-buy some items, the writes are replicated asynchronously after all.
-  The ORSet's semantics also mean, that if write conflicts were to happen, they are resolved by the "added" value winning, meaning that an item that an actor thought was removed
-  could appear again if another actor added it in the meantime. In the real world such trade-off is less harmful than accidentally removing an item after all -- the user can check off the item again if needed,
-  while a "remove" always winning could yield more confusing behavior. +
-  +
-  If we wanted to _guarantee_ that only a single shopper would buy a specific item, we would have to implement some form of coordination between them (most often via a form of consensus). +
+The ORSet's semantics also mean that if write conflicts were to happen they are resolved by the "added" value winning, meaning that an item that an actor thought was removed could appear again if another actor added it in the meantime.
+In the real world such trade-off is less harmful than accidentally removing an item -- the user can check off the item again if needed, while a "remove" always winning could yield more confusing behavior. +
+    +
+If we wanted to _guarantee_ that only a single shopper would buy a specific item, we would have to implement some form of coordination between them (most often via a form of consensus).
 
-Now that we implemented an actor which can add and check off items from its shopping list, let us spawn two actors (they could be located on different nodes) and have them independently
-add and remove some items from their respective owned shopping list instances as they perform their shopping tasks.
+Now that we've implemented an actor which can add and check off items from its shopping list, let us spawn two actors (they could be located on different nodes) and have them independently add and remove some items from their respective owned shopping list instances as they perform their shopping tasks.
 
 [source]
 ----
@@ -105,43 +93,35 @@ include::{dir_sact_doc_tests}/CRDT/CRDTDocExamples.swift[tag=quickstart_alice_bo
 
 ==== Step 3: Reacting to changes in the shopping list items (Gossip Replication)
 
-While the previous step already introduced some distributed replication, it was "direct" and not in the background.
-Meaning, the changes when we performed a write were replicated directly when we made the change, and specifically to at-least
-as many cluster members as we specified in the `writeConsistency`. In our example we wrote only locally, but in normal
-datacenter scenarios it is more usual to write to a quorum, for example like this:
+While the previous step already introduced some distributed replication, it was "direct" and not in the background, meaning the changes were replicated directly when we made the change, and specifically to at least as many cluster members as we specified in the `writeConsistency`.
+In our example we wrote only locally, but in normal datacenter scenarios it is more usual to write to a quorum, for example like this:
 
 [source]
 ----
 data.insert(element, writeConsistency: .quorum, timeout: .seconds(3))
 ----
 
-This is already better if we were an on-line replicated shopping list that replicates its in memory state to multiple nodes members, e.g. by using `.atLeast(2)` or `.quorum`.
-However it would not handle spreading the data to members which join the cluster at a later time, nor would it spread the information to any not-directly-written to members.
+This is already better if we were an on-line replicated shopping list that replicates its in-memory state to multiple nodes members, e.g. by using `.atLeast(2)` or `.quorum`.
+However, it would not handle spreading the data to members which join the cluster at a later time, nor would it spread the information to any not-directly-written to members.
 This is why _actor-owned_ CRDTs also automatically participate in Gossip Replication.
 
-Gossip Replication is a transparent, running in the background, process that runs on every node participating in a cluster (and using CRDTs) which ensures
-that all members (#TODO: with a given cluster role#) eventually get up-to-date with regards to the active data types.
+Gossip Replication is a transparent background process that runs on every node participating in a cluster (and using CRDTs), which ensures that all members (#TODO: with a given cluster role#) eventually get up-to-date with regards to the active data types.
 
-In our example, Alice and Bob only performed `.local` writes, which means their writes would not end up on each-others systems,
-unless gossip replication took them there (!). Local writes are a good way to see gossip replication do its magic - since we
-did not write to any other nodes, the only way those writes end up on other members is via gossip (which we will explore in depth in <<gossip_replication>>).
+In our example, Alice and Bob only performed `.local` writes, which means their writes would not end up on each-others systems unless gossip replication took them there (!).
+Local writes are a good way to see gossip replication do its magic - since we did not write to any other nodes, the only way those writes end up on other members is via gossip (which we will explore in depth in <<gossip_replication>>).
 
-In order to observe incoming writes to an api:CRDT.ActorOwned[class,nested_in=enum] CRDT, we can use the `ActorOwned.onUpdate` function to install a listener,
-which will be fired every time the CRDT experiences a change in its state (e.g. via direct, or gossip replication):
+In order to observe incoming writes to an api:CRDT.ActorOwned[class,nested_in=enum] CRDT, we can use the `ActorOwned.onUpdate` function to install a listener, which will be fired every time the CRDT experiences a change in its state (e.g. via direct, or gossip replication):
 
 [source]
 ----
 include::{dir_sact_doc_tests}/CRDT/CRDTDocExamples.swift[tag=quickstart_bob_onUpdate]
 ----
 
-This callback will be triggered every time the CRDT gets updated by remote (direct, or gossip) replication.
-It also works the same way if you have multiple actors owning the same CRDT identity in the same cluster member,
-which is useful for testing - there is no need to change your programming model at all between programming in a single process
-and programming a highly distributed deployment of the same CRDT and Actor based system.
+This callback will be triggered every time the CRDT gets updated by remote (direct or gossip) replication.
+It also works the same way if you have multiple actors owning the same CRDT identity on the same cluster member, which is useful for testing -- there is no need to change your programming model at all between a single process and a highly distributed deployment of the same CRDT and Actor based system.
 
-TIP: All callbacks on api:CRDT.ActorOwned[class,nested_in=enum] types are actor-concurrency-safe, meaning that they will be executed on the actor's context,
-and are guaranteed to not overlap with any other actor message handling. 🟢 In other words, they are completely thread safe and may
-access and modify the actor state without taking any locks or other means of synchronization.
+TIP: All callbacks on api:CRDT.ActorOwned[class,nested_in=enum] types are actor-concurrency-safe, meaning that they will be executed on the actor's context, and are guaranteed to not overlap with any other actor message handling.
+🟢 In other words, they are completely thread safe and may access and modify the actor state without taking any locks or other means of synchronization.
 
 Alternatively, there exist functions to _peek_ at an _actor-owned_ CRDT's last observed value:
 
@@ -150,135 +130,109 @@ Alternatively, there exist functions to _peek_ at an _actor-owned_ CRDT's last o
 include::{dir_sact_doc_tests}/CRDT/CRDTDocExamples.swift[tag=quickstart_peek_state]
 ----
 
-
 [[crdt_types]]
 === Built-in CRDT Types
 
 Distributed Actors comes with a number of pre-defined https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type#State-based_CRDTs[State-Based CRDT] types (also known as _CvRDTs_), such as:
 
-- Counters:
-  * Grow-only Counter api:CRDT.GCounter[struct,nested_in=enum]
-- Sets:
-  * Observed Removed Set api:CRDT.ORSet[struct,nested_in=enum]
-- Maps (Dictionaries):
-  * Observed Removed Map api:CRDT.ORMap[struct,nested_in=enum],
-  * Observed Removed MultiMap api:CRDT.ORMultiMap[struct,nested_in=enum] (a dictionary where values are of type `ORSet`),
-  * ⚠️ "Last Writer Wins" Map api:CRDT.LWWMAP[struct,nested_in=enum], which is wall-clock time sensitive and should be used only very infrequently
-- Registers:
-  * ⚠️ "Last Writer Wins" Register api:CRDT.LWWRegister[struct,nested_in=enum], which is wall-clock time sensitive and should be used only very infrequently
+* Counters:
+** Grow-only Counter api:CRDT.GCounter[struct,nested_in=enum]
+* Sets:
+** Observed Removed Set api:CRDT.ORSet[struct,nested_in=enum]
+* Maps (Dictionaries):
+** Observed Removed Map api:CRDT.ORMap[struct,nested_in=enum],
+** Observed Removed MultiMap api:CRDT.ORMultiMap[struct,nested_in=enum] (a dictionary where values are of type `ORSet`),
+** ⚠️ "Last Writer Wins" Map api:CRDT.LWWMAP[struct,nested_in=enum], which is wall-clock time sensitive and should be used only very infrequently
+*Registers:
+** ⚠️ "Last Writer Wins" Register api:CRDT.LWWRegister[struct,nested_in=enum], which is wall-clock time sensitive and should be used only very infrequently
 
 [[direct_replication]]
 === Direct Replication
 
-Direct replication is what happens when a write to an actor-owned CRDT is performed using the `write(writeConsistency:timeout:)`
-function, or its close cousins such as `ORSet.insert(:writeConsistency:timeout)` and similar.
+Direct replication is what happens when a write to an actor-owned CRDT is performed using the `write(writeConsistency:timeout:)` function, or its close cousins such as `ORSet.insert(:writeConsistency:timeout)` and similar.
 
 ==== Direct writes
 
 Direct replication allows performing immediate writes (sends of the CRDT change/delta) to remote peers.
 
-When a write is issued, e.g. by invoking `ownedSet.insert("apples", writeConsistency: .quorum, timeout: .seconds(3))`
-the system's direct replicator is notified about this action, informs all other actors on the same node which may be owning
-the CRDT identified with the same `CRDT.Identity` (which is assigned at creation time), and then proceeds to notify other nodes.
+When a write is issued, e.g. by invoking `ownedSet.insert("apples", writeConsistency: .quorum, timeout: .seconds(3))`, the system's direct replicator is notified about this action and informs all other actors on the same node which may be owning the CRDT identified with the same `CRDT.Identity` (which is assigned at creation time), and then proceeds to notify other nodes.
 
 The number of nodes the replicator contacts is configured by the `writeConsistency`: api:CRDT.OperationConsistency[enum] parameter.
-Refer to it's API documentation for detailed explanation of the consistency levels, however in general it simply translates to a
-number of peers that will be notified about the change _and acknowledge this write back_ to the originator of the write.
+Refer to its API documentation for detailed explanation of the consistency levels, however, in general it simply translates to a number of peers that will be notified about the change _and acknowledge this write back_ to the originator of the write.
 
-Once enough (e.g. `.quorum` or `.atLeast(2)`) acknowledgements have been received by the initiating direct replicator,
-it confirms the write as successful and the callback which can be assigned to the write's result is executed (🟢 `write.onComplete`).
-The `onComplete` is always safely executed on the owning actor's context, so you do not need to perform any additional synchronization
-and are free to modify the actor's internal state.
+Once enough (e.g. `.quorum` or `.atLeast(2)`) acknowledgements have been received by the initiating direct replicator, it confirms the write as successful and the callback assigned to the write's result is executed, if present (🟢 `write.onComplete`).
+The `onComplete` is always safely executed on the owning actor's context, so you do not need to perform any additional synchronization and are free to modify the actor's internal state.
 
-A common pattern includes performing a write to at least a few nodes, and replying to whichever task has kicked off this
-write once the `onComplete` triggers -- thanks to this we can be sure that the piece of information has been replicated to
-at least some peers already, and even if _this_ cluster member were to crash immediately after the data would remain in the cluster.
+A common pattern includes performing a write to at least a few nodes, and replying to whichever task has kicked off this write once the `onComplete` triggers -- thanks to this we can be sure that the piece of information has been replicated to at least some peers already, and even if _this_ cluster member were to crash immediately after, the data would remain in the cluster.
 
-NOTE: The current implementation does not persist the replicated data types, however this is another natural extension
-to the replicator in which the writes would only be confirmed once peers have stored them on disk or some other storage.
+NOTE: The current implementation does not persist the replicated data types, however, this is another natural extension to the replicator in which the writes would only be confirmed once peers have stored them on disk or some other storage.
 If this is a requirement for your use case, please get in touch and we can prioritize this work.
 
-Finally, as most tasks in Distributed Actors, an operation is bound by a timeout, after which the `onComplete` is triggered
-with a failure. The failure will include information about how many acknowledgements have been gathered, how many were missing (timed out),
-or perhaps if a write was incorrect because the identity did not match type-wise with the rest of the system. Do note however,
-that a write which was replicated to some (or even zero remote) peers, will still *eventually* spread to all nodes, thanks
-to the background actor which performs periodic gossip replication of all CRDTs.
+Finally, as with most tasks in Distributed Actors, an operation is bound by a timeout, after which the `onComplete` is triggered with a failure.
+The failure will include information about how many acknowledgements have been gathered, how many were missing (timed out), or perhaps if a write was incorrect because the identity did not match type-wise with the rest of the system.
+Do note, however, that a write which was replicated to some (or even zero remote) peers, will still *eventually* spread to all nodes, thanks to the background actor which performs periodic gossip replication of all CRDTs.
 
 All peers in a cluster participate in the dissemination of CRDTs.
-(#TODO: cluster roles can give fine grained control over this# More fine grained control is something we'd like to add, but is not implemented currently.)
+(More fine grained control is something we'd like to add, but is not implemented currently. #TODO: cluster roles can give fine grained control over this#)
 
 ==== Direct reads
 
-Similarity, one may perform a direct read, one may issue `read(atConsistency:timeout:)` which instructs
-the direct replicator to perform a read from as many peers as configured using the passed in api:CRDT.OperationConsistency[enum].
+Similarly, one may perform a direct read by issuing `read(atConsistency:timeout:)`, which instructs the direct replicator to perform a read from as many peers as configured using the passed in api:CRDT.OperationConsistency[enum].
 
-Direct reads can be useful to aggressively "refresh" the state of an actor owned CRDT, without having to wait for gossip
-replication to spread any new information to our node. Such read is of course not "transactional" as one might think about
-those in a traditional database, however thanks to the properties of CRDTs it has some useful benefits:
+Direct reads can be useful to aggressively "refresh" the state of an actor owned CRDT without having to wait for gossip replication to spread any new information to our node.
+This read is of course not "transactional," as one might think about those in a traditional database, but thanks to the properties of CRDTs it has some useful benefits:
 
-Given a 3 node cluster, of nodes `A`, `B` and `C` if node `A` performs a `.read(atConsistency: .all, timeout: .seconds(...))`,
-even if nodes `B` and `C` have their own local changes made to the CRDT the read from all will automatically gather them and
-_merge_ the CRDTs into one resulting value which is then passed as result to the `read`. In other words, the gathering and merging
-of CRDTs is done transparently and we can configure how many nodes we want to reach with such read.
+Given a 3 node cluster of nodes `A`, `B` and `C`, if node `A` performs a `.read(atConsistency: .all, timeout: .seconds(...))`, even if nodes `B` and `C` have their own local changes made to the CRDT the read from all will automatically gather them and _merge_ the CRDTs into one resulting value which is then passed as result to the `read`.
+In other words, the gathering and merging of CRDTs is done transparently and we can configure how many nodes we want to reach with such read.
 
-Quite often it is enough to read from just 2 or quorum of nodes, as the reads and nature of the CRDTs is eventually consistent in any case.
-A `.read(.all)` however can be useful if data is always written directly only locally, and gossip is taking care of its dissemination,
-however for some reason we'd like to increase the likelihood of seeing "recent" updates.
+Quite often it is enough to read from just 2 or a quorum of nodes, as the reads and nature of the CRDTs is eventually consistent in any case.
+A `.read(.all)`, however, can be useful if data is always written directly only locally and gossip is taking care of its dissemination, but for some reason we'd like to increase the likelihood of seeing "recent" updates.
 
 TIP: Usually performing operations at `.quorum` is a good default, unless you have other specific needs for the write's consistency.
 
 [[gossip_replication]]
 === Gossip Replication
 
-WARNING: The Gossip replicator implementation is still very much work in progress and today relies on full-state sync,
-  which is prohibitive for larger CRDT types. We have previous experience building gossip delta replicated systems, and the
-  current types will support it natively, however the replicator today has not been implemented to benefit from these yet.
-  *This is a matter of prioritization more than anything, if you have an use case for delta CRDTs in your project, please reach out.*
+WARNING: The Gossip replicator implementation is still very much work in progress and today relies on full-state sync, which is prohibitive for larger CRDT types.
+We have previous experience building gossip delta replicated systems, and the current types will support it natively, however, the replicator today has not been implemented to benefit from these yet.
+*This is a matter of prioritization more than anything.
+If you have a use case for delta CRDTs in your project, please reach out.*
 
-With https://en.wikipedia.org/wiki/Gossip_protocol[Gossip] Replication, clustered peers periodically exchange information
-and synchronize state of their owned CRDTs. This is done automatically and transparently in the background for _any_
-api:CRDT.ActorOwned[class,nested_in=enum]/api:CRDT.ActorableOwned[enum] CRDTs registered in the actor system.
+With https://en.wikipedia.org/wiki/Gossip_protocol[Gossip] Replication, clustered peers periodically exchange information and synchronize state of their owned CRDTs.
+This is done automatically and transparently in the background for _any_ api:CRDT.ActorOwned[class,nested_in=enum]/api:CRDT.ActorableOwned[enum] CRDTs registered in the actor system.
 
 The system runs a special actor called the gossip replicator which is responsible for synchronizing states of the owned CRDTs.
-Currently this replication is implemented in it's most naive form and has to gossip the entire payload to other peers,
-when a peer notices it is not up-to date with another's state. #TODO: This is not the final implementation of gossip replication
-and we will eventually implement delta-replication which the CRDT types themselves are already prepared for.#
+Currently this replication is implemented in it's most naive form and has to gossip the entire payload to other peers when it notices that it is not up-to date with another's state.
+#TODO: This is not the final implementation of gossip replication and we will eventually implement delta-replication which the CRDT types themselves are already prepared for.#
 
-In general, without diving into the dissemination protocol details, gossip replication means that even a `.local` write
-eventually ends up visible on _all_ cluster members. The exact timing of when it is going to be visible is not strongly guaranteed,
-but generally is an function of the cluster size, and gossip interval configuration (which can be set in the system's settings).
+In general, without diving into the dissemination protocol details, gossip replication means that even a `.local` write eventually ends up visible on _all_ cluster members.
+The exact timing of when it is going to be visible is not strongly guaranteed, but generally is an function of the cluster size and gossip interval configuration (which can be set in the system's settings).
 
-TIP: Currently CRDTs are shared between all members of a cluster. Once cluster nodes gain "roles" it will be possible to
-  control which members should participate in the replication of a specific CRDT. E.g. only "game-play" nodes need to host
-  values relating to any game-play related things or similar. See: https://github.com/apple/swift-distributed-actors/issues/636
+TIP: Currently CRDTs are shared between all members of a cluster.
+Once cluster nodes gain "roles" it will be possible to control which members should participate in the replication of a specific CRDT, e.g. only "game-play" nodes need to host values relating to any game-play related things or similar.
+See: https://github.com/apple/swift-distributed-actors/issues/636
 
 [[crdt_caveats_limitations]]
 === Caveats and Limitations of Work-in-Progress implementation
 
-The present implementation of the CRDT dissemination should be treated as a work-in-progress that semantically works,
-however is insufficient for larger workloads and/or clusters. Please get in touch if CRDTs in Swift and on the server are
-of interest to you so we can re-prioritize this work.
+The present implementation of the CRDT dissemination should be treated as a work-in-progress that semantically works, but is insufficient for larger workloads and/or clusters.
+Please get in touch if CRDTs in Swift and on the server are of interest to you so we can re-prioritize this work.
 
-Today's implementation is limited in the sense that it relies on full-state sync, which will exponentially grow metadata
-and payload sizes of messages used to spread the CRDT in a cluster which has adverse effects on the rest of the system
-as well as message throughput.
+Today's implementation is limited in the sense that it relies on full-state sync, which will exponentially grow metadata and payload sizes of messages used to spread the CRDT in a cluster, which has adverse effects on the rest of the system as well as message throughput.
 
-Roughly, for direct replication today you can expect a few millisecond round trips for direct replication.
-The writes are performed in parallel to all targets of a write, once all writes are acknowledged the write is completed.
-The gossip replication takes place in the background, as configured in `settings.crdt.gossipInterval` (defaults to `.seconds(2)`,
-with some noise to avoid all peers gossiping in the same moment). The gossip replicator is aware which peers have been contacted directly
-and avoids targeting them. The gossip replication currently shares the full states, and stops gossiping a payload (CRDT identity),
-once it has seen a peer spread the same payload it owns - this is naive, and what we aim to improve in the follow up work).
+Roughly, today you can expect a few millisecond round trips for direct replication.
+Writes are performed in parallel to all targets, and once all writes are acknowledged the write is completed.
+The gossip replication takes place in the background, as configured in `settings.crdt.gossipInterval` (defaults to `.seconds(2)`, with some noise to avoid all peers gossiping in the same moment).
+The gossip replicator is aware of which peers have been contacted directly and avoids targeting them.
+The gossip replication currently shares the full states, and stops gossiping a payload (CRDT identity) once it has seen a peer spread the same payload it owns -- this is naive, and what we aim to improve in the follow up work.
 
-The payloads are serialized using protocol buffers, though since the full state is synchronized they can end up quite large as well,
-in situations spreading 2 writes each between 10 nodes, the metadata _today_ can reach a few kb. We understand this is not acceptable,
-and there are specific tickets to address this, including a more compact actor/owner representation (single number, rather than complete address string, repeated multiple times in the metadata).
+The payloads are serialized using protocol buffers, though since the full state is synchronized they can end up quite large as well.
+In situations spreading 2 writes each between 10 nodes the metadata _today_ can reach a few kb.
+We understand this is not acceptable, and there are specific tickets to address this, including a more compact actor/owner representation (single number, rather than complete address string, repeated multiple times in the metadata).
 
 Most notable tickets to resolve:
 
-- https://github.com/apple/swift-distributed-actors/issues/628[CRDT: Update CRDT.GossipLogic to be Delta aware #628],
-  matters the most our of all remaining work; this enables the underlying delta infrastructure to be actually used for replication. This is the main remaining task.
-- https://github.com/apple/swift-distributed-actors/issues/629[CRDT: Implement flushDelay #629], matters for less churn locally when
-  lots of updates are performed;
-- https://github.com/apple/swift-distributed-actors/pull/650[CRDT Replicator: chunking updates #426], matters for new nodes joining
-  so even though they'd need the "full state" to be sent, we don't necessarily have to send it in one huge message, but we can chunk it up.
+* https://github.com/apple/swift-distributed-actors/issues/628[CRDT: Update CRDT.GossipLogic to be Delta aware #628], matters the most of all remaining work; this enables the underlying delta infrastructure to be actually used for replication.
+    This is the main remaining task.
+* https://github.com/apple/swift-distributed-actors/issues/629[CRDT: Implement flushDelay #629], matters for less churn locally when lots of updates are performed;
+* https://github.com/apple/swift-distributed-actors/pull/650[CRDT Replicator: chunking updates #426], matters for new nodes joining so even though they'd need the "full state" to be sent, we don't necessarily have to send it in one huge message, but we can chunk it up.

--- a/Docs/examples.adoc
+++ b/Docs/examples.adoc
@@ -14,33 +14,33 @@ The 5 philosophers are competing for 5 shared forks so they can have their meal 
 
 The problem's solution is implemented using actors representing both the forks and philosophers.
 
-See example code here: https://github.com/apple/swift-distributed-actors/tree/master/Sources/Swift Distributed ActorsSampleDiningPhilosophers[Sources/Swift Distributed ActorsSampleDiningPhilosophers]
+See example code here: https://github.com/apple/swift-distributed-actors/tree/main/Samples/Sources/SampleDiningPhilosophers[Samples/Sources/SampleDiningPhilosophers]
 
 Run it by:
 
 [source]
 ----
-git clone https://github.com/apple/swift-distributed-actors
-cd sact
-swift run Swift Distributed ActorsSampleDiningPhilosophers
+git clone https://github.com/apple/swift-distributed-actors sact
+cd sact/Samples
+swift run SampleDiningPhilosophers
 ----
 
 
 === Distributed Dining Philosophers
 
-Same as the normal dining philosophers example, however differing in the set-up step: this time the philosophers and forks
-are distributed across a number of nodes. Thus some philosophers have an advantage in reaching for forks, since they only
-have to message the forks locally! Will any of the philosophers starve? Run the examples to find out.
+Same as the normal dining philosophers example, however differing in the set-up step: this time the philosophers and forks are distributed across a number of nodes, thus some philosophers have an advantage in reaching for forks since they only have to message the forks locally!
+Will any of the philosophers starve?
+Run the examples to find out.
 
-See example code here: https://github.com/apple/swift-distributed-actors/tree/master/Sources/Swift Distributed ActorsSampleDiningPhilosophers[Sources/Swift Distributed ActorsSampleDiningPhilosophers]
+See example code here: https://github.com/apple/swift-distributed-actors/tree/main/Samples/Sources/SampleDiningPhilosophers[Samples/Sources/SampleDiningPhilosophers]
 
 Run it by:
 
 [source]
 ----
-git clone https://github.com/apple/swift-distributed-actors
-cd sact
-swift run Swift Distributed ActorsSampleDiningPhilosophers dist
+git clone https://github.com/apple/swift-distributed-actors sact
+cd sact/Samples
+swift run SampleDiningPhilosophers dist
 ----
 
 === Full-blown Examples ✗

--- a/Docs/failure_handling.adoc
+++ b/Docs/failure_handling.adoc
@@ -4,25 +4,22 @@
 > Let it Crash!
 
 Failures in distributed systems are common, and one has to design such systems to be resilient to failures.
-Thankfully actors make this task much simpler, as all kinds of failures are unified into termination events, to which one can react to.
+Thankfully actors make this task much simpler, as all kinds of failures are unified into termination events which one can react to.
 
 === Letting it Crash!
 
-The simplest way to explain failure handling with Actors is the _"Let it Crash!"_ motto. It means that rather than trying to
-continue running in a (potentially) faulty state, the actor that ended up in some "wrong" state is meant to crash,
-and the system shall react to this by providing compensating actions. This model is simple at its core, but can be
-surprisingly powerful and liberating when applied to concurrent or distributed systems.
+The simplest way to explain failure handling with Actors is the _"Let it Crash!"_ motto.
+It means that rather than trying to continue running in a (potentially) faulty state, the actor that ended up in some "wrong" state is meant to crash, and the system shall react to this by providing compensating actions.
+This model is simple at its core, but can be surprisingly powerful and liberating when applied to concurrent or distributed systems.
 
-NOTE: Failure handling in actors leans itself more towards handling "panics" (drives, connections or databases failing)
-      rather than errors which may be used for flow control, such as validation errors and similar. +
+NOTE: Failure handling in actors leans itself more towards handling "panics" (drives, connections or databases failing) rather than errors which may be used for flow control, such as validation errors and similar. +
       +
-      Continue using familiar Swift mechanism such as `try/throws`, `Error` and `Result` to handle errors which can be accounted for,
-      and rely on actor supervision and isolation for "unrecoverable" or "unpredicted" failures.
+Continue using familiar Swift mechanism such as `try/throws`, `Error` and `Result` to handle errors which can be accounted for, and rely on actor supervision and isolation for "unrecoverable" or "unpredicted" failures.
 
 In this chapter we will learn about <<actor_supervision>> and the various <<failure_isolation>> offered by this library.
 
-- By using <<actor_supervision>> it is possible to automate some of the otherwise mundane tasks of restarting with fresh state or backing off a few seconds before attempting to resume processing of messages.
-- And by utilizing some of the built-in stronger isolation capabilities it is possible to isolate and deal with even faults such as fatalErrors, or node failures in a clustered environment.
+* By using <<actor_supervision>> it is possible to automate some of the otherwise mundane tasks of restarting with fresh state or backing off a few seconds before attempting to resume processing of messages.
+* By utilizing some of the built-in stronger isolation capabilities it is possible to isolate and deal with even such faults as fatalErrors, or node failures in a clustered environment.
 
 [[supervision_vocabulary]]
 === Failure Vocabulary
@@ -30,47 +27,46 @@ In this chapter we will learn about <<actor_supervision>> and the various <<fail
 Before we explain the mechanisms available to handle failures, we first need to define a shared vocabulary that we will use while discussing these.
 Since there are various "types" of failure conditions, we want to be as specific as possible when discussing them.
 
-* *Error* as in "throw an error" - the classic meaning of "error" in Swift, which is bound to the `Error` type.
-** Examples: any `Error` that is `throw`n from inside of a Swift function.
-* *Fault* as in "faulty operation" - are most types of faults that Swift does not expose as Errors but would normally
-  result in terminating the entire process.
-** Examples: array-out-of-bounds access, forced `nil` unwrapping, division by zero, as well as calls to `fatalError`.
-* *Failure* - is the term Swift Distributed Actors uses to classify either an Error or Fault, as supervision works for both classes of failures.
-** Examples: either a Fault or an Error.
+Error:: As in "throw an error".
+    The classic meaning of "error" in Swift, which is bound to the `Error` type. +
+    Examples: any `Error` that is ``throw``n from inside of a Swift function.
+
+Fault:: As in "faulty operation".
+    The most types of faults that Swift does not expose as Errors but would normally result in terminating the entire process. +
+    Examples: array-out-of-bounds access, forced `nil` unwrapping, division by zero, as well as calls to `fatalError`.
+
+Failure:: The term Swift Distributed Actors uses to classify either an Error or Fault, as supervision works for both classes of failures. +
+    Examples: either a Fault or an Error.
 
 Summing up: any `Error` or _fault_ is a kind of _failure_.
 
-TIP: This wording is also in alignment with Swift's own https://github.com/apple/swift/blob/master/stdlib/public/core/Result.swift[`Result`] type,
-     where failed case is called `failure` and carries an `Error` instance.
+TIP: This wording is also in alignment with Swift's own https://github.com/apple/swift/blob/master/stdlib/public/core/Result.swift[`Result`] type, where failed case is called `failure` and carries an `Error` instance.
 
-Further more, you can expect see phases involving the word "crash". We use this word to mean a "stop" result of failure
-handling or a failure causing the stopping of an entire node. The wording should usually classify what the subject of the
-crash was, e.g. _"the system crashed"_ or _"the request handler (actor) crashed."_
+Further more, you can expect see phases involving the word "crash".
+We use this word to mean a "stop" result of failure handling or a failure causing the stopping of an entire node.
+The wording should usually classify what the subject of the crash was, e.g. _"the system crashed"_ or _"the request handler (actor) crashed."_
 
 [[actor_supervision]]
 === Actor Supervision
 
-> Supervision allows actors to isolate failures and optionally restart by clearing their state and continuing to process
-their mailbox while retaining their identity.
+> Supervision allows actors to isolate failures and optionally restart by clearing their state and continuing to process their mailbox while retaining their identity.
 
-Actor supervision is a mechanism using which whoever is starting an actor (most often, its parent) can define
-how the actor should handle failures if they occur.
+Actor supervision is a mechanism allowing whoever starts an actor (most often, its parent) to define how the actor should handle failures if they occur.
 
 Supervision is configured using api:Props[struct] (see <<props>>), and as such can only be set while starting an actor.
 
-Typically one would decide while starting an actor what supervision mechanism to apply to it, as it depends on the parents
-requirements and expectations of the to-be-started actor. Alternatively, the actor itself may want to suggest `props`
-to whomever is going to start it -- this pattern is explained in more depth in the <<suggested_props_pattern>>.
+Typically one would decide while starting an actor what supervision mechanism to apply to it, as it depends on the parents requirements and expectations of the to-be-started actor.
+Alternatively, the actor itself may want to suggest `props` to whomever is going to start it -- this pattern is explained in more depth in the <<suggested_props_pattern>>.
 
-The following snipped showcases how one can step by step prepare a props with a api:SupervisionStrategy[enum]`.restart`:
+The following snippet showcases how one can step-by-step prepare a `props` instance with a api:SupervisionStrategy[enum]`.restart`:
 
 [source]
 ----
 include::{dir_sact_doc_tests}/SupervisionDocExamples.swift[tag=supervise_props]
 ----
-<1> Create a new `Props` instance
-<2> Configure it by adding supervision strategies
-<3> Pass it as `props:` while spawning an actor
+<1> Create a new `Props` instance.
+<2> Configure it by adding supervision strategies.
+<3> Pass it as `props:` while spawning an actor.
 
 Alternatively, it is possible to to define the supervision props in-line, using the following short-hand syntax:
 
@@ -80,32 +76,29 @@ include::{dir_sact_doc_tests}/SupervisionDocExamples.swift[tag=supervise_inline]
 ----
 <1> Adding a single supervision strategy to the greeter actor in-line.
 
-In both cases, the `addSupervision(strategy:)` results in creating a simple catch-all supervision strategy which will
-be triggered for all kind of failures. It is possible to specific in more detail _which_ kinds of failures we are interested
-in supervising, as well defining a number of supervisors for different failure types. These more advanced supervision
-options are explained in depth in <<specific_failure_supervision>>.
+In both cases, the `addSupervision(strategy:)` results in creating a simple catch-all supervision strategy which will be triggered for all kind of failures.
+It is possible to specify in more detail _which_ kinds of failures we are interested in supervising, as well define a number of supervisors for different failure types.
+These more advanced supervision options are explained in depth in <<specific_failure_supervision>>.
 
 TIP: It is only possible to supervise code running "inside" of an actor. +
-     If you schedule some asynchronous operation onto a different thread from within the actor,
-     that failure is unlikely to return to the actor and make it fail. Be aware of this while integrating actors with other APIs.
+     If you schedule some asynchronous operation onto a different thread from within the actor, that failure is unlikely to return to the actor and make it fail.
+     Be aware of this while integrating actors with other APIs.
 
 ==== Supervision: Simple Error Handling Example
 
-Before explaining in depth the semantics of the various supervision strategies, we can already try out.
+Before explaining in depth the semantics of the various supervision strategies, we can try one out.
 We define a simple greeter actor which will greet persons it knows, however if it gets a name it does not
 recognize it throws an `Error.`
 
-NOTE: In reality such logic would be better served by explicit error handling rather than
-      allowing the actor failure handling to kick in, but sometimes it can be useful to implement even such simple things
-      as actors thanks to the restart mechanism they provide.
+NOTE: In reality such logic would be better served by explicit error handling rather than allowing the actor failure handling to kick in, but sometimes it can be useful to implement even such simple things as actors thanks to the restart mechanism they provide.
 
-.Messages and behavior
+`.Messages` and behavior
 [source]
 ----
 include::{dir_sact_doc_tests}/SupervisionDocExamples.swift[tag=supervise_full_example]
 ----
 
-.Spawning and interacting with a .restart supervised actor:
+`.Spawning` and interacting with a `.restart` supervised actor:
 [source]
 ----
 include::{dir_sact_doc_tests}/SupervisionDocExamples.swift[tag=supervise_full_usage]
@@ -129,17 +122,14 @@ The above snippet would yield the following log output (with logLevel set to `IN
 // we have to set table mode again, as it is friendlier for copy/paste
 :pygments-linenums-mode: table
 
-The above example log contains all the information regarding the failure: what was thrown, which actor has failed, which
-supervisor has handled this failure as well as its state and supervision result, which in this case is a restart of the actor.
-Following a restart, the actor can seamlessly continue processing messages of its mailbox -- this means, that even if the
-mailbox already contained the next `"Bob"` message it would _not_ be dropped due to the restart. Additionally, the api:ActorRef[struct]
-remains valid and other actors can continue to send messages to it, as if nothing ever happened.
+The above example log contains all the information regarding the failure: what was thrown, which actor has failed, which supervisor has handled this failure as well as its state and supervision result, which in this case is a restart of the actor.
+Following a restart, the actor can seamlessly continue processing messages of its mailbox -- this means, that even if the mailbox already contained the next `"Bob"` message it would _not_ be dropped due to the restart.
+Additionally, the api:ActorRef[struct] remains valid and other actors can continue to send messages to it, as if nothing ever happened.
 
-Internally however the greeter's state has been "reset" during a restart -- it started anew using the initial behavior
-that was originally used to start it. This is a safe way of restarting actors in a general fashion #TODO: if we solve the leaks#,
-as it may upon a restart recover other "good state" it may want to use for its functioning. Actors are _not_ allowed to assume that
-nothing bad happened to the state and just continue with the now potentially corrupt state -- this is core to the "Let it Crash!"
-philosophy. We focus on crashing and recovering, rather than continuing in "maybe good, maybe not" state.
+Internally however the greeter's state has been "reset" during a restart -- it started anew using the initial behavior that was originally used to start it.
+This is a safe way of restarting actors in a general fashion #TODO: if we solve the leaks#, as it may upon a restart recover other "good state" it may want to use for its functioning.
+Actors are _not_ allowed to assume that nothing bad happened to the state and just continue with the now potentially corrupt state -- this is core to the "Let it Crash!" philosophy.
+We focus on crashing and recovering, rather than continuing in "maybe good, maybe not" state.
 
 #TODO: it did not contain which message caused the failure, which should be added automatically by Swift Distributed Actors in case it is not obvious#
 
@@ -148,53 +138,54 @@ philosophy. We focus on crashing and recovering, rather than continuing in "mayb
 
 Actor systems allow you to isolate failure in various levels, of both "effort" and amount of achieved isolation / safety.
 
-NOTE: Failure isolation across nodes is simple, as such processes by design do not share memory and only communicate
-using messages over the network, the failure of one component is already isolated thanks to the network boundary. +
-      +
-      We do however have the ability to detect and react to node failures, which we'll discuss in the <<cluster>> section of the guide.
+NOTE: Failure isolation across nodes is simple, as such processes by design do not share memory and only communicate using messages over the network, the failure of one component is already isolated thanks to the network boundary. +
+    +
+    We do, however, have the ability to detect and react to node failures, which we'll discuss in the <<cluster>> section of the guide.
 
 ==== Thread Isolation (Default)
 
 [cols="15,10,75"]
 |===
 
-h| When to use     2.+| Always; Always-on and complementary to other modes.
+h| When to use      2.+| Always; Always-on and complementary to other modes.
 
-.2+<.^h| Isolation   s| Failure  | Errors are handled by the offending actor's supervision strategy, or its parent if escalated. Faults are not isolated.
+.2+<.^h| Isolation    s| Failure    | Errors are handled by the offending actor's supervision strategy, or its parent if escalated.
+    Faults are not isolated.
 
-                     s| Memory   | By convention actors _SHOULD NOT_ share any mutable state with eachother as it may result in concurrent access violations.
+                      s| Memory     | By convention actors _SHOULD NOT_ share any mutable state with eachother as it may result in concurrent access violations.
 
-h| Effort          2.+| None
+h| Effort           2.+| None
 |===
 
 By design an actor is always ensured to "own" a thread during its execution, however no further isolation (of heap, nor otherwise) is currently provided.
 
-By convention, actors MUST NOT share mutable state between one another, as this breaks the underlying core assumption that an actor "owns" all of its state,
-and communicates with others only via (immutable) messages. It is highly recommended to achieve defacto isolation of state
+By convention, actors MUST NOT share mutable state between one another, as this breaks the underlying core assumption that an actor "owns" all of its state, and communicates with others only via (immutable) messages.
+It is highly recommended to achieve defacto isolation of state.
 
-NOTE: Swift currently does not allow for stronger forms of isolation of faults. +
-      But if it did, the actor model's failure handling extends nicely over to isolating faults "in a specific actor."
+NOTE: Swift currently does not allow for stronger forms of isolation of faults, but if it did the actor model's failure handling extends nicely over to isolating faults "in a specific actor."
 
 ==== (Managed) Process Isolation
 
 [cols="15,10,75"]
 |===
 
-h| When to use      2.+| To isolate groups of actors from faults, including Swift fatal errors, or even unsafe (objective-)C code interop.
+h| When to use      2.+| To isolate groups of actors from faults, including Swift fatal errors, or even unsafe (Objective-)C code interop.
 
-.2+<.^h| Isolation    s| Failure  | Errors and Faults (!), are isolated at the process boundary. Errors may be escalated to Guardian actors and cause a system re-spawn when needed.
+.2+<.^h| Isolation    s| Failure    | Errors and Faults (!), are isolated at the process boundary.
+Errors may be escalated to Guardian actors and cause a system re-spawn when needed.
 
-                      s| Memory   | Same as parent/child-process isolation. Memory leaks or corruption within child do not affect parent or other nodes directly (though may cause resource exhaustion of host).
+                      s| Memory     | Same as parent/child-process isolation.
+                      Memory leaks or corruption within child do not affect parent or other nodes directly (though may cause resource exhaustion of host).
 
-h| Effort           2.+| Low/Medium; The bootstrap of your application MUST be handled within <<process_isolated>>. See #TODO NIO example# how to use with Swift NIO.
+h| Effort           2.+| Low/Medium; The bootstrap of your application MUST be handled within <<process_isolated>>.
+See #TODO NIO example# how to use with Swift NIO.
 
 h| Security note    2.+| *This is NOT a security feature.* No protection from actively malicious code is achieved by this approach.
-                         It can protect from faulty code and memory leaks leaks and issues in unsafe, but not from malicious code.
+It can protect from faulty code and memory leaks leaks and issues in unsafe, but not from malicious code.
 |===
 
-Managed process isolation, using <<process_isolated>>, allows the the actor system to automatically manage processes on your behalf,
-and enables deploying actors onto specific sub-processes forming failure domains, as well as allowing for automatic supervision
-of those processes. See <<process_isolated>> for an in depth guide for setting up a process isolated actor system.
+Managed process isolation, using <<process_isolated>>, allows the the actor system to automatically manage processes on your behalf, and enables deploying actors onto specific sub-processes forming failure domains, as well as allowing for automatic supervision of those processes.
+See <<process_isolated>> for an in depth guide for setting up a process isolated actor system.
 
 ==== Node Isolation
 
@@ -203,25 +194,25 @@ of those processes. See <<process_isolated>> for an in depth guide for setting u
 
 h| When to use      2.+| To be resilient against node failure, or scale out; Isolate nodes by means of network between them.
 
-.2+<.^h| Isolation    s| Failure  | Complete; A separate node (e.g. on different host) is completely isolated from any other node, and can not cause issue to other nodes, other than being detected as down.
+.2+<.^h| Isolation    s| Failure    | Complete; A separate node (e.g. on different host) is completely isolated from any other node, and can not cause issue to other nodes, other than being detected as down.
 
-                      s| Memory   | Complete (by means of network)
+                      s| Memory     | Complete (by means of network)
 
-h| Effort           2.+| Low/Medium; The bootstrap of your application MUST be handled within <<process_isolated>>. See #TODO NIO example# how to use with Swift NIO.
+h| Effort           2.+| Low/Medium; The bootstrap of your application MUST be handled within <<process_isolated>>.
+See #TODO NIO example# how to use with Swift NIO.
 |===
 
-By scaling out an actor system to multiple hosts, one is able to build resilient fault tolerant systems, that even in case of an entire node terminating can continue to function.
-The down side is the operational cost of having to worry about multiple hosts, however this cost can often be mitigated by automating host or node restarts with external cluster orchestrators such as kubernetes or similar.
+By scaling out an actor system to multiple hosts, one is able to build resilient fault tolerant systems that even in case of an entire node terminating can continue to function.
+The down side is the operational cost of having to worry about multiple hosts, however, this cost can often be mitigated by automating host or node restarts with external cluster orchestrators such as kubernetes or similar.
 
 Failure detection in clustered mode is handled by a distributed failure detector (see <<SWIM>>) and has an inherent timing aspect to it.
-However, even though nodes may be distributed, all the same <<death_watch>> mechanisms as worked locally work the exact same way within the clustered system.
+Even though nodes may be distributed, all the same <<death_watch>> mechanisms available locally work in the exact same way within the clustered system.
 
 [[supervision_strategies]]
 === Supervision Strategies
 
-As shown in the previous section, actors can be supervised by applying specific props settings to them at spawn-time.
-In a later section <<death_watch, Death Watch>> is introduced, which allows for more freedom with regards to observing actors for failure,
-however does not allow for identity preserving restarts of failing actors.
+As shown in the previous section, actors can be supervised by applying specific `props` settings to them at spawn-time.
+In a later section <<death_watch, Death Watch>> is introduced, which allows for more freedom with regards to observing actors for failure, however, does not allow for identity preserving restarts of failing actors.
 
 Swift Distributed Actors provides a number of built in supervision strategies to choose from (see api:SupervisionStrategy[enum]).
 
@@ -230,10 +221,9 @@ Swift Distributed Actors provides a number of built in supervision strategies to
 
 > Logs failure and crashes the given actor immediately.
 
-One can think of any actor being automatically supervised with the strategy `.stop`, as it deals with fault isolation and
-stops the failing actor unconditionally in case of any failure.
+One can think of any actor being automatically supervised with the strategy `.stop`, as it deals with fault isolation and stops the failing actor unconditionally in case of any failure.
 
-For now let's see how we could configure an actor to restart a few times, if it encountered a failure:
+For now let's see how we could configure an actor to restart a few times if it encountered a failure:
 
 [[supervision_restart]]
 ==== Supervision Strategy: `.restart(atMost:within:)`
@@ -249,21 +239,19 @@ For now let's see how we could configure an actor to restart a few times, if it 
 
 #TODO: better docs or point to API docs?#
 
-One of the more advanced strategies is restarting with backoff. The term backoff here means that after a failure,
-the actor will remain "alive" however it will not be restarted until a certain amount of time has passed -- the backoff time.
+One of the more advanced strategies is restarting with backoff.
+The term backoff here means that after a failure, the actor will remain "alive" but will not be restarted until a certain amount of time has passed -- the backoff time.
 
-This strategy is useful for situations where rapid restarts (as they are by default) are not a good idea, and could
-potentially even be harmful to the system.
+This strategy is useful for situations where rapid restarts (as they are by default) are not a good idea, and could potentially even be harmful to the system.
 
 #TODO implement and document completely#
 
-An example of where supervision _without_ backoff is even harmful includes situations where e.g. database goes down, and all actors crash and repeatedly try to re-establish the connection).
+An example of where supervision _without_ backoff is even harmful includes situations such as a database goes down and all actors crash and repeatedly try to re-establish the connection).
 
 [[supervision_escalate]]
 ==== Supervision Strategy: `.escalate`
 
 #TODO: better docs or point to API docs?#
-
 
 [[supervision_tree]]
 === Supervision Hierarchies
@@ -271,10 +259,9 @@ An example of where supervision _without_ backoff is even harmful includes situa
 #TODO: write this#
 
 Actors live and die in a strict hierarchy, the so-called _Actor Hierarchy_ or _Supervision Tree_ which groups actors using parent-child relationships.
-Parent actors enjoy some special privileges with regards to being able to select and react to their children's failures,
-including (when using `.escalate` supervision) being able to inspect the cause of a child actor's failure.
+Parent actors enjoy some special privileges with regards to being able to select and react to their children's failures, including (when using `.escalate` supervision) being able to inspect the cause of a child actor's failure.
 
-Other actors - be it siblings or other completely unrelated actors - may only _watch_ a given actor for termination.
+Other actors, be it siblings or other completely unrelated actors, may only _watch_ a given actor for termination.
 
 This leads to the formation of so-called supervision hierarchies or supervision "trees".
 It also allows us to structure our applications in ways that represent their _fault domains_.
@@ -285,61 +272,50 @@ image::actor_tree.png[]
 
 ==== Escalating Failures
 
-The `.escalate` supervision strategy deserves a bit more discussion as it fulfils the useful pattern of escalating ("bubbling up")
-failures up a supervision tree until an actor prevents it from escalating.
+The `.escalate` supervision strategy deserves a bit more discussion as it fulfils the useful pattern of escalating ("bubbling up") failures up a supervision tree until an actor prevents it from escalating.
 
-WARNING: If such escalation is not stopped at any level and reaches a guardian actor (e.g. `/user`, or `/system`),
-         it will react by performing the action configured in api:ActorSystemSettings[struct]`.failure.onGuardianFailure`,
-         which may result in shutting down the actor system, or forcefully exiting the process.
-
+WARNING: If such escalation is not stopped at any level and reaches a guardian actor (e.g. `/user`, or `/system`), it will react by performing the action configured in api:ActorSystemSettings[struct]`.failure.onGuardianFailure`, which may result in shutting down the actor system, or forcefully exiting the process.
 
 [[death_watch]]
 === Death Watch and Terminated signals
 
-While supervision is very powerful, it is also (by design) limited to parent-child relationships. This is in order to simplify
-supervision schemes and confine them to _supervision trees_, where parent actors define the supervision scheme of their children,
-when they spawn them. In that sense, supervision strategies are part of the actor itself, rather than the parent. However,
-the parent is the place where this supervision is selected, as well as any parent being automatically terminations of their children.
+While supervision is very powerful, it is also (by design) limited to parent-child relationships.
+This is in order to simplify supervision schemes and confine them to _supervision trees_, where parent actors define the supervision scheme of their children when they spawn them.
+In that sense, supervision strategies are part of the actor itself, rather than the parent.
+However, the parent is the place where this supervision is selected, and terminating a parent will automatically terminate its children.
 
-While supervision is enforced in _tree_ hierarchies, the _watch_ ("death watch") feature lifts this restriction,
-and any actor may `context.watch()` any other actor it has a reference to. Death watch however does not enable the watchee
-to take any part in the watched actors lifecycle, other than being notified when the watched actor has terminated (either
-by stopping gracefully, or crashing).
+While supervision is enforced in _tree_ hierarchies, the _watch_ ("death watch") feature lifts this restriction, and any actor may `context.watch()` any other actor it has a reference to.
+Death watch however does not enable the watchee to take any part in the watched actors lifecycle, other than being notified when the watched actor has terminated (either by stopping gracefully or crashing).
 
-Once an actor is watched, its termination will result in the watching actor receiving a api:Signals.Terminated[enum]
-signal, which may be handled using `Behavior.receiveSignal` or `Behavior.receiveSpecificSignal` behaviors.
+Once an actor is watched, its termination will result in the watching actor receiving a api:Signals.Terminated[enum] signal, which may be handled using `Behavior.receiveSignal` or `Behavior.receiveSpecificSignal` behaviors.
 
 TIP: Any actor can `watch` any other actor, if it has obtained its api:ActorRef<Message>[struct].
 
 ==== Death Pact
 
-Upon _watching_ another actor, the watcher enters a so-called "death pact" with the watchee. In other words, if the watchee
-terminates, the watcher will receive a api:Signals.Terminated[enum] signal, and if that signal is _not handled_ the watcher
-will fail itself with a api:DeathPactError[enum].
+Upon _watching_ another actor, the watcher enters a so-called "death pact" with the watchee.
+In other words, if the watchee terminates, the watcher will receive a api:Signals.Terminated[enum] signal, and if that signal is _not handled_ the watcher will fail itself with a api:DeathPactError[enum].
 
-This pattern is tremendously useful to bind lifecycles of multiple actors to one another. For example, if a `player` actor
-signifies the presence of the player in a game match, and other actors represent its various actions, tasks, or units it is controlling,
-it makes sense, for all the auxiliary actors to only exist while the player remains active. This can be achieved by having each of
-those actors api:ActorContext[class]`.watch` the `player` they belong to. Without any further modifications, if the player actor
-terminates (for whatever reason), all of its actions, tasks and units would terminate automatically:
+This pattern is tremendously useful to bind lifecycles of multiple actors to one another.
+For example, if a `player` actor signifies the presence of the player in a game match, and other actors represent its various actions, tasks, or units it is controlling, it makes sense for all the auxiliary actors to only exist while the player remains active.
+This can be achieved by having each of those actors api:ActorContext[class]`.watch` the `player` they belong to.
+Without any further modifications, if the player actor terminates (for whatever reason), all of its actions, tasks and units would terminate automatically:
 
 [source]
 ----
 include::{dir_sact_doc_tests}/DeathWatchDocExamples.swift[tag=simple_death_watch]
 ----
-<1> Whenever creating a game unit, we pair it with its owning player; the unit immediately _watches_ the `player` upon starting
-<2> Once setup is complete, we become the unit's main behavior, along with handling the player _termination signal_
-<3> By _not_ handling any termination signals, whenever the `player` terminates, the `gameUnit` will automatically fail with a death pact error; ensuring we won't leak the unit.
+<1> Whenever creating a game unit, we pair it with its owning player; the unit immediately _watches_ the `player` upon starting.
+<2> Once setup is complete, we become the unit's main behavior, along with handling the player _termination signal_.
+<3> By _not_ handling any termination signals, whenever the `player` terminates the `gameUnit` will automatically fail with a death pact error, ensuring we won't leak the unit.
 
-The above scenario can be performed more gracefully as well.  All actors watching the `player` could explicitly handle
-the player termination signal and decide on how they want to deal with this individually.
+The above scenario can be performed more gracefully as well.
+All actors watching the `player` could explicitly handle the player termination signal and decide on how they want to deal with this individually.
 
-Perhaps a game match in an multilayer game would want to wait for the player to reconnect for a few seconds,
-before they indeed signal termination and concede the game to the opponent. Or perhaps, any ongoing workers related to given player
-should run to completion their current work, but not accept any new requests, and eventually terminate as well?
+Perhaps a game match in an multilayer game would want to wait for the player to reconnect for a few seconds before they signal termination and concede the game to the opponent.
+Or perhaps any ongoing workers related to given player should run to completion of their current work but not accept any new requests, and eventually terminate as well?
 
-In the example below, if the `player` terminates, the `GameMatch` gives it a few seconds reconnect to the game, and otherwise we terminate the match,
-effectively giving up the match by withdrawal of one of the players.
+In the example below, if the `player` terminates, the `GameMatch` gives it a few seconds reconnect to the game, otherwise we terminate the match, effectively giving up the match by withdrawal of one of the players.
 
 [source]
 ----
@@ -347,75 +323,59 @@ include::{dir_sact_doc_tests}/DeathWatchDocExamples.swift[tag=handling_terminati
 ----
 
 TIP: Use death pacts to bind lifecycles of various actors to one another. +
-     A death pact error is thrown whenever an api:Signals.Terminated[enum] is received but left `.unhandled`.
+A death pact error is thrown whenever an api:Signals.Terminated[enum] is received but left `.unhandled`.
 
 ==== Death Watch Guarantees
 
-For the sake of describing those guarantees let us assume we have two actors, Romeo and Juliet.
+For the sake of describing those guarantees, let us assume we have two actors: Romeo and Juliet.
 Romeo performs a `context.watch(juliet)` during its `setup`.
 
-It is by Swift Distributed Actors guaranteed that:
+Swift Distributed Actors guarantees that:
 
-- if Juliet terminated Romeo will receive a `.terminated` signal which it can handle by using an `Behavior.receiveSignal`,
-- the `.terminated` message will never be duplicated or lost. As it goes with system messages, one can assume "exactly once" processing for them,
-including in distributed settings (which is a stronger guarantee than given for plain user messages),
--
+* If Juliet terminates, Romeo will receive a `.terminated` signal which it can handle by using an `Behavior.receiveSignal`.
+* The `.terminated` message will never be duplicated or lost.
+As it goes with system messages, one can assume "exactly once" processing for them, including in distributed settings (which is a stronger guarantee than given for plain user messages).
 
-Furthermore, if we imagine the above two actors be in the actual play of Shakespeare, then there would also be an audience,
-which would be watching both of these actors. This means that many actors (the audience) can be watching our "stage" actors.
+Furthermore, if we imagine the above two actors to be in the actual Shakespearean play, then there would also be an audience watching both of these actors.
+This means that many actors (the audience) can be watching our "stage" actors.
 For this situation the following is guaranteed:
 
-- if an actor (any actor) is watching any of the terminating actors it WILL receive a `.terminated` message,
-- all of the actors watching a terminating actor WILL receive the `.terminated` message,
-- even in distributed settings, if a watcher has "not noticed immediately" what was going on on stage (e.g. due to lack of network connectivity),
-once it is informed by other actors (handled internally via cluster gossip), it will receive the outstanding `.terminated` as-if it had observed the death with its own eyes.
+* All of the actors watching a terminating actor *WILL* receive the `.terminated` message.
+* Even in distributed settings, if a watcher has "not noticed immediately" what was going on on stage, e.g. due to lack of network connectivity, once it is informed by other actors (handled internally via cluster gossip) it will receive the outstanding `.terminated` as if it had observed the death with its own eyes.
 
 #TODO: complete this section#
-
 
 [[specific_failure_supervision]]
 === Selective Supervision of Specific Failures
 
 > It is also possible to selectively apply supervision depending on the type of the failure.
 
-For example, when working with APIs that might throw errors when they are "overwhelmed" and our goal is simply to drop the message which caused this fault,
-yet do not terminate the actor but continue processing other messages as they are independent requests, we might want to
-supervise only for this `SomeLibraryOverloadedError`, yet leave all other errors to crash the actor and leave any compensating
-actions to its parent.
+For example, when working with APIs that might throw errors when they are "overwhelmed."
+If our goal is simply to drop the message which caused this fault and not terminate the actor, but continue processing other messages as they are independent requests, we might want to supervise only for this `SomeLibraryOverloadedError` and leave all other errors to crash the actor, leaving any compensating actions to its parent.
 
-For example, it is possible to supervise for a specific Error by always restarting, however all other Errors and faults
-will cause an immediate crash of the actor:
+It is possible to supervise for a specific `Error` by always restarting, however, all other Errors and faults will cause an immediate crash of the actor:
 
 [source]
 ----
 include::{dir_sact_doc_tests}/SupervisionDocExamples.swift[tag=supervise_specific_error_else_stop]
 ----
-<1> The actor is implemented to "re-throw" all errors that are sent to it
-<2> The `.restart` supervision strategy is selected for the specific error type `CatchThisError`
-<3> An "catch all" `.stop` supervisor is always implicitly applied to the end of the supervisor chain.
+<1> The actor is implemented to "re-throw" all errors that are sent to it.
+<2> The `.restart` supervision strategy is selected for the specific error type `CatchThisError`.
+<3> A "catch all" `.stop` supervisor is always implicitly applied to the end of the supervisor chain.
 
-Using this mechanism we are able to supervise only for failures we know may occur and perhaps maybe for some reason
-can not do much about them right now and restarting the actor to reinitialize is the right thing to do.
+Using this mechanism we are able to supervise only for failures we know may occur and perhaps cannot do much about, so restarting the actor to reinitialize it is the right thing to do.
 
-It is also possible to supervise "all errors" or "all faults" with a specific supervision strategy.
-This is done as shown in the above snipped in point 3. It is possible to explicitly select supervision strategies
-for "all" types of a failure category. This is done using the api:Supervise/All[enum]`.[errors|faults|failures]` cases
-and the `addSupervision(strategy:forAll:)` overload of the supervision chain builder.
+It is also possible to supervise "all errors" or "all faults" with a specific supervision strategy, as shown in the above snippet in point 3.
+It is also possible to explicitly select supervision strategies for "all" types of a failure category.
+This is done using the api:Supervise/All[enum]`.[errors|faults|failures]` cases and the `addSupervision(strategy:forAll:)` overload of the supervision chain builder.
 
-It is worth remembering that while supervision can deal with Errors, it is often times preferable to handle those using
-plain `do/catch` notation, as it has two benefits over supervision:
+It is worth remembering that while supervision can deal with `Errors`, it is often times preferable to handle those using plain `do/catch` notation, as it has two benefits over supervision:
 
-- firstly, it allows for more control as `do/catch` may indeed catch
-  an error and decide that it was harmless and we should continue operations,
-- and secondly, it likely is the right thing to do semantically, as handling errors usually is normal in Swift applications,
-  and supervision should remain for those instances where unexpected problems arise or the supervision chain or backoff mechanisms
-  could be useful.
+* It allows for more control as `do/catch` may indeed catch an error and decide that it was harmless and we should continue operations.
+* It likely is the right thing to do semantically, as handling errors in this way is normal in Swift applications, and supervision should remain for those instances where unexpected problems arise, or the supervision chain or backoff mechanisms could be useful.
 
-NOTE: Supervision is not intended to replace `do/catch` blocks, and should be used for "unexpected" failures.
-      Try to use the "let it crash" philosophy when designing your actors and their interactions.
-      Make sure that a crash would carry enough useful information to be able to attempt fixing it later on,
-      e.g. by carrying trace or similar metadata which could help identify if the error exists only for a specific
-      entity or situation.
+NOTE: Supervision is not intended to replace `do/catch` blocks, and should be used for "unexpected" failures -- try to use the "let it crash" philosophy when designing your actors and their interactions.
+Make sure that a crash would carry enough useful information to be able to attempt fixing it later on, e.g. by carrying trace or similar metadata which could help identify if the error exists only for a specific entity or situation.
 
 #TODO: DOCUMENT MORE?#
 
@@ -424,20 +384,17 @@ NOTE: Supervision is not intended to replace `do/catch` blocks, and should be us
 
 #TODO: document in depth#
 
-Process isolation can be seen as an extension of actor supervision, however on the process level.
+Process isolation can be seen as an extension of actor supervision on the process level.
 
-By segregating groups of actors into their own processes, this allows building semantically meaningful _failure domains_,
-i.e. one might put all actors responsible for a specific batch job or specific work type into their own process, as if any
-of those actors _fault_, all of them should be terminated as a whole.
+By segregating groups of actors into their own processes, this allows building semantically meaningful _failure domains_, i.e. one might put all actors responsible for a specific batch job or specific work type into their own process as if any of those actors _fault_, they should all be terminated.
 
 ==== Using `ProcessIsolated`
 
-In order to discover semantic relationships of "failing together" one might keep the musketeers motto of "all for one, and one for all" in mind
-when considering the following: when given actor faults, which actors should also terminate as they are very likely in "bad state" as well.
+In order to discover semantic relationships of "failing together," one might keep the musketeers motto of "all for one, and one for all" in mind when considering the following: when a given actor faults, which actors should also terminate as they are very likely to be in a "bad state" as well?
 
-In a fully pure and isolated actor world the answer usually is that only itself, and potentially any of its watchers and parent,
-however in face of unsafe code and faults (fatal errors), we might have to thread more carefully, and terminate an entire group of actors.
-The such discovered grouping of actors is a good approximation of a good failure domain -- and you should put all those actors into the same servant process.
+In a fully pure and isolated actor world, the answer is usually that only the actor itself, and potentially its parent and/or any of its watchers.
+However, in the face of unsafe code and faults (fatal errors), we might have to thread more carefully, and terminate an entire group of actors.
+This grouping of actors is an approximation of a good failure domain, and you should put all those actors into the same process.
 
 Spawning actors in a specific process is done like this:
 
@@ -447,36 +404,37 @@ include::{dir_sact_doc_tests}/ProcessIsolatedDocExamples.swift[tag=spawn_in_doma
 ----
 <1> Every process isolated application needs to start off with creating an isolated actor system for its own. +
     The returned `isolated` contains the actor system and additional control functions.
-<2> In general, any code not enclosed in an `isolated.run` will execute on _any_ spawned process, including the master. Use this to prepare things common for master and servant processes.
+<2> In general, any code not enclosed in an `isolated.run` will execute on _any_ spawned process, including the master.
+    Use this to prepare things common for `.master` and `.servant` processes.
 <3> Any code enclosed in an `isolated.run(on: ProcessIsolated.Role)` will execute only on given process role. Default roles are `.master` and `.servant`, however you can add additional roles.
-<4> Inside the `.master` process, we spawn one servant process. This will execute "the same" application, however with different configuration, such that it will automatically connect to the master.
-<5> We decide to _supervise_ the servant _process_ using a _respawn_ strategy with exponential backoff as well as at most 5 faults within its lifetime. Upon process fault, the master will re-spawn another process with the same configuration as the terminated process.
-<6> We spawn an actor in the master node. As there is always only one master node, this actor will also _definitely_ only exist once on the master process.
-<7> Finally, we run a block _only_ on servant processes, in which we spawn another actor. If we spawned more servant processes, each would get its own "alfredPennyworth" actor on its own process/node.
+<4> Inside the `.master` process we spawn one `.servant` process.
+    This will execute "the same" application, however with different configuration, such that it will automatically connect to the `.master`.
+<5> We decide to _supervise_ the `.servant` _process_ using a _respawn_ strategy with exponential backoff as well as at most 5 faults within its lifetime.
+    Upon process fault, the `.master` will re-spawn another process with the same configuration as the terminated process.
+<6> We spawn an actor in the `.master` node.
+    As there is always only one `.master` node, this actor will also _definitely_ only exist once on the `.master` process.
+<7> Finally, we run a block _only_ on `.servant` processes, in which we spawn another actor.
+    If we spawned more `.servant` processes, each would get its own "alfredPennyworth" actor on its own process/node.
 <8> Last but not least, we park the main thread of the applications in a loop that is used for handling process spawning. #TODO this may be simplified in the future#
 
-The above example shows how to use api:ProcessIsolated[class] to build a simple 2 process application. If either a failure
-were to _escalate_ through alfred to the `/user` guardian or the servant process were to encounter a _fault_ anywhere,
-the parent (master) process would notice this immediately, and use its `.respawn` servant process supervision strategy
-to respawn the child process, causing a new _alfred_ actor to be spawned.
+#TODO: Update for inclusive language, as defined in https://help.apple.com/applestyleguide/#
 
-As for how _bruce_ and _alfred_ can communicate to one another, you should refer to documentation about the <<receptionist>>.
+The above example shows how to use api:ProcessIsolated[class] to build a simple 2 process application.
+If either a failure were to _escalate_ through `alfred` to the `/user` guardian, or the `.servant` process were to encounter a _fault_ anywhere, the parent (`.master`) process would notice this immediately, and use its `.respawn` `.servant` process supervision strategy to respawn the child process, causing a new `alfred` actor to be spawned.
 
-It is also worth exploring the various helper functions on the api:ProcessIsolated[class] class, as it offers some convenience utilities
-for working with processes in various roles.
+As for how `bruce` and `alfred` can communicate to one another, you should refer to documentation about the <<receptionist>>.
 
-Note also that file descriptors or any other state is _not_ passed to servant processes, so e.g. all files that the master
-process had opened before spawning the child are closed when the servant is spawned. Any communication between the two,
-should be implemented the same way as if the processes were completely separate nodes in a cluster -- i.e. by using the receptionist,
-or other mechanisms such as gossip.
+It is also worth exploring the various helper functions on the api:ProcessIsolated[class] class, as it offers some convenience utilities for working with processes in various roles.
 
-TIP: Since actors spawned in different processes have to serialize messages when they communicate with each other,
-     you have to ensure that messages they exchange are serializable using <<serialization,serialization infrastructure>>.
+Note also that file descriptors or any other state is _not_ passed to servant processes, so e.g. all files that the `.master` process had opened before spawning the child are closed when the `.servant` is spawned.
+Any communication between the two should be implemented the same way as if the processes were completely separate nodes in a cluster, i.e. by using the receptionist or other mechanisms such as gossip.
 
-==== One for all and, all for one
+TIP: Since actors spawned in different processes have to serialize messages when they communicate with each other, you have to ensure that messages they exchange are serializable using <<serialization, serialization infrastructure>>.
 
-Using the previous code snippet, showing how to use `ProcessIsolated`, let us now discuss the various failure situations this
-setup is able to deal with. We will discuss 3 situations, roughly depicted by the following points of failure:
+==== One for all, and all for one
+
+Using the previous code snippet, showing how to use `ProcessIsolated`, let us now discuss the various failure situations this setup is able to deal with.
+We will discuss 3 situations, roughly depicted by the following points of failure:
 
 [.center]
 image::process_isolated_servants.png[]
@@ -485,34 +443,29 @@ image::process_isolated_servants.png[]
 
 Actor failure, shall (currently) be discussed in two categories: a _fault_ and an _error_.
 
-TIP: In the future, we hope to unify those two failure handling schemes under the same scheme, the same which currency applies
-     to error supervision, however right now this is not possible. In this scenario, let us focus on the escalating errors pattern,
-     and the fault scenario will be analysed in depth in <<process_isolated_scenario_b>>.
+TIP: In the future we hope to unify those two failure handling schemes under the scheme which currently applies to error supervision, right now, however, this is not possible.
+In this scenario, let us focus on the escalating errors pattern, and the fault scenario will be analysed in depth in <<process_isolated_scenario_b>>.
 
 When the actor throws an error which causes it to crash, its <<supervision_strategies, supervision strategy>> is applied.
-If this happens to result in an `.escalate` decision, the error is _bubbled up_ through the actor hierarchy, and if it reached
-the `/user` guardian actor, it would terminate the process, and thus triggering the master's servant process supervision mechanism.
+If this happens to result in an `.escalate` decision, the error is _bubbled up_ through the actor hierarchy, and if it reaches the `/user` guardian actor it will terminate the process, and thus trigger the ``.master``'s `.servant` process supervision mechanism.
 
 [[process_isolated_scenario_b]]
-===== Failure scenario b) Fault in .servant process
+===== Failure scenario b) Fault in `.servant` process
 
-Whenever a _fault_ (such as `fatalError`, a division by zero, or a more serious issue, such as a segmentation fault or similar)
-happens in a servant process, it shall be immediately terminated (with printing a backtrace if configured to do so which it is by default).
+Whenever a _fault_ (such as `fatalError`, a division by zero, or a more serious issue, such as a segmentation fault or similar) happens in a `.servant` process, it will be immediately terminated (printing a backtrace if configured to do so, which it is by default).
 
-All actors hosted in this servant process are terminated, and if any other actor _watched_ any of them on another process/node,
-they will immediately be notified with an api:Signals.Terminated[enum] signal. You can read more about terminated messages
-and watch semantics in <<death_watch>>.
+All actors hosted in this `.servant` process are terminated, and if any other actor _watched_ any of them on another process/node, they will immediately be notified with an api:Signals.Terminated[enum] signal.
+You can read more about terminated messages and watch semantics in <<death_watch>>.
 
-===== Failure scenario c) Fault or .escalation in .master process
+===== Failure scenario c) Fault or `.escalation` in `.master` process
 
-Each time a servant process terminates, the master will apply the supervision strategy that was tied with the now terminated process.
-Such strategy MAY yield an `.escalate` decision, which means that the given servant's termination, should escalate and also cause the _master_
-to terminate.
+Each time a `.servant` process terminates, the `.master` will apply the supervision strategy that was tied to the now terminated process.
+Such strategy MAY yield an `.escalate` decision, which means that the given ``.servant``'s termination, should escalate and also cause the `.master` to terminate.
 
-If the master terminates, it also _causes all of its servants to terminate as well_. This is done unconditionally in order to prevent
-lingering "orphan" processes. This termination is guaranteed, even if the master process is terminated forcefully killing it with a `SIGKILL` signal.
+If the `.master` terminates, it also _causes all of its ``.servant``s to terminate_.
+This is done unconditionally in order to prevent lingering "orphan" processes.
+This termination is guaranteed, even if the `.master` process is terminated forcefully by killing it with a `SIGKILL` signal.
 
 
-NOTE: While this method is effective in isolating faults including serious ones like segfaults or similar in
-      the servant (child) processes, it comes at a price; Maintaining many processes is expensive and communication between them
-      is less efficient than communicating between actors located in the same actor system (as serialization needs to be involved).
+NOTE: While this method is effective in isolating faults, including serious ones like segfaults or similar in the `.servant` (child) processes, it comes at a price.
+Maintaining many processes is expensive and communication between them is less efficient than communicating between actors located in the same actor system, as serialization needs to be involved.

--- a/Docs/faq.adoc
+++ b/Docs/faq.adoc
@@ -5,21 +5,16 @@
 
 ==== Why does `context` not contain the `parent` ref?
 
-Since it would not be possible (without significant boilerplate) to statically enforce the
-type of the parents `ActorRef<Message>` if offered in such way.
+Since it would not be possible (without significant boilerplate) to statically enforce the type of the parents `ActorRef<Message>` if offered in such way.
 
-Suggestion: If a child actor is intending to communicate often to the parent, pass the parents
-ref during creation as plain-old parameter. Alternatively if the child has to "reply" at some
-point to a message, that message should use the `replyTo: ActorRef<ReplyType>` pattern (even if
-the replied to actor is the parent -- the child should not care too much about this).
+Suggestion: If a child actor is intending to communicate often to the parent, pass the parent's ref during creation as plain-old parameter.
+Alternatively, if the child has to "reply" to a message at some point, that message should use the `replyTo: ActorRef<ReplyType>` pattern (even if the replied to actor is the parent -- the child should not care too much about this).
 
 ==== Should I always name my actors?
 
-Yes. Unless you have really really good reasons not to.
+Yes, unless you have really, really good reasons not to.
 
-Try to avoid using the `spawnAnonymous` version of spawning,
-your future self will thank you, since once things break you will know exactly which actor
-had the fault, rather than an anonymous one like "$abc".
+Try to avoid using the `spawnAnonymous` version of spawning, your future self will thank, you since once things break you will know exactly which actor had the fault, rather than an anonymous one like "$abc".
 
 ==== How to get an well-typed ActorRef<MyMessage> of a child actor?
 
@@ -27,33 +22,28 @@ had the fault, rather than an anonymous one like "$abc".
 
 Establishing the common language used when talking about actors.
 
-- `Behavior` --
-    * a behavior can be "run"
-- `Actor` -- The main indivisible conceptual unit of an actor system. Actors communicate only using messages, have identity
-             and a well defined lifecycle. They can be watched for termination and notify others when they fail.
-             They also serve as failure isolation primitives -- thanks to which faults terminate actors, and not entire processes.
-- Mailbox -- An internal implementation detail of an actor, however sometimes used when explaining message processing semantics.
-             Mailboxes are not accessed directly in normal usage, however they are the message queues that are used during actor communication.
-             Actors may configure their mailboxes upon spawning to satisfy certain requirements, like never extending beyond a fixed size etc.
-- Message -- The common term used to talk about "user-land" messages. It is the type of object that you can send to an `ActorRef<Message>`.
-- `Signal` -- A signal is a special kind of message (in fact, they most often correspond to internal system messages),
-              which can be handled by users using the `api:Behavior[struct]..receiveSignal` behavior.
-- System message -- A system message is an _internal_ message sent only by the system itself, and never from user code.
-                    They drive features like actor lifecycle, watch and termination handling.
-                    They are also always re-delivered in face of network failure and reconnection of a networked node,
-                    while this comes at a cost (buffering on sending node), it is required for correctness of mechanisms
-                    like death watch et al.
-- Failure -- Any kind of failure condition that may happen during message processing.
-             It can refer to an error or fault specifically, when talking about actors.
-             It is also used casually  when talking about node failures and failure detection.
-- `FailureDetector` -- A mechanism employed by the system to observe other nodes of a cluster, and notify the system in
-                       case of suspicion that another node has become unresponsive or has crashed completely.
-                       Failure detectors are necessary in distributed systems as one can never know for certain if another
-                       node is only taking a long time to respond, is experiencing networking issues, or is actually fully crashed.
-- Canonicalize / Canonicalized Behavior -- refers to the "canonical" form of a behavior. A simple way to think about this process is
-                                           taking the example of nested `.setup()` behaviors, which have to be "canonicalize" when a behavior
-                                           starts, such that only the inner most `.receive` (or other) behavior is actually stored and executed,
-                                           the setups run only _once_ during startup after all -- at which time they are canonicalized.
-                                           Other behaviors which are automatically canonicalized on each reduction are e.g. interceptors,
-                                           `orElse` alternatives or suspension behaviors.
-- #TODO define all main words#
+`Behavior`:: A behavior can be "run"
+`Actor`:: The main indivisible conceptual unit of an actor system.
+    Actors communicate only using messages, have identity and a well defined lifecycle.
+    They can be watched for termination and notify others when they fail.
+    They also serve as failure isolation primitives -- thanks to which faults terminate actors, and not entire processes.
+Mailbox:: An internal implementation detail of an actor, sometimes used when explaining message processing semantics.
+    Mailboxes are not accessed directly in normal usage, however they are the message queues that are used during actor communication.
+    Actors may configure their mailboxes upon spawning to satisfy certain requirements, like never extending beyond a fixed size, etc.
+Message:: The common term used to talk about "user-land" messages.
+    It is the type of object that you can send to an `ActorRef<Message>`.
+`Signal`:: A signal is a special kind of message (in fact, they most often correspond to internal system messages), which can be handled by users using the `api:Behavior[struct]..receiveSignal` behavior.
+System message:: A system message is an _internal_ message sent only by the system itself, and never from user code.
+    They drive features like actor lifecycle, watch and termination handling.
+    They are also always re-delivered in face of network failure and reconnection of a networked node.
+    While this comes at a cost (buffering on sending node), it is required for correctness of mechanisms like death watch et al.
+Failure:: Any kind of failure condition that may happen during message processing.
+    It can refer to an error or fault specifically, when talking about actors.
+    It is also used casually  when talking about node failures and failure detection.
+`FailureDetector`:: A mechanism employed by the system to observe other nodes of a cluster, and notify the system in case of suspicion that another node has become unresponsive or has crashed completely.
+    Failure detectors are necessary in distributed systems as one can never know for certain if another node is only taking a long time to respond, is experiencing networking issues, or is actually fully crashed.
+Canonicalize / Canonicalized Behavior:: Refers to the "canonical" form of a behavior.
+    A simple way to think about this process is taking the example of nested `.setup()` behaviors, which have to be "canonicalize" when a behavior starts, such that only the inner most `.receive` (or other) behavior is actually stored and executed -- the setups run only _once_ during startup after all -- at which time they are canonicalized.
+    Other behaviors which are automatically canonicalized on each reduction are e.g. interceptors, `orElse` alternatives, or suspension behaviors.
+
+#TODO define all main words#

--- a/Docs/index.adoc
+++ b/Docs/index.adoc
@@ -53,9 +53,7 @@ ifndef::host-github[:ext-relative: {outfilesuffix}]
 
 ++++
 <!--
-    Some trickery is made in the index.adoc file, as we use the +++ "pass through" blocks to avoid including the
-    sections here in the ToC since it would cause the index to become part of the "tree" (as in,
-    we'd become one level "nested" already on the index page, which is not what we want for our documentation).
+    Some trickery is made in the index.adoc file, as we use the +++ "pass through" blocks to avoid including the sections here in the ToC since it would cause the index to become part of the "tree" (as in, we'd become one level "nested" already on the index page, which is not what we want for our documentation).
 
     The first h1 heading is used as title of the pdf documentation, as well as name of "top", no other h1 must be defined anywhere.
 -->
@@ -74,38 +72,35 @@ ifndef::host-github[:ext-relative: {outfilesuffix}]
 ++++
 
 Swift Distributed Actors provide straightforward building blocks that enable and simplify building distributed and concurrent systems.
-Using the same mental model and programming style, one can communicate across threads, processes, nodes in a cluster, or even devices.
+Using the same mental model and programming style one can communicate across threads, processes, nodes in a cluster, or even devices.
 
-Swift Distributed Actors aims to provide the hard parts of distributed systems design as reusable components, which can be
-used to build high-performant and reliable systems at any scale. It can be thought of as "what Swift NIO is for networking libraries,
-Distributed Actors is for distributed applications."
+Swift Distributed Actors aims to provide the hard parts of distributed systems design as reusable components, which can be used to build high-performant and reliable systems at any scale.
+It can be thought of as "what Swift NIO is for networking libraries, Distributed Actors is for distributed applications."
 
-> Note also that even a single laptop is essentially a small distributed system -- when various daemons and servers need
-  to communicate to one another.
+> Note also that even a single laptop is essentially a small distributed system when various daemons and servers need to communicate to one another.
 
 ++++
 <h3>Main features</h3>
 ++++
 
-The core building block of all components are <<actors, Actors>>. They are entities which communicate The same semantics are used for local
-and remote actors, which unifies distributed and "local" development, allowing for fast development cycles and one shared
-mental model for how a system communicates. Swift Distributed Actors is type-safe and able to handle various serialization mechanisms
-transparently, so you can focus on developing business logic, without serialization boilerplate getting in the way.
+The core building block of all components are <<actors, Actors>> -- entities which communicate.
+The same semantics are used for local and remote actors, which unifies distributed and "local" development, allowing for fast development cycles and one shared mental model for how a system communicates.
+Swift Distributed Actors is type-safe and able to handle various serialization mechanisms transparently so you can focus on developing business logic, without serialization boilerplate getting in the way.
 
 TIP: You can define actors using the high-level <<actorable, Actorable>> API or using the low-level/power-user <<behaviors, Behavior>> API.
-     Most applications should prefer the `Actorable` style whenever possible, and can mix-in `Behavior` whenever they need to.
+Most applications should prefer the `Actorable` style whenever possible, and can mix-in `Behavior` whenever they need to.
 
-Actors embrace the _"Let it crash!"_ mentality, as popularized by https://www.erlang.org and https://akka.io[Akka],
-and implement various specific ways to <<failure_isolation, isolate as well as detect failure>> in distributed (or local, multi-process) systems.
-Actors can form <<clustering, clusters>> spanning multiple nodes, or communicate between <<process_isolated, processes>>
-on the same machine, all using the same communication style and APIs. Actors <<process_isolated, isolated in processes>>
-allow us to handle fatal faults (such as fatalError, and other preconditions) in a graceful manner, without terminating the entire system.
+Actors embrace the _"Let it crash!"_ mentality, as popularized by https://www.erlang.org and https://akka.io[Akka], and implement various specific ways to <<failure_isolation, isolate as well as detect failure>> in distributed (or local, multi-process) systems.
+
+Actors can form <<clustering, clusters>> spanning multiple nodes, or communicate between <<process_isolated, processes>> on the same machine, all using the same communication style and APIs.
+
+Actors <<process_isolated, isolated in processes>> allow us to handle fatal faults (such as fatalError, and other preconditions) in a graceful manner, without terminating the entire system.
 #Eventually aiming to allow handling panics within process as well; which we aim to make safe by following the data isolation style of Actor programming.#
 
 #TODO Coming Soon:# Actors also provide a way to use *XPC* as a transport, while remaining in the same programming model.
 
-Last but not least, the Actor system provides built in <<observability>> capabilities, such as metrics, tracing, logging with metadata,
-and more. #Not many metrics are exposed yet, and tracing is pending still, but the groundwork has been done at the core of the system.#
+Last, but not least, the Actor system provides built in <<observability>> capabilities, such as metrics, tracing, logging with metadata, and more.
+#Not many metrics are exposed yet, and tracing is pending still, but the groundwork has been done at the core of the system.#
 
 The transport layer of Actors is implemented on top of https://github.com/apple/swift-nio[Swift NIO].
 
@@ -115,27 +110,27 @@ The transport layer of Actors is implemented on top of https://github.com/apple/
 
 Distributed Actors currently requires:
 
-- Swift 5.1+
-  - though do get in touch if you require Swift 5.0 support
-- Swift NIO 2.x
+* Swift 5.1+
+** Though do get in touch if you require Swift 5.0 support
+* Swift NIO 2.x
 
 ++++
 <h3>Getting in Touch</h3>
 ++++
 
 While the project is still in its early days, we are looking for early adopters or general discussion
-about use cases you might have for Swift Distributed Actors. Please feel free reach out to us:
+about use cases you might have for Swift Distributed Actors.
+Please feel free reach out to us:
 
-- **Direct mail** to our development team: TODO@APPLE.COM
-- Follow us or open issues on GitHub: https://github.com/apple/swift-distributed-actors
+* **Direct mail** to our development team: TODO@APPLE.COM
+* Follow us or open issues on GitHub: https://github.com/apple/swift-distributed-actors
 
 ++++
 <h3>Reference Guide</h3>
 ++++
 
-This reference guide is written in a style intended to familiarize yourself with the concepts that the library includes,
-yet does not dive in depth into all parameters and details of the APIs. If you are looking to quickly skim over APIs
-and SwiftDoc you may want to check out the API Documentation here.
+This reference guide is written in a style intended to familiarize you with the concepts that the library includes, but does not dive in depth into all parameters and details of the APIs.
+If you are looking to quickly skim over APIs and SwiftDoc you may want to check out the link:../../api/{sourceversion}/DistributedActors/index.html[API Documentation here].
 
 The guide is composed of the following modules:
 

--- a/Docs/internals.adoc
+++ b/Docs/internals.adoc
@@ -1,4 +1,5 @@
 
+[[internals]]
 == Internals ✗
 
 === Actors ✗
@@ -17,43 +18,36 @@ image::internals/faultHandling_mailbox_poc.png[]
 
 ==== Gossip
 
-Membership gossip is implemented using "seen tables" and `ConvergentGossip` (#TODO: use GossipLogic rather than this, and remove Convergent Gossip#).
+Membership in `gossip` is implemented using "seen tables" and `ConvergentGossip` (#TODO: use GossipLogic rather than this, and remove Convergent Gossip#).
 
-Membership is known to have "converged" if all members have at least seen the same - or later - version of a local membership.
-This is tremendously important e.g. for removing nodes, which may ONLY happen when a member was previously seen down.
-Thanks to issuing the `.down -> .removed` only under convergence, we can guarantee that all members have definitely
-seen the now removed node as `.down` before, thus the removal will be interpreted correctly as such, and not as a new node
-that the other side knows about, but we did not.
+Membership is known to have "converged" if all members have at least seen the same, or later, version of a local membership.
+This is tremendously important, e.g. for removing nodes, which may *ONLY* happen when a member was previously seen down.
+Thanks to issuing the `.down -> .removed` only under convergence, we can guarantee that all members have definitely seen the now removed node as `.down` before, thus the removal will be interpreted correctly as such, and not as a new node that the other side knows about but we did not.
 
 === Wire Protocol
 
-#These are simplified WIP things while we work things out and then propose a proper protocol format.#
+#These are a simplified WIP while we work things out and then propose a proper protocol format.#
 
 
 ==== Handshake
 
 Swift Distributed Actors is P2P, and other than connection establishment "server" or "client" does not really matter.
-For purpose of establishing a handshake however we will use the terms "client-side" and "server-side",
-even though after the nodes have an association in place, they are equally able to perform all actions
-and the connection is used in full-duplex mode.
+For purpose of establishing a handshake, however, we will use the terms "client-side" and "server-side", even though after the nodes have an association in place they are equally able to perform all actions, and the connection is used in full-duplex mode.
 
-Handshake, initiated by "client-side"
-
-"Client-side"
-- allocate WIP association (not ready yet)
-- store handshake in progress
-- send `HandshakeOffer`
-  - contains this nodes `UniqueNode`,
-  - and `Address` of target
-
-"Server-side"
-- accept connection and receive `HandshakeOffer`
-- validate and allocate `Association`, the association is complete on this end already
-  - an Association is "ready" when it has both `UniqueNode`
-    - TODO: Assign an UID to an association as well to easier identify it, when we send data in envelopes
-- send back `HandshakeAccept` with
-  - own `UniqueNode`
-
+* Handshake, initiated by "client-side"
+* "Client-side"
+** Allocate WIP association (not ready yet)
+** Store handshake in progress
+** Send `HandshakeOffer`
+*** Contains this node's `UniqueNode`
+*** Contains `Address` of target
+* "Server-side"
+** Accept connection and receive `HandshakeOffer`
+** Validate and allocate `Association`, the association is complete on this end already
+*** An Association is "ready" when it has both ``UniqueNode``s
+**** TODO: Assign a UID to an association as well for easier identification when we send data in envelopes
+** Send back `HandshakeAccept`
+*** Contains this node's `UniqueNode`
 
 Data formats:
 
@@ -75,9 +69,10 @@ We currently do:
 
 #TODO: we may want to have handshake be inside envelope? not sure yet#
 
-#I would like to be able for the initial message to already contain data. It would also allow us
-to perform "quick sends" where we just send Handshake with data, and mark that this is already last message;
-This would work well and nice on QUIC, tho on TCP we don't care. It would enable connectionless "just send this one thing" more nicely.#
+#I would like to be able to have the initial message already contain data. It would also allow us
+to perform "quick sends" where we just send Handshake with data and mark that this is already last message.
+This would work well and nice on QUIC, tho on TCP we don't care.
+It would enable connectionless "just send this one thing" more nicely.#
 
 ```
   0                   1                   2                   3
@@ -110,7 +105,6 @@ Reply with
 ```
 
 Thanks to replying with unique address origin can now create an association.
-
 
 [plantuml]
 ....
@@ -155,32 +149,25 @@ R -[#red]-x L: HandshakeReject
 
 Note that handshakes may "race" from both nodes to each other concurrently, thus the system has to "pick one".
 
-
-
-
 ==== Watch and clustering
 
-In case of a clustered system, the `FailureDetector` drives decisions about when a node should be marked as leaving/down etc.
+In case of a clustered system, the `FailureDetector` drives decisions about when a node should be marked as leaving/down, etc.
 
-Any actor, when it performs a watch of a remote actor (known by the presence of an address in the actor's path),
-also registers to be notified about termination of given address.
+Any actor, when it performs a watch of a remote actor (known by the presence of an address in the actor's path), also registers to be notified about termination of the given address.
 
-Upon determining a remote node is terminated, the local `FailureDetector` signals all local actors that have been watching
-at least one actor on given (now terminated) address, by sending an `.addressTerminated` system message to them.
+Upon determining a remote node is terminated, the local `FailureDetector` signals all local actors that have been watching at least one actor on the given (now terminated) address by sending an `.addressTerminated` system message to them.
 
-From there on, each actor automatically handles this system message, by triggering a api:Signals.Terminated[enum] signal,
-for each of the actors it has been watching on this address. This way the sending of terminated signal is as parallel as many there have been watchers.
-And each actor utilizes as much time to process its _own_ watched actors as it has watched, so actors which did not watch any remote actors
-are not awoken to perform any checks.
-
+From there on, each actor automatically handles this system message by triggering a api:Signals.Terminated[enum] signal for each of the actors it has been watching on this address.
+This way the sending of terminated signal is as parallel as the number of watchers, and each actor utilizes as much time to process its _own_ watched actors as it has watched, so actors which did not watch any remote actors are not awoken to perform any checks.
 
 #TODO consider and explain races of lookups; should be correct by construction (since a watch needs a message send) but do make sure#
 
 ==== Vocabulary
 
-- peer - any "peer", could be an actor or a node, used in peer-to-peer / gossip situations
-- member - a member of the cluster, participating in gossip and with its own lifecycle etc
-- node - any node we are talking to, it may not YET be part of the cluster, i.e. every member is a node, but not every node is a member
-- convergence - a situation in which "we know that all other members know" about some information at some given time T (usually in "vector clock time")
-- leader - a leader is a special member within within membership, and may perform special tasks; Leaders are NOT guaranteed to be globally unique (!), it is just a role filed by some node
-- *Control - common pattern for an actor based thing to expose a subset of operations as a "control object", e.g. "RemoteControl" (pun intended), "GossipControl" etc.
+Peer:: Any "peer", could be an actor or a node, used in peer-to-peer / gossip situations.
+Member:: A member of the cluster, participating in gossip, and with its own lifecycle, etc.
+Node:: Any node we are talking to, it may not YET be part of the cluster, i.e. every member is a node, but not every node is a member.
+Convergence:: A situation in which "we know that all other members know" about some information at some given time T (usually in "vector clock time").
+Leader:: A leader is a special member within within the cluster, and may perform special tasks.
+    Leaders are NOT guaranteed to be globally unique (!), it is just a role filled by a random node.
+*Control:: Common pattern for an actor based thing to expose a subset of operations as a "control object," e.g. "RemoteControl" (pun intended), "GossipControl," etc.

--- a/Docs/observability.adoc
+++ b/Docs/observability.adoc
@@ -9,14 +9,14 @@
 
 ==== Actor metrics
 
-#TODO: we should expose metrics like actor count, throughput, mailbox states etc. using the SSWG metrics APIs.#
+#TODO: we should expose metrics like actor count, throughput, mailbox states, etc. using the SSWG metrics APIs.#
 
 === Tracing
 
 #TODO: We carry trace information in our envelopes, we should decide how to expose those.#
 
-Actor messages are always carried within an `Envelope`. This envelope can easily be extended to carry additional metadata
-such as trace information.
+Actor messages are always carried within an `Envelope`.
+This envelope can easily be extended to carry additional metadata such as trace information.
 
 === Metadata propagation
 
@@ -24,6 +24,6 @@ such as trace information.
 
 === Motivating Example
 
-TODO: talk about MMO or some IoT things. Or some other massively multiplayer thing. where actors are lovely to model the entities.
+TODO: talk about MMO, some IoT things, or some other massively multiplayer thing where actors are lovely to model the entities.
 
 This should become our example, so here we can say "click here to follow the guided example", or continue to read about the concepts.

--- a/Docs/plugin_actor_singleton.adoc
+++ b/Docs/plugin_actor_singleton.adoc
@@ -2,24 +2,23 @@
 [[actor_singleton]]
 == Plugin: Actor Singletons
 
-Sometimes it is necessary to require that there is only _one_ instance of an actor in the cluster. For examples:
+Sometimes it is necessary to require that there is only _one_ instance of an actor in the cluster, for example:
 
-- A single manager that oversees specific tasks and makes decisions.
-- A single coordinator of actions across the cluster.
-- A centralized service.
+* A single manager that oversees specific tasks and makes decisions.
+* A single coordinator of actions across the cluster.
+* A centralized service.
 
 The singleton of an actor type may run on _any_ one of the candidate nodes based on api:AllocationStrategySettings[enum,module=ActorSingletonPlugin].
 Keep in mind that this node may change due to cluster membership updates, and moving the actor singleton to the new designated node is done automatically.
 
-WARNING: Do not assume the actor singleton to be available at all times. When the node on which the actor singleton has
-been running dies, it may take a few seconds for the system to detect that and spawn a new instance elsewhere. Messages
-could be lost during the migration.
+WARNING: Do not assume the actor singleton will be available at all times.
+When the node on which the actor singleton has been running dies, it may take a few seconds for the system to detect that and spawn a new instance elsewhere.
+Messages could be lost during the migration.
 
-Regardless of where an actor singleton is running, an actor on _any_ cluster node can send messages to it. This is
-because there is a _proxy_ on each node keeping track of the exact location of the singleton. The node selected to host
-the singleton also has a _manager_ responsible for spawning and stopping the actual singleton instance according to
-api:AllocationStrategySettings[enum,module=ActorSingletonPlugin]. Currently the only supported allocation strategy is by cluster leadership--i.e.,
-the leader of the cluster hosts all actor singletons.
+Regardless of where an actor singleton is running, an actor on _any_ cluster node can send messages to it.
+This is because there is a _proxy_ on each node keeping track of the exact location of the singleton.
+The node selected to host the singleton also has a _manager_ responsible for spawning and stopping the actual singleton instance according to api:AllocationStrategySettings[enum,module=ActorSingletonPlugin].
+Currently the only supported allocation strategy is by cluster leadership, i.e. the leader of the cluster hosts all actor singletons.
 
 === Dependency
 
@@ -44,13 +43,13 @@ var package = Package(
 [[actor_singleton_quickstart]]
 === Quickstart
 
-Firstly, configure the system to use the plugin:
+First, configure the system to use the plugin:
 
 [source]
 ----
 include::{dir_sact_doc_tests}/ActorSingletonDocExamples.swift[tag=configure-system]
 ----
-<1> Enables the singleton plugin in this system
+<1> Enables the singleton plugin in this system.
 
 Next, if a node can host the singleton:
 
@@ -58,17 +57,17 @@ Next, if a node can host the singleton:
 ----
 include::{dir_sact_doc_tests}/ActorSingletonDocExamples.swift[tag=host-ref]
 ----
-<1> To host a singleton its actor behavior must be defined
+<1> To host a singleton its actor behavior must be defined.
 <2> Use the singleton ref to send messages to it, regardless of _where_ it is located.
 
 [source]
 ----
 include::{dir_sact_doc_tests}/ActorSingletonDocExamples.swift[tag=host-actorable]
 ----
-<1> To host a singleton provide a closure for creating an instance of the `Actorable`
+<1> To host a singleton, provide a closure for creating an instance of the `Actorable`.
 <2> Use the singleton actor to send messages to it, regardless of _where_ it is located.
 
-Or, if we only want to send messages to the singleton, but never want to also _host_ it on this node:
+Or, if we only want to send messages to the singleton but never want to also _host_ it on this node:
 
 [source]
 ----
@@ -82,7 +81,7 @@ include::{dir_sact_doc_tests}/ActorSingletonDocExamples.swift[tag=proxy-actorabl
 ----
 <1> Use the singleton actor to send messages to it, regardless of _where_ it is located.
 
-NOTE: For now since `byLeadership` is the only supported allocation strategy, _all_ nodes are candidates for hosting
-actor singletons and therefore `host` is the only valid option. `ref`/`actor` cannot be used yet.
+NOTE: Since `byLeadership` is currently the only supported allocation strategy, _all_ nodes are candidates for hosting actor singletons and therefore `host` is the only valid option.
+`ref`/`actor` cannot be used yet.
 
-TIP: The same code snippets are applicable to systems that do not have cluster enabled. No adjustments required.
+TIP: The same code snippets are applicable to systems that do not have cluster enabled, no adjustments required.

--- a/Docs/serialization.adoc
+++ b/Docs/serialization.adoc
@@ -2,39 +2,36 @@
 [[serialization]]
 == Serialization
 
-> The Actor system provides _transparent serialization_, allowing to avoid entangling of business logic and any serialization (coding, decoding) logic with your actors.
+> The Actor system provides _transparent serialization_, allowing you to avoid entangling business logic and any serialization (coding, decoding) logic with your actors.
 
-Serialization of actor messages is handled transparently, meaning that you can simply send https://developer.apple.com/documentation/foundation/archives_and_serialization/encoding_and_decoding_custom_types[Codable] messages
-to other actors and they will decode and receive them properly, without any additional coding work needing to be done.
+Serialization of actor messages is handled transparently, meaning that you can simply send https://developer.apple.com/documentation/foundation/archives_and_serialization/encoding_and_decoding_custom_types[Codable] messages to other actors and they will decode and receive them properly, without any additional work needing to be done.
 
-Serialization is only employed to messages which are sent across process or network boundaries (unless `serializeLocalMessages` is enabled). Helper types are provided for encoding messages using <<serialization_protobuf,Protocol Buffers>>, and any custom serializer (e.g. flat buffers, or your custom binary format) are possible to plug-in on a type-by-type basis.
+Serialization is only employed for messages which are sent across process or network boundaries (unless `serializeLocalMessages` is enabled).
+Helper types are provided for encoding messages using <<serialization_protobuf,Protocol Buffers>>, and any custom serializer (e.g. flat buffers, or your custom binary format) are possible to plug-in on a type-by-type basis.
 
-NOTE: For security reasons, in **production environments** we strongly recommend registering all types which are meant for serialization, for details on how to do this see <<serialization_production>>.
+NOTE: For security reasons, in *production environments* we strongly recommend registering all types which are meant for serialization.
+For details on how to do this see <<serialization_production>>.
 
 [[quickstart_serialization]]
 === Quickstart: Sending (Remote) Messages
 
-In order to take your local-only actor system, to the next level and allow its actors to communicate over the network,
-you should follow the following 3 steps:
+In order to take your local-only actor system to the next level and allow its actors to communicate over the network, you should follow the following 3 steps:
 
-- Step 1: Ensure that your system has multiple nodes to host your actors as explained in  <<cluster_quickstart>>,
-- Step 2: Since all actor messages are enforced to be `Codable`, you can send them _just the same way as before_ to (now remote) actors: `remoteActor.hello()` (or when using ActorRefs: `remoteActorRef.tell(.hello)`),
-  * In order to locate actors on different nodes, you can use the <<receptionist_cluster>>,
-- Step 3: "There's no step 3." https://www.youtube.com/watch?v=YHzM4avGrKI[*]
+* *Step 1*: Ensure that your system has multiple nodes to host your actors as explained in  <<cluster_quickstart>>.
+* *Step 2*: Since all actor messages are enforced to be `Codable`, you can send them _just the same way as before_ to (now remote) actors: `remoteActor.hello()` (or when using ActorRefs: `remoteActorRef.tell(.hello)`).
+** In order to locate actors on different nodes, you can use the <<receptionist_cluster>>.
+* *Step 3*: "There's no step 3." https://www.youtube.com/watch?v=YHzM4avGrKI[*]
 
 Having that said, there are a few more steps to take when deploying an actor system into **production**, which we'll explore in the following section.
 
 [[serialization_production]]
 === Serialization considerations for Production Deployments
 
-By default in DEBUG mode, the system operates in `inboundSerializerManifestMappings` mode (see api:Serialization.Settings[class]),
-which will log warnings whenever a "not registered" type is sent or received; the system will however to attempt to (de-)serialize
-any such message.
+In DEBUG mode, the system operates in `inboundSerializerManifestMappings` mode by default (see api:Serialization.Settings[class]), which will log warnings whenever a "not registered" type is sent or received; the system will, however, attempt to (de-)serialize any such message.
 
-In release mode (when building with `swift build -c release`), the `inboundSerializerManifestMappings` is automatically changed to
-`false`, meaning that messages which have not been registered fail to (de-)serialize.
+In release mode (when building with `swift build -c release`), the `inboundSerializerManifestMappings` is automatically changed to `false`, meaning that messages which have not been registered fail to (de-)serialize.
 
-In order to register messages for a production deployment, it is recommended to work locally in debug mode, gather logs which highlight which messages are needed to be sent, and then codify this in the system's setup, like shown below:
+In order to register messages for a production deployment it is recommended to work locally in debug mode, gather logs which highlight which messages are needed to be sent, and then codify this in the system's setup, as shown below:
 
 [source]
 ----
@@ -47,19 +44,19 @@ include::{dir_sact_doc_tests}/SerializationDocExamples.swift[tag=serialization_r
 === Codable Messages
 
 As messages are constrained to conform to `Codable`, all messages are in principle able to be sent over the wire.
-Serialization however is only applied when messages cross process or network boundaries.
+Serialization is only applied when messages cross process or network boundaries.
 
-NOTE: While messages locally are passed simply by storing the passed message in the recipients mailbox and thus technically _could_ store references to shared state -- beware of such designs as they lead to hard to make distributed (or process isolated) designs, and will break the actor's concurrency guarantees if the shared data-structure is mutable.
+NOTE: While messages locally are passed simply by storing the message in the recipients mailbox and thus technically _could_ store references to shared state, beware of such designs as they lead to hard-to-make distributed (or process isolated) designs, and will break the actor's concurrency guarantees if the shared data-structure is mutable.
 
 ==== Selecting the default Codable Coders
 
-NOTE: By default, Foundation's JSON and PropertyList (binary or xml) coders are supported.
-+
+NOTE: By default, Foundation's JSON and PropertyList (binary or xml) coders are supported. +
 You can configure which coder should be used by default by setting `settings.serialization.defaultSerializerID`.
 
-The ActorSystem's serialization infrastructure allows for specifying what coder should be used for certain messages.
+The ActorSystem's serialization infrastructure allows for specifying which coder should be used for certain messages.
 
-If a type is safe to be serialized (see <<serialization_register>>), it will be serialized using the serializer associated with its type. If no serializer is specified for its specific type, the default Codable coder will be used.
+If a type is safe to be serialized (see <<serialization_register>>), it will be serialized using the serializer associated with its type.
+If no serializer is specified for its specific type, the default Codable coder will be used.
 
 You can configure which coder should be used by default when encoding messages by setting `settings.serialization.defaultSerializer`.
 
@@ -70,16 +67,17 @@ It is possible to specify a different serializer for specific messages, this is 
 include::{dir_sact_doc_tests}/SerializationDocExamples.swift[tag=serialization_specific_coder]
 ----
 
-
 ==== Manually implementing Codable for Enums with Associated Values
 
-WARNING: Messages are most often enums with associated values, for which Swift does not synthesize Codable conformances today. We are aiming to solve this in Swift itself by improving its synthesising capabilities, please bear with us while we work to make this happen.
+WARNING: Messages are most often enums with associated values, for which Swift does not synthesize Codable conformances today. +
+    +
+We are aiming to solve this in Swift itself by improving its synthesising capabilities, please bear with us while we work to make this happen.
 
-Most of the time you should be able to lean on Swift's synthesis of Codable conformances. However, sometimes you may have
-to implement such conformance yourself. While there is plenty guides about doing so online, we would like to explicitly
-outline the suggested style of encoding enums with associated values (as many messages often are).
+Most of the time you should be able to lean on Swift's synthesis of Codable conformances.
+However, sometimes you may have to implement such conformance yourself.
+While there are plenty of guides about doing so online, we would like to explicitly outline the suggested style of encoding enums with associated values (as many messages often are).
 
-NOTE: When using <<actorable>> you do not need ot implement the conformance for `MyActorable.Message` because it is generated for you using the `GenActors` source generator.
+NOTE: When using <<actorable>> you do not need to implement the conformance for `MyActorable.Message` because it is generated for you using the `GenActors` source generator.
 
 We suggest the use of the following pattern to encoding enums with associated values:
 
@@ -92,30 +90,25 @@ include::{dir_sact_doc_tests}/SerializationDocExamples.swift[tag=serialization_c
 
 There are a few things to consider while choosing a serializer:
 
-- Schema evolution capabilities
-- Backward compatibility
-- Performance
+* Schema evolution capabilities
+* Backward compatibility
+* Performance
 
-Generally speaking, the recommendation is <<serialization_protobuf,Protocol Buffers>> or similar mechanisms for production use,
-whereas <<serialization_codable,Codable>> is more suitable for quick-start projects and experimentation.
+Generally speaking, the recommendation is <<serialization_protobuf,Protocol Buffers>> or similar mechanisms for production use, whereas <<serialization_codable,Codable>> is more suitable for quick-start projects and experimentation.
 
 NOTE: It is not necessary to define any serialization format while developing in-process actors only. +
-      This goes hand-in-hand with Swift's concept of https://en.wikipedia.org/wiki/Progressive_disclosure[progressive disclosure]--you
-      only have to care about serialization when you need it.
+This goes hand-in-hand with Swift's concept of https://en.wikipedia.org/wiki/Progressive_disclosure[progressive disclosure] -- you only have to care about serialization when you need it.
 
-Swift Distributed Actors does not enforce all messages to be serializable since some messages may never need to leave the local system,
-thus it would be too restrictive to require all messages to conform to a serializable format. Messages that are intended to cross
-node boundaries, however, must be serializable.
+Swift Distributed Actors does not enforce all messages to be serializable since some messages may never need to leave the local system, thus it would be too restrictive to require all messages to conform to a serializable format.
+Messages that are intended to cross node boundaries, however, must be serializable.
 
 [[serialization_protobuf]]
 === Serializing Messages with Protocol Buffers
 
-https://developers.google.com/protocol-buffers/[Google's Protocol Buffers], or protobuf, are a popular serialization format due to
-its flexibility for schema evolution and superior performance. Using protobuf or a similar serialization mechanism with externally
-defined schema is recommended for production use of actors, as it enables simple and controlled schema changes.
+https://developers.google.com/protocol-buffers/[Google's Protocol Buffers], or protobuf, is a popular serialization format due to its flexibility for schema evolution and superior performance.
+Using protobuf or a similar serialization mechanism with externally defined schema is recommended for production use of actors as it enables simple and controlled schema changes.
 
-It is _not_ recommended to use the protobuf message types directly as your actor messages, but rather treat them as a transport-only layer,
-for translation to and from your domain objects (i.e., messages defined by yourself as `struct` or `enum`).
+It is _not_ recommended to use the protobuf message types directly as your actor messages, but rather treat them as a transport-only layer, for translation to and from your domain objects (i.e., messages defined by yourself as `struct` or `enum`).
 
 #TODO: Example should include ActorRef<Response> to show how to use ActorAddress.proto#
 
@@ -137,13 +130,15 @@ And we define the protobuf message type for it:
 include::{dir_sact_doc_tests}/DocumentationProtos/SerializationDocExamples.proto[tag=serialization_protobuf]
 ----
 
-Next we generate the Swift output using https://github.com/apple/swift-protobuf[Swift Protobuf]. For example: `protoc --swift_out=Sources/ Protos/Example.proto`
+Next we generate the Swift output using https://github.com/apple/swift-protobuf[Swift Protobuf].
+For example: `protoc --swift_out=Sources/ Protos/Example.proto`
 
 It produces a `ProtoParkingGarageStatus` struct in `Example.pb.swift`, with which we can conform `ParkingGarageStatus` to api:ProtobufRepresentable[protocol].
 
 ==== Step 2: Conform messages to `ProtobufRepresentable`
 
-api:ProtobufRepresentable[protocol] is a helper protocol for conversion between Swift and protobuf message types. To conform implement the `toProto` and `init` methods:
+api:ProtobufRepresentable[protocol] is a helper protocol for conversion between Swift and protobuf message types.
+To conform implement the `toProto` and `init` methods:
 
 .Example: Conform message to ProtobufRepresentable
 [source]
@@ -154,11 +149,9 @@ include::{dir_sact_doc_tests}/SerializationDocExamples.swift[tag=serialization_p
 ==== Step 3: Register `ProtobufRepresentable` types for serialization
 
 In order to let Swift Distributed Actors know which serialization engine to use, a serializer has to be registered for each type.
-Since it is very important that the _right_ serializer is picked up by another node in a cluster, serializers _must_ be
-given unique identifiers (which matters in case of upgrading your system where the message types change).
+Since it is very important that the _right_ serializer is picked up by another node in a cluster, serializers _must_ be given unique identifiers (which matters in case of upgrades to your system where the message types change).
 
-To register the message types intended for use in the cluster they have to be registered at system bootstrap,
-using the optional trailing settings configuration closure:
+To register the message types intended for use in the cluster, they have to be registered at system bootstrap using the optional trailing settings configuration closure:
 
 .Configuring ActorSystem to use protobuf serializers for the passed in types
 [source]
@@ -166,17 +159,16 @@ using the optional trailing settings configuration closure:
 include::{dir_sact_doc_tests}/SerializationDocExamples.swift[tag=prepare_system_protobuf]
 ----
 
-The `settings` argument passed to the configuration closure is an api:ActorSystemSettings[struct], which can be used to
-configure various parts of the actor system.
+The `settings` argument passed to the configuration closure is an api:ActorSystemSettings[struct], which can be used to configure various parts of the actor system.
 
-NOTE: Serialization identifiers until 16 are reserved for Swift Distributed Actors's internal use.
-  If you want to register a different serialization format, please use numbers from greater or equal to 17.
+NOTE: Serialization identifiers up to 16 are reserved for Swift Distributed Actors's internal use.
+If you want to register a different serialization format, please use numbers greater than or equal to 17.
 
 ==== Step 4: Send messages as usual
 
-And finally, we use our messages in an actor interaction. The following function snippet is meant to reply to a query about a parking garage.
-The sender of the query here is called a `driver` (as-in, a driver looking for a parking garage with empty spots near a popular theater or cinema),
-and according to some logic we reply to it with the parking garage's availability:
+Finally, we use our messages in an actor interaction.
+The following function snippet is meant to reply to a query about a parking garage.
+The sender of the query here is called a `driver` (as-in, a driver looking for a parking garage with empty spots near a popular theater or cinema), and according to some logic we reply to it with the parking garage's availability:
 
 .Sending messages to a (potentially) remote Actor
 [source]
@@ -184,29 +176,24 @@ and according to some logic we reply to it with the parking garage's availabilit
 include::{dir_sact_doc_tests}/SerializationDocExamples.swift[tag=sending_serialized_protobuf_messages]
 ----
 
-What is most notable here, is that the actor code needs not concern itself _at all_ about any serialization details
-of the messages and actors it interacts with. This is one of the many ways the property of _location transparency_ shows up.
-Regardless of the actor being local or remote, this allows us to focus on the interactions, rather than sprinkle serialization
-and/or network call concerns into the middle of our business logic.
+What is most notable here is that the actor code need not concern itself _at all_ about any serialization details of the messages and actors it interacts with.
+This is one of the many ways the property of _location transparency_ shows up.
+Regardless of the actor being local or remote, this allows us to focus on the interactions, rather than sprinkling serialization and/or network call concerns into the middle of our business logic.
 
-
-WARNING: Due to this permissive style of sending messages, it technically is possible to accidentally send a message
-         intended only for local messaging to a remote actor, in which case such send would fail and a serialization
-         error would be logged. +
-         +
-         It is possible to configure `Serialization` to always serialize all messages, so you would catch such mistakes even when testing locally. <<verify-serialization>>
+WARNING: Due to this permissive style of sending messages, it technically is possible to accidentally send a message intended only for local messaging to a remote actor, in which case such send would fail and a serialization error would be logged. +
+    +
+It is possible to configure `Serialization` to always serialize all messages, so you would catch such mistakes even when testing locally.
+See: <<verify-serialization>>.
 
 === Using Custom Serialization
 
-If for some reason `ProtobufRepresentable` and `Codable` are not the serialization mechanisms you want to employ to serialize your messages,
-it is possible to use any custom serialization mechanism by plugging it into Swift Distributed Actors' api:Serialization[class] layer.
+If for some reason `ProtobufRepresentable` and `Codable` are not the serialization mechanisms you want to employ to serialize your messages, it is possible to use any custom serialization mechanism by plugging it into Swift Distributed Actors' api:Serialization[class] layer.
 
 NOTE: Alternatively, you may also want to explore if it is possible and/or feasible to extend the alternative serialization engine to cooperate with `ProtobufRepresentable` or `Codable` types.
 
-NOTE: When using `ProtobufRepresentable` or `Codable` messages, you don't need to do anything special. As long as the message containing your
-`ActorRef<Message>` and the `Message` type itself are registered as `ProtobufRepresentable` or `Codable` serializable, the serialization engine
-will "just work", and (de-)serializing refs will work transparently. This section only matters for use cases where you
-implement your own serializers.
+NOTE: When using `ProtobufRepresentable` or `Codable` messages, you don't need to do anything special.\
+As long as the message containing your `ActorRef<Message>` and the `Message` type itself are registered as `ProtobufRepresentable` or `Codable` serializable, the serialization engine will "just work", and (de-)serializing refs will work transparently.
+This section only matters for use cases where you implement your own serializers.
 
 The following example will serialize a simple `enum` into a simple custom format.
 
@@ -218,8 +205,7 @@ The following example will serialize a simple `enum` into a simple custom format
 include::{dir_sact_doc_tests}/SerializationDocExamples.swift[tag=serialization_custom_messages]
 ----
 
-You can use the api:NonTransportableActorMessage[protocol] to provide throwing implementations of `encode(to:)`/`init(from:)`
-codable functions, and instead implement the serialization using a custom serializer.
+You can use the api:NonTransportableActorMessage[protocol] to provide throwing implementations of `encode(to:)`/`init(from:)` codable functions, and instead implement the serialization using a custom serializer.
 
 ==== Step 2: Define custom serializer
 
@@ -234,8 +220,7 @@ include::{dir_sact_doc_tests}/SerializationDocExamples.swift[tag=custom_serializ
 
 ==== Step 3: Register custom types for serialization
 
-Next, we register the custom type and serializer by using the plain `register(:for:underId:)` function where the first parameter
-is a api:Serializer[class] factory which will be passed a system's configured nio:ByteBufferAllocator[struct].
+Next, we register the custom type and serializer by using the plain `register(:for:underId:)` function where the first parameter is a api:Serializer[class] factory which will be passed a system's configured nio:ByteBufferAllocator[struct].
 
 .Configuring ActorSystem to use custom serializers for the passed in types
 [source]
@@ -244,40 +229,38 @@ include::{dir_sact_doc_tests}/SerializationDocExamples.swift[tag=prepare_system_
 ----
 
 The serializer which will be invoked to serialize a message is selected by the system based on the bindings performed during system startup.
-When a message is sent over the wire, the id of the serializer that was used to serialize the message will be carried with it,
-such that the receiving end can invoke the right serializer to deserialize the payload.
+When a message is sent over the wire, the id of the serializer that was used to serialize the message will be carried with it, so that the receiving end can invoke the right serializer to deserialize the payload.
 
-NOTE: Great care should be taken so that the serializer ids are not changed without care when intending to perform rolling
-upgrades of nodes -- as otherwise an incorrect serializer might be selected to deserialize a message.
+NOTE: Great care should be taken so that the serializer ids are not changed without care when intending to perform rolling upgrades of nodes -- as otherwise an incorrect serializer might be selected to deserialize a message.
 
-NOTE: Serialization identifiers until 1000 are reserved for Swift Distributed Actors's internal use. #TODO sadly we have to register for every specific type... This is the correct thing to do for protocol evolution, but makes getting started harder. We can't register for "any codable" (or I can't figure out how), due to how Swift's MetaTypes work.#
+NOTE: Serialization identifiers up through 1000 are reserved for Swift Distributed Actors's internal use.
+#TODO sadly we have to register for every specific type... This is the correct thing to do for protocol evolution, but makes getting started harder.
+We can't register for "any codable" (or I can't figure out how), due to how Swift's MetaTypes work.#
 
 ==== (De-)Serializing `ActorRef`
 
-Serializing and deserializing actor references (i.e. both `Actor<Act>` and `ActorRef<Message>` types) is somewhat special
-since an actor ref has to refer to an actual "live" entity, rather than simply be deserialized into a plain data structure.
+Serializing and deserializing actor references (i.e. both `Actor<Act>` and `ActorRef<Message>` types) is somewhat special, since an actor ref has to refer to an actual "live" entity rather than simply be deserialized into a plain data structure.
 
-In order to hook into the api:ActorSystem[class] that invokes the serializer, a special `ActorSerializationContext`
-is injected into serializers when they are bound to a system. If your serializer needs to handle `ActorRef`s or similar
-actor specific types, you can accept this context like this:
+In order to hook into the api:ActorSystem[class] that invokes the serializer, a special `ActorSerializationContext` is injected into serializers when they are bound to a system.
+If your serializer needs to handle `ActorRef`s or similar actor specific types, you can accept this context like this:
 
 [source]
 ----
 include::{dir_sact_doc_tests}/SerializationDocExamples.swift[tag=custom_actorRef_serializer]
 ----
 <1> Implement `setSerializationContext` and store the context in a property.
-<2> Use the `context` to resolve the actor path to an `ActorRef`. If the path does not point to an _alive_ actor, the reference will automatically point to `/system/deadLetters`.
+<2> Use the `context` to resolve the actor path to an `ActorRef`.
+If the path does not point to an _alive_ actor, the reference will automatically point to `/system/deadLetters`.
 
 #TODO: I think we don't constructor inject this because Codable things AFAIR... but we may want to double check if we could constructor inject anyway somehow?#
 
 [[verify-serialization]]
 === Message Serialization Verification
 
-Since messages may be serialized using various different techniques, the check to see if a message can be serialized has to be performed at runtime.
+Since messages may be serialized using various techniques, the check to see if a message can be serialized has to be performed at runtime.
 
-To avoid situations where one forgets to register a serializer for a given type, it is possible to run the actor system with
-the `settings.serialization.serializeLocalMessages` option enabled. This causes all messages sent between actors to be serialized (even if they are not remote),
-which allows us to catch the mistake of forgetting to enable a serializer for a specific type early.
+To avoid situations where one forgets to register a serializer for a given type, it is possible to run the actor system with the `settings.serialization.serializeLocalMessages` option enabled.
+This causes all messages sent between actors to be serialized (even if they are not remote), which allows us to catch the mistake of forgetting to enable a serializer for a specific type early.
 
 TIP: This option is only intended for testing, as there is performance penalty associated with it.
 
@@ -290,18 +273,19 @@ include::{dir_sact_doc_tests}/SerializationDocExamples.swift[tag=configure_seria
 
 This will cause the _sending_ actor (or process, in case of sending messages from outside of an actor) to crash with a fault, similar to the following:
 
-     Fatal error: Serialization check failed for message [NotSerializable()]:NotSerializable.
-     Make sure this type has either a serializer registered OR is marked as `NonTransportableActorMessageNeeded`.
-     This check was performed since `settings.serialization.serializeLocalMessages` was enabled.: file Mailbox.swift, line 260
+----
+ Fatal error: Serialization check failed for message [NotSerializable()]:NotSerializable.
+ Make sure this type has either a serializer registered OR is marked as `NonTransportableActorMessageNeeded`.
+ This check was performed since `settings.serialization.serializeLocalMessages` was enabled.: file Mailbox.swift, line 260
+----
 
 === Internals: Serialization With Manifests
 
-The ActorSystem serialization infrastructure is based around so-called api:Serialization.Manifest[class],
-which carries both type "hint" as well as the serializer ID of the serializer (e.g. the _specific_ coder implementation)
-that was used to serialize the payload. Thanks to these two pieces of information, it is possible for the actor system
-to transparently pick the right serializer when deserializing messages on the receiving end.
+The ActorSystem serialization infrastructure is based around so-called api:Serialization.Manifest[class], which carries both a type "hint" as well as the ID of the serializer (e.g. the _specific_ coder implementation) that was used to serialize the payload.
+Thanks to these two pieces of information it is possible for the actor system to transparently pick the right serializer when deserializing messages on the receiving end.
 
-In simplified terms, messages are sent in envelopes, those envelopes contain metadata as well as the message payload itself.
+In simplified terms, messages are sent in envelopes.
+These envelopes contain metadata as well as the message payload itself.
 The following ASCII diagram explains the general idea:
 
 
@@ -321,50 +305,41 @@ The following ASCII diagram explains the general idea:
  +-------------------------------------------+
 ----
 
-The serialization into/from this wrapped wire format is performed automatically, and the `typeHint` is also able to capture
-generic information of the carried message.
+The serialization into/from this wrapped wire format is performed automatically, and the `typeHint` is also able to capture generic information of the carried message.
 
-It is possible to summon a type from a `Serialization.Manifest` by using the `system.serialization.summonType(manifest)` function (though statically still typed as `Any.Type`). It is also then possible to, if the type is Codable, invoke it's decoding `init(from:)` - which is what the serialization infrastructure does transparently.
+It is possible to summon a type from a `Serialization.Manifest` by using the `system.serialization.summonType(manifest)` function (though statically still typed as `Any.Type`).
+It is also then possible to, if the type is Codable, invoke its decoding `init(from:)` -- which is what the serialization infrastructure does transparently.
 
 ==== Troubleshooting Manifest Issues
 
-When using automatic manifests powered by `_getMangledTypeName` and their recovery into types using `_typeByName`,
-it is important that the messages being sent are _NOT_ `private`, as then the `_typeByName` function (and as such the `serialization.summonType`)
-will not be able to return a proper type from its mangled name.
+When using automatic manifests powered by `_getMangledTypeName` and their recovery into types using `_typeByName`, it is important that the messages being sent are _NOT_ `private`, as then the `_typeByName` function (and as such the `serialization.summonType`) will not be able to return a proper type from its mangled name.
 
 ==== Advanced: Using Manifests manually
 
-While usually the Codable infrastructure should handle all messages automatically, you may sometimes find yourself in need of
-manually carrying a "some Codable" value in your message. A typical scenario where this might happen is when implementing a
-generic distributed algorithm, which will have to carry "some Codable payload that the user will provide", and the library code
-should not concern itself about the details of those payloads -- maybe they will be serialized using JSON, maybe protocol buffers, or maybe using some other custom format. The library is also not in a position to determine if a type is "safe" to deserialize or not. These are all decisions that are made by end users in their systems, and configured when starting the actor system.
+While usually the Codable infrastructure should handle all messages automatically, you may sometimes find yourself in need of manually carrying a "some Codable" value in your message.
+A typical scenario where this might happen is when implementing a generic distributed algorithm, which will have to carry "some Codable payload that the user will provide", and the library code should not concern itself about the details of those payloads -- maybe they will be serialized using JSON, maybe protocol buffers, or maybe using some other custom format.
+The library is also not in a position to determine if a type is "safe" to deserialize or not.
+These are all decisions that are made by end users in their systems, and configured when starting the actor system.
 
-We strongly recommend to sticking to the manifest and serialization infrastructure when doing so, as it allows to go
-through the same "is this type trusted or not" when performing (de-)serialization of such payloads.
+We strongly recommend sticking to the manifest and serialization infrastructure when doing so, as it allows going through the same "is this type trusted or not" check when performing (de-)serialization of such payloads.
 
-Here is a simple example how one might implement a serialization of such "carry anything" while adhering to the system's
-type safe-list of types:
+Here is a simple example how one might implement a serialization of such "carry anything" while adhering to the system's type safe-list of types:
 
 [source]
 ----
 include::{dir_sact_doc_tests}/SerializationDocExamples.swift[tag=serialize_manifest_any]
 ----
 
-
 ==== A Note on Serialization.Manifest.typHint Size
 
-WARNING: Most of the time you should NOT be needing to drop down to this level. Make all your types Codable and let the infrastructure do the rest. We document this pattern, for those _few_ cases where it might prove beneficial _or_ necessary for other reasons.
+WARNING: Most of the time you should *NOT* need to drop down to this level -- make all your types Codable and let the infrastructure do the rest.
+We document this pattern for those _few_ cases where it might prove beneficial _or_ necessary for other reasons.
 
-Automatic type hints result may result in (relatively) _large_ strings that identify the
-types. Especially if payloads are highly optimized binary formats, such as protocol buffers or similar. It may happen
-that type hints dominate the message size; If this is of concern to you, you can `register(MyType.self, hint: "Z")`
-a type hint override, which will be used rather than the fully qualified name (or mangled name on Swift 5.3) for the type hint.
+Automatic type hints may result in (relatively) _large_ strings that identify the types, especially if payloads are highly optimized binary formats such as protocol buffers or similar.
+It may happen that type hints dominate the message size.
+If this is of concern to you, you can `register(MyType.self, hint: "Z")` a type hint override, which will be used rather than the fully qualified name (or mangled name on Swift 5.3) for the type hint.
 
-Specialized serializers may not even need type hints _at all_ if they use some other mechanism to identify the message type,
-or if they are registered with a specific serializer ID for a specific type they deserialize.
+Specialized serializers may not even need type hints _at all_ if they use some other mechanism to identify the message type, or if they are registered with a specific serializer ID for a specific type they deserialize.
 
-
-WARNING: **Using Swift 5.3:** The serialization is based on _mangledTypeName when used with Swift 5.3, which is very useful for prototyping,
-  however is also very fragile, as small changes in the types (such as a change of a type from a `struct` to a `class`,
-  will cause the type to be NOT the same anymore, and thus being unable to deserialize (decode) it on the receiving node
-  if it "still" knows about that type being a struct. This makes versioning and evolution of messages hard.
+WARNING: *Using Swift 5.3:* The serialization is based on `_mangledTypeName` when used with Swift 5.3, which is very useful for prototyping but is also very fragile, as small changes in the types (such as a change of a type from a `struct` to a `class`) will cause the type to *NOT* be the same anymore, and thus being unable to deserialize (decode) it on the receiving node if it "still" knows about that type being a struct.
+This makes versioning and evolution of messages hard.

--- a/Docs/xpc.adoc
+++ b/Docs/xpc.adoc
@@ -2,37 +2,31 @@
 [[xpc]]
 == ⚠️ PoC: XPC Transport
 
-> As Actors are "only" an abstraction of identifiable entities that communicate _only_ using messaging,
-> they can be used to abstract and ease interactions not only over network but also between processes.
+> As Actors are "only" an abstraction of identifiable entities that communicate _only_ using messaging, they can be used to abstract and ease interactions not only over network but also between processes.
 >
-> On Apple platforms the recommended IPC mechanism is XPC, and Actors support it as a transport in order to communicate
-> with XPC services defined in Swift, or raw C api.
+> On Apple platforms the recommended IPC mechanism is XPC, and Actors support it as a transport in order to communicate with XPC services defined in Swift, or raw C api.
 
-WARNING: The XPC transport for Actors is only a Proof-of-Concept, and thus is **highly experimental and incomplete**.
-         If you are interested in this transport, please reach out to the team to discuss.
+WARNING: The XPC transport for Actors is only a Proof-of-Concept, and thus is *highly experimental and incomplete*.
+If you are interested in this transport, please reach out to the team to discuss.
 
 NOTE: See also <<actorable>>, which can be used to define and interact with XPC services as described below.
 
 === About XPC
 
-https://developer.apple.com/documentation/xpc[XPC] is a system library provided on Apple platforms that provides
-a way to implement inter-process communication (based on property lists). XPC services are managed by `launchd`,
-and thus defining them has to follow some special rules about where they are located within an `*.app`.
+https://developer.apple.com/documentation/xpc[XPC] is a system library provided on Apple platforms that provides a way to implement inter-process communication (based on property lists).
+XPC services are managed by `launchd`, and thus defining them has to follow some special rules about where they are located within an `*.app`.
 
-This module allows for building and interacting with XPC services using the familiar `Actorable` and actor abstractions,
-allowing to learn a smaller set of APIs and implementing inter-process communication in the same manner (using the same
-core concepts) as one would implement inter-thread or intra-node (clustered) systems.
+This module allows for building and interacting with XPC services using the familiar `Actorable` and actor abstractions, allowing learning a smaller set of APIs and implementing inter-process communication in the same manner (using the same core concepts) as one would implement inter-thread or intra-node (clustered) systems.
 
 === Getting Started: (Actorable) XPC Service
 
-Actors along with the `GenActors` source generator may be used to implement and consume XPC services in Swift.
-The user experience is
+Actors, along with the `GenActors` source generator, may be used to implement and consume XPC services in Swift.
+The user experience is the same for either one.
 
 ==== Defining an XPC protocol
 
 The most common way of interacting with XPC services is through a known `protocol`.
-In Actors, this is expressible by defining an protocol conforming to `XPCActorableProtocol`,
-and generating the needed Actorable message passing infrastructure by invoking `swift run GenActors`.
+In Actors, this is expressible by defining a protocol conforming to `XPCActorableProtocol` and generating the needed Actorable message passing infrastructure by invoking `swift run GenActors`.
 
 The following protocol defines an ipc interface that we will be able to invoke from the parent application:
 
@@ -45,17 +39,15 @@ include::{dir_sact_samples}/XPCActorServiceAPI/GreetingsService.swift[tag=xpc_ex
 
 Implementing the protocol is the same as implementing any other <<actorable>>.
 
-We need to conform to the `GreetingsService` protocol as well as to the api:Actorable[protocol] in order to trigger
-the source generation for it:
+We need to conform to the `GreetingsService` protocol as well as to the api:Actorable[protocol] in order to trigger the source generation for it:
 
 [source]
 ----
 include::{dir_sact_samples}/XPCActorServiceProvider/GreetingsServiceImpl.swift[tag=xpc_example]
 ----
 
-The XPC service will be spawned on-demand (i.e. on the first message being sent to the service), and is actually
-an entire fresh process. We need to therefore implement a special `main.swift` for purpose of being spawned on demand
-by `launchd` when the service should be started:
+The XPC service will be spawned on-demand (i.e. on the first message being sent to the service), and is actually an entire fresh process.
+We therefore need to implement a special `main.swift` for purpose of being spawned on demand by `launchd` when the service should be started:
 
 [source]
 ----
@@ -66,8 +58,7 @@ include::{dir_sact_samples}/XPCActorServiceProvider/main.swift[tag=xpc_example]
 
 Consuming an api:Actorable[protocol] defined protocol is straight-forward.
 
-Make sure to include the `.xpc` transport in the system's settings during its startup, as this will ensure the lookups
-of XPC services are going to
+Make sure to include the `.xpc` transport in the system's settings during its startup, as this will ensure the lookups of XPC services.
 
 [source]
 ----
@@ -76,19 +67,18 @@ include::{dir_sact_samples}/XPCActorCaller/main.swift[tag=xpc_example]
 
 === Complete example
 
-For a complete example refer to https://github.com/apple/swift-distributed-actors/tree/master/Samples/Sources`Samples/Sources/` in which you will find the various bits of n XPC using application:
+For a complete example refer to https://github.com/apple/swift-distributed-actors/tree/master/Samples/Sources[Samples/Sources/] in which you will find the various bits of an XPC using application:
 
-- `XPCActorServiceAPI` - which defines the shared protocol between the application and the service,
-- `XPCActorCaller` - the main _executable_, which calls the XPC service,
-- `XPCActorServiceProvider` - the _executable_, containing the service implementation,
-- `XPCSupportFiles` - which are the raw `*.plist` files used to configure/announce the application and the xpc service.
+* `XPCActorServiceAPI` - which defines the shared protocol between the application and the service.
+* `XPCActorCaller` - the main _executable_, which calls the XPC service.
+* `XPCActorServiceProvider` - the _executable_, containing the service implementation.
+* `XPCSupportFiles` - which are the raw `*.plist` files used to configure/announce the application and the xpc service.
 
-The entire application is assembled together using the `Makefile`, so no use of XCode directly is required,
-the application can be built just using SwiftPM and some file movements as explained in the `Makefile`.
+The entire application is assembled together using the `Makefile`, so no use of XCode directly is required.
+The application can be built using only SwiftPM and some file movements as explained in the `Makefile`.
 
 You can run the example by running:
 
-[source]
 ----
 make
   # swift run GenActors --clean
@@ -104,11 +94,9 @@ Similar to the `Terminated` signal for plain actors, XPC services also signal me
 
 Two signals are available:
 
-- `Signals.XPC.Interrupted` - Will be delivered to the connection's event handler if the remote service exited.
-   The connection is still live even in this case, and resending a message will cause the service to be launched on-demand.
-   This error serves as a client's indication that it should resynchronize any state that it had given the service.
-- `Signals.XPC.Invalidated` - Will be delivered to the connection's event handler if the named service
-   provided to xpc_connection_create() could not be found in the XPC service namespace. The connection is useless and should be disposed of.
-   - This signal *is equivalent* to a `Signals.Terminated` and extends it as well, i.e. just watching and reacting to termination
-     of an actor using the normal watch functions and reacting to it in `receiveSignal` follows the same semantics as actor termination --
-     in a way, the actor that _is_ the service, has terminated and may not be communicated with anymore.
+* `Signals.XPC.Interrupted` - Will be delivered to the connection's event handler if the remote service exited.
+    The connection is still alive in this case, and resending a message will cause the service to be launched on-demand.
+    This error serves as a client's indication that it should resynchronize any state that it had given the service.
+* `Signals.XPC.Invalidated` - Will be delivered to the connection's event handler if the named service provided to xpc_connection_create() could not be found in the XPC service namespace.
+    The connection is useless and should be disposed of.
+** This signal *is equivalent* to a `Signals.Terminated` and extends it as well, i.e. just watching and reacting to termination of an actor using the normal watch functions and reacting to it in `receiveSignal` follows the same semantics as actor termination -- in a way, the actor that _is_ the service has terminated and may not be communicated with anymore.

--- a/Tests/DistributedActorsDocumentationTests/ActorDocExamples.swift
+++ b/Tests/DistributedActorsDocumentationTests/ActorDocExamples.swift
@@ -42,8 +42,7 @@ class ActorDocExamples: XCTestCase {
 
     func example_receiveMessage_behavior() throws {
         // tag::receiveMessage_behavior[]
-        let behavior: Behavior<Greetings> = .receiveMessage { message in
-            // <1>
+        let behavior: Behavior<Greetings> = .receiveMessage { message in // <1>
             print("Received \(message)") // <2>
             return .same // <3>
         }
@@ -55,8 +54,7 @@ class ActorDocExamples: XCTestCase {
         // tag::spawn[]
         let system = ActorSystem("ExampleSystem") // <1>
 
-        let greeterBehavior: Behavior<String> = .receiveMessage { name in
-            // <2>
+        let greeterBehavior: Behavior<String> = .receiveMessage { name in // <2>
             print("Hello \(name)!")
             return .same
         }

--- a/scripts/docs/generate_reference.sh
+++ b/scripts/docs/generate_reference.sh
@@ -46,6 +46,7 @@ asciidoctor \
   -r asciidoctor-diagram \
   -b multipage_html5 \
   -D $target_dir \
+  -a sourceversion=${version} \
   $root_path/Docs/index.adoc
 
 cp -r $root_path/Docs/images $target_dir/


### PR DESCRIPTION
Updates to Distributed Actors reference.

### Motivation:

Clean up the docs - meaning unifying formatting used throughout, catching and fixing typos, improving clarity.

### Modifications:

- Each complete sentence is a single line, this will make future diffs for changes much easier to read.
- All unordered lists use “`*`” for bullets and multiples (“`**`”, “`***`”) for nesting.
- Clean up extra blank lines.
- Some editing to improve clarity in the docs.

### Result:

N/A, documentation only.
