### PR TITLE
Update Serialization.swift

### DIFF
--- a/Sources/DistributedActors/Serialization/Serialization.swift
+++ b/Sources/DistributedActors/Serialization/Serialization.swift
@@ -769,7 +769,7 @@ public enum SerializationError: Error {
     case serializationError(_: Error, file: String, line: UInt)
 
     // --- registration errors ---
-    case alreadyDefined(hint: String, serializerID: Serialization.SerializerID, serializerID: AnySerializer?)
+    case alreadyDefined(hint: String, serializerID: Serialization.SerializerID)
     case reservedSerializerID(hint: String)
 
     // --- lookup errors ---


### PR DESCRIPTION
fix duplicate labels on SerializationError::alreadyDefined

motivation: duplicate labels are no longer supported

changes: remove second serializerID, it does not seem to be in use?

