### PR TITLE
Package.swift fixes for Swift 5.4 release

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -296,7 +296,11 @@ var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.3.2")), // not API stable, Apache v2
 ]
 
-#if swift(>=5.4)
+#if swift(>=5.5)
+dependencies.append(
+    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .revision("swift-DEVELOPMENT-SNAPSHOT-2021-05-18-a"))
+)
+#elseif swift(>=5.4)
 dependencies.append(
     .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50400.0"))
 )


### PR DESCRIPTION
Fix some issues in Package.swift for the final Swift 5.4 Linux/Darwin releases

### Motivation:

There are a couple Package.swift issues that are breaking builds under Swift 5.4 for both Linux and Darwin:
- The `-enable-experimental-concurrency` flag only appears to be present in Swift 5.4 for Linux
- The `swift-syntax` snapshot selected for 5.4 doesn't appear to be compatible with the final 5.4 release

### Modifications:

- Only enable the `-enable-experimental-concurrency` flag for Linux platforms
- Migrate to the `0.50400.0` release of `swift-syntax`
- Use `swift-syntax` development snapshot for Swift versions beyond 5.4


### Result:

- Resolves #796 
