### PR TITLE
update the requried version to 5.6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import class Foundation.ProcessInfo
@@ -244,9 +244,13 @@ dependencies += [
     .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.3.2")), // not API stable, Apache v2
 ]
 // swift-syntax is Swift version dependent, and added as such below
-#if swift(>=5.5)
+#if swift(>=5.6)
 dependencies.append(
-    .package(url: "https://github.com/apple/swift-syntax.git", .revision("swift-5.5-DEVELOPMENT-SNAPSHOT-2021-06-14-a"))
+    .package(url: "https://github.com/apple/swift-syntax.git", revision: "swift-DEVELOPMENT-SNAPSHOT-2021-09-09-a")
+)
+#elseif swift(>=5.5)
+dependencies.append(
+    .package(url: "https://github.com/apple/swift-syntax.git", revision: "swift-5.5-DEVELOPMENT-SNAPSHOT-2021-06-14-a")
 )
 #else
 fatalError("Currently only Swift 5.5+ is supported, if you need earlier Swift support please reach out to the team.")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,12 +19,13 @@ RUN apt-get update && apt-get install -y lsof dnsutils netcat-openbsd net-tools 
 # ruby and jazzy for docs generation
 RUN apt-get update && apt-get install -y ruby ruby-dev libsqlite3-dev build-essential
 # switch of gem docs building
-RUN echo "gem: --no-document" > ~/.gemrc
+
 # jazzy no longer works on xenial as ruby is too old.
-RUN if [ "${ubuntu_version}" != "xenial" ] ; then  gem install jazzy; fi
-RUN gem install asciidoctor -v 1.5.8
-RUN gem install asciidoctor-pdf --pre
-RUN gem install asciidoctor-diagram -v 1.5.8
+RUN if [ "${ubuntu_version}" = "focal" ] ; then echo "gem: --no-document" > ~/.gemrc; fi
+RUN if [ "${ubuntu_version}" = "focal" ] ; then gem install jazzy; fi
+RUN if [ "${ubuntu_version}" = "focal" ] ; then gem install asciidoctor -v 1.5.8; fi
+RUN if [ "${ubuntu_version}" = "focal" ] ; then gem install asciidoctor-pdf --pre; fi
+RUN if [ "${ubuntu_version}" = "focal" ] ; then gem install asciidoctor-diagram -v 1.5.8; fi
 
 # tools
 RUN mkdir -p $HOME/.tools

--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -1,0 +1,33 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-distributed-actors:20.04-5.6
+    build:
+      args:
+        base_image: "swiftlang/swift:nightly-main-focal"
+
+  unit-tests:
+    image: swift-distributed-actors:20.04-5.6
+
+  unit-tests-until-failure:
+    image: swift-distributed-actors:20.04-5.6
+
+  integration-tests:
+    image: swift-distributed-actors:20.04-5.6
+
+  test:
+    image: swift-distributed-actors:20.04-5.6
+
+  bench:
+    image: swift-distributed-actors:20.04-5.6
+
+  shell:
+    image: swift-distributed-actors:20.04-5.6
+
+  sample-crash:
+    image: swift-distributed-actors:20.04-5.6
+
+  sample-crash-actor:
+    image: swift-distributed-actors:20.04-5.6


### PR DESCRIPTION
motivation: plugins are available only in version 5.6

changes: update the Package manifest to require tools version 5.6
