### PR TITLE
Fix swift-syntax version for Swift 5.5.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -294,9 +294,13 @@ var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.3.2")), // not API stable, Apache v2
 ]
 
-#if swift(>=5.5)
+#if swift(>=5.6)
 dependencies.append(
-    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .revision("swift-DEVELOPMENT-SNAPSHOT-2021-05-18-a"))
+    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .revision("swift-DEVELOPMENT-SNAPSHOT-2021-09-23-a"))
+)
+#elseif swift(>=5.5)
+dependencies.append(
+    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50500.0"))
 )
 #elseif swift(>=5.4)
 dependencies.append(


### PR DESCRIPTION
5.5 version is stable now.