### PR TITLE
Require newer version of swift-nio-ssl

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -187,11 +187,13 @@ var targets: [PackageDescription.Target] = [
         dependencies: [
             "DistributedActors",
             "SwiftBenchmarkTools",
-        ]
+        ],
+        exclude: ["README.md"]
     ),
     .target(
         name: "SwiftBenchmarkTools",
-        dependencies: ["DistributedActors"]
+        dependencies: ["DistributedActors"],
+        exclude: ["README_SWIFT.md"]
     ),
 
     // ==== ----------------------------------------------------------------------------------------------------------------
@@ -208,12 +210,14 @@ var targets: [PackageDescription.Target] = [
 
     .target(
         name: "CDistributedActorsAtomics",
-        dependencies: []
+        dependencies: [],
+        exclude: ["README.md"]
     ),
 
     .target(
         name: "DistributedActorsConcurrencyHelpers",
-        dependencies: ["CDistributedActorsAtomics"]
+        dependencies: ["CDistributedActorsAtomics"],
+        exclude: ["README.md"]
     ),
 ]
 
@@ -222,7 +226,7 @@ var dependencies: [Package.Dependency] = [
 
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.12.0"),
     .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.2.0"),
-    .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.2.0"),
+    .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.16.1"),
 
     .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.7.0"),
 


### PR DESCRIPTION
Motivation:
My local environment was pulling an older version of nio-ssl (2.8?),
which caused build to fail:

```
In file included from /Users/ylee/apple/swift-distributed-actors/.build/checkouts/swift-nio-ssl/Sources/CNIOBoringSSL/include/CNIOBoringSSL_bytestring.h:20:
:139:7: error: missing '#include <stdlib.h>'; 'abort' must be declared before it is used
      abort();
```

Modifications:
- Require nio-ssl 2.16.1+
- Fix some build time warnings

