### PR TITLE
+watch introduce DistributedActor based 'watch' feature

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -62,6 +62,7 @@ var targets: [PackageDescription.Target] = [
         name: "DistributedActorsGenerator",
         dependencies: [
             .product(name: "SwiftSyntax", package: "swift-syntax"),
+            .product(name: "SwiftSyntaxParser", package: "swift-syntax"),
             .product(name: "Logging", package: "swift-log"),
             .product(name: "ArgumentParser", package: "swift-argument-parser"),
         ]
@@ -78,7 +79,12 @@ var targets: [PackageDescription.Target] = [
 
     .target(
         name: "ActorSingletonPlugin",
-        dependencies: ["DistributedActors"]
+        dependencies: [
+            "DistributedActors"
+        ],
+        plugins: [
+            "DistributedActorsGeneratorPlugin"
+        ]
     ),
 
     // ==== ------------------------------------------------------------------------------------------------------------
@@ -87,7 +93,12 @@ var targets: [PackageDescription.Target] = [
     /// This target is intended only for use in tests, though we have no way to mark this
     .target(
         name: "DistributedActorsTestKit",
-        dependencies: ["DistributedActors", "DistributedActorsConcurrencyHelpers"]
+        dependencies: [
+            "DistributedActors", "DistributedActorsConcurrencyHelpers"
+        ],
+        plugins: [
+            "DistributedActorsGeneratorPlugin"
+        ]
     ),
 
     // ==== ------------------------------------------------------------------------------------------------------------
@@ -102,6 +113,9 @@ var targets: [PackageDescription.Target] = [
         ],
         exclude: [
           "DocumentationProtos/",
+        ],
+        plugins: [
+            "DistributedActorsGeneratorPlugin"
         ]
     ),
 
@@ -110,7 +124,10 @@ var targets: [PackageDescription.Target] = [
 
     .testTarget(
         name: "DistributedActorsTests",
-        dependencies: ["DistributedActors", "DistributedActorsTestKit"],
+        dependencies: [
+            "DistributedActors",
+            "DistributedActorsTestKit"
+        ],
         plugins: [
             "DistributedActorsGeneratorPlugin"
         ]
@@ -118,7 +135,10 @@ var targets: [PackageDescription.Target] = [
 
     .testTarget(
         name: "DistributedActorsTestKitTests",
-        dependencies: ["DistributedActors", "DistributedActorsTestKit"],
+        dependencies: [
+            "DistributedActors",
+            "DistributedActorsTestKit"
+        ],
         plugins: [
             "DistributedActorsGeneratorPlugin"
         ]
@@ -126,7 +146,10 @@ var targets: [PackageDescription.Target] = [
 
     .testTarget(
         name: "CDistributedActorsMailboxTests",
-        dependencies: ["CDistributedActorsMailbox", "DistributedActorsTestKit"]
+        dependencies: [
+            "CDistributedActorsMailbox",
+            "DistributedActorsTestKit"
+        ]
     ),
 
     .testTarget(
@@ -139,13 +162,18 @@ var targets: [PackageDescription.Target] = [
         dependencies: [
             "DistributedActorsGenerator",
             "DistributedActorsTestKit",
-        ],
-        plugins: ["DistributedActorsGeneratorPlugin"]
+        ]
     ),
 
     .testTarget(
         name: "ActorSingletonPluginTests",
-        dependencies: ["ActorSingletonPlugin", "DistributedActorsTestKit"]
+        dependencies: [
+            "ActorSingletonPlugin",
+            "DistributedActorsTestKit"
+        ],
+        plugins: [
+            "DistributedActorsGeneratorPlugin"
+        ]
     ),
 
     // ==== ------------------------------------------------------------------------------------------------------------
@@ -199,6 +227,9 @@ var targets: [PackageDescription.Target] = [
         exclude: [
           "README.md",
           "BenchmarkProtos/bench.proto",
+        ],
+        plugins: [
+            "DistributedActorsGeneratorPlugin"
         ]
     ),
     .target(
@@ -222,7 +253,7 @@ var targets: [PackageDescription.Target] = [
     ),
 
     .target(
-        name: "CDistributedActorsAtomics",
+        name: "CDistributedActorsAtomics", // TODO: remove since swift-atomics is ready now
         dependencies: [],
         exclude: [
           "README.md"
@@ -268,7 +299,10 @@ dependencies += [
 // swift-syntax is Swift version dependent, and added as such below
 #if swift(>=5.6)
 dependencies.append(
-    .package(url: "https://github.com/apple/swift-syntax.git", revision: "swift-DEVELOPMENT-SNAPSHOT-2021-09-18-a")
+//      // Works with: swift-PR-39560-1149.xctoolchain
+//    .package(url: "https://github.com/apple/swift-syntax.git", revision: "swift-DEVELOPMENT-SNAPSHOT-2021-10-05-a")
+      // Works with: swift-PR-39654-1170.xctoolchain
+    .package(url: "https://github.com/apple/swift-syntax.git", revision: "b8e4a69237f9dfa362268dddaef8793bc694dc6f")
 //    .package(url: "https://github.com/apple/swift-syntax.git", branch: "main")
 )
 #else

--- a/Plugins/DistributedActorsGeneratorPlugin/Plugin.swift
+++ b/Plugins/DistributedActorsGeneratorPlugin/Plugin.swift
@@ -26,7 +26,7 @@ import PackagePlugin
         } : []
 
         let command = Command.buildCommand(
-            displayName: "Generating distributed actors for \(context.targetName)",
+            displayName: "Generating distributed actors for target '\(context.targetName)'",
             executable: generatorPath,
             arguments: [
                 "--source-directory", context.targetDirectory.string,

--- a/Sources/DistributedActors/ActorAddress.swift
+++ b/Sources/DistributedActors/ActorAddress.swift
@@ -67,6 +67,10 @@ public struct ActorAddress: ActorIdentity {
         }
     }
 
+    public var asAnyActorIdentity: AnyActorIdentity {
+        .init(self)
+    }
+
     // TODO: public var identity: ActorIdentity = Path + Name
 
     /// Underlying path representation, not attached to a specific Actor instance.

--- a/Sources/DistributedActors/DeathWatch.swift
+++ b/Sources/DistributedActors/DeathWatch.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import _Distributed
 import Dispatch
 import NIO
 
@@ -116,7 +117,7 @@ public protocol DeathWatchProtocol {
 // Implementation notes:
 // Care was taken to keep this implementation separate from the ActorCell however not require more storage space.
 @usableFromInline
-internal struct DeathWatch<Message: ActorMessage> {
+internal struct DeathWatchImpl<Message: ActorMessage> {
     private var watching: [AddressableActorRef: OnTerminationMessage] = [:]
     private var watchedBy: Set<AddressableActorRef> = []
 
@@ -310,4 +311,5 @@ internal struct DeathWatch<Message: ActorMessage> {
 
 public enum DeathPactError: Error {
     case unhandledDeathPact(ActorAddress, myself: AddressableActorRef, message: String)
+    case unhandledDeathPactError(AnyActorIdentity, myself: AnyActorIdentity, message: String)
 }

--- a/Sources/DistributedActors/DistributedActor+Messages.swift
+++ b/Sources/DistributedActors/DistributedActor+Messages.swift
@@ -22,7 +22,7 @@ public enum _Done: String, ActorMessage {
 }
 
 public protocol AnyDistributedClusterActor {
-    // TODO(distributed): hopefully remove this, actually system.spawn the underlying reference for the reserved address
+    // TODO(distributed): remove this, actually system.spawn the underlying reference for the reserved address
     static func _spawnAny(instance: Self, on system: ActorSystem) throws -> AddressableActorRef
 }
 

--- a/Sources/DistributedActors/LifecycleWatch.swift
+++ b/Sources/DistributedActors/LifecycleWatch.swift
@@ -1,0 +1,410 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2018-2021 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+import _Distributed
+import NIO
+
+// FIXME(distributed): we can't express the Self: Distributed actor, because the runtime does not understand "hop to distributed actor" - rdar://84054772
+//public protocol LifecycleWatchSupport where Self: DistributedActor {
+public protocol LifecycleWatchSupport {
+    nonisolated var actorTransport: ActorTransport { get } // FIXME: replace with DistributedActor conformance
+    nonisolated var id: AnyActorIdentity { get } // FIXME: replace with DistributedActor conformance
+}
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: Lifecycle Watch API
+
+extension LifecycleWatchSupport {
+
+    public func watchTermination<Watchee>(
+        of watchee: Watchee,
+        @_inheritActorContext @_implicitSelfCapture whenTerminated: @escaping @Sendable (AnyActorIdentity) -> (),
+        file: String = #file, line: UInt = #line
+    ) -> Watchee where Self: DistributedActor, Watchee: DistributedActor { // TODO(distributed): allow only Watchee where the watched actor is on a transport that supports watching
+        // TODO(distributed): reimplement this as self.id as? ActorContext which will have the watch things.
+        guard let system = self.actorTransport._unwrapActorSystem else {
+            fatalError("TODO: handle more gracefully") // TODO: handle more gracefully, i.e. say that we can't watch that actor
+        }
+
+        // TODO(distributed): these casts will go away once we can force LifecycleWatchSupport: DistributedActor
+//        guard let watcher = self as? (LifecycleWatchSupport & DistributedActor) else {
+//            fatalError("It should be guaranteed that we're in such type") // TODO: once we can express LWS: DA we don't need this cast
+//        }
+
+//        func doWatchTermination<Act: LifecycleWatchSupport & DistributedActor>(watcher: Act) {
+            guard let watch = system._getLifecycleWatch(watcher: self) else {
+                return watchee
+            }
+
+            watch.termination(of: watchee, whenTerminated: whenTerminated, file: file, line: line)
+//        }
+//        _openExistential(watcher, do: doWatchTermination)
+
+        return watchee
+    }
+
+    /// Reverts the watching of an previously watched actor.
+    ///
+    /// Unwatching a not-previously-watched actor has no effect.
+    ///
+    /// ### Semantics for in-flight Terminated signals
+    ///
+    /// After invoking `unwatch`, even if a `Signals.Terminated` signal was already enqueued at this actors
+    /// mailbox; this signal would NOT be delivered, since the intent of no longer watching the terminating
+    /// actor takes immediate effect.
+    ///
+    /// #### Concurrency:
+    ///  - MUST NOT be invoked concurrently to the actors execution, i.e. from the "outside" of the current actor.
+    ///
+    /// - Returns: the passed in watchee reference for easy chaining `e.g. return context.unwatch(ref)`
+    public func isWatching<Watchee>(_ watchee: Watchee) -> Bool where Self: DistributedActor, Watchee: DistributedActor {
+        // TODO(distributed): reimplement this as self.id as? ActorContext which will have the watch things.
+        guard let system = self.actorTransport._unwrapActorSystem else {
+            fatalError("TODO: handle more gracefully") // TODO: handle more gracefully, i.e. say that we can't watch that actor
+        }
+
+        return system._getLifecycleWatch(watcher: self)?.isWatching(watchee.id) ?? false
+    }
+
+    /// Reverts the watching of an previously watched actor.
+    ///
+    /// Unwatching a not-previously-watched actor has no effect.
+    ///
+    /// ### Semantics for in-flight Terminated signals
+    ///
+    /// After invoking `unwatch`, even if a `Signals.Terminated` signal was already enqueued at this actors
+    /// mailbox; this signal would NOT be delivered to the `onSignal` behavior, since the intent of no longer
+    /// watching the terminating actor takes immediate effect.
+    ///
+    /// #### Concurrency:
+    ///  - MUST NOT be invoked concurrently to the actors execution, i.e. from the "outside" of the current actor.
+    ///
+    /// - Returns: the passed in watchee reference for easy chaining `e.g. return context.unwatch(ref)`
+    @discardableResult
+    func unwatch<Watchee>(
+            _ watchee: Watchee,
+            file: String = #file, line: UInt = #line
+    ) -> Watchee where Self: DistributedActor, Watchee: DistributedActor  {
+        // TODO(distributed): reimplement this as self.id as? ActorContext which will have the watch things.
+        guard let system = self.actorTransport._unwrapActorSystem else {
+            fatalError("TODO: handle more gracefully") // TODO: handle more gracefully, i.e. say that we can't watch that actor
+        }
+
+        guard let watch = system._getLifecycleWatch(watcher: self) else {
+            return watchee
+        }
+
+        return watch.unwatch(watchee: watchee, file: file, line: line)
+    }
+}
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: "Internal" functions made to make the watch signals work
+
+extension LifecycleWatchSupport {
+    /// Function invoked by the actor transport when a distributed termination is detected.
+    public func _receiveActorTerminated(identity: AnyActorIdentity) async throws where Self: DistributedActor {
+        guard let system = self.actorTransport._unwrapActorSystem else {
+            return // TODO: error instead
+        }
+
+        guard let watch: LifecycleWatch = system._getLifecycleWatch(watcher: self) else {
+            return
+        }
+
+        watch.receiveTerminated(identity)
+    }
+}
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: System extensions to support watching // TODO: move those into context, and make the ActorIdentity the context
+
+extension ActorSystem {
+
+    public func _makeLifecycleWatch<Watcher: LifecycleWatchSupport & DistributedActor>(watcher: Watcher) -> LifecycleWatch {
+        return self.lifecycleWatchLock.withLock {
+            if let watch = self._lifecycleWatches[watcher.id] {
+                return watch
+            }
+
+            let watch = LifecycleWatch(watcher)
+            self._lifecycleWatches[watcher.id] = watch
+            return watch
+        }
+    }
+
+    // public func _getWatch<DA: DistributedActor>(_ actor: DA) -> LifecycleWatch? {
+    public func _getLifecycleWatch<Watcher: LifecycleWatchSupport & DistributedActor>(watcher: Watcher) -> LifecycleWatch? {
+        return self.lifecycleWatchLock.withLock {
+            return self._lifecycleWatches[watcher.id]
+        }
+    }
+
+}
+
+/// Implements watching distributed actors for termination.
+///
+/// Termination of local actors is simply whenever they deinitialize.
+/// Remote actors are considered terminated when they deinitialize, same as local actors,
+/// or when the node hosting them is declared `.down`.
+public final class LifecycleWatch {
+
+    private weak var myself: DistributedActor? // TODO: make this just store the address instead?
+    private let myselfID: AnyActorIdentity
+
+    private let system: ActorSystem
+    private let nodeDeathWatcher: NodeDeathWatcherShell.Ref?
+
+    typealias OnTerminatedFn = @Sendable (AnyActorIdentity) async -> Void
+    private var watching: [AnyActorIdentity: OnTerminatedFn] = [:]
+    private var watchedBy: [AnyActorIdentity: AddressableActorRef] = [:]
+
+    // FIXME(distributed): use the Transport typealias to restrict that the transport has watch support
+    init<Act>(_ myself: Act) where Act: DistributedActor {
+        traceLog_DeathWatch("Make LifecycleWatch owned by \(myself.id)")
+        self.myself = myself
+        self.myselfID = myself.id
+        let system = myself.actorTransport._forceUnwrapActorSystem
+        self.system = system
+        self.nodeDeathWatcher = system._nodeDeathWatcher
+    }
+
+    deinit {
+        traceLog_DeathWatch("Deinit LifecycleWatch owned by \(myselfID)")
+        for watched in watching.values {
+            nodeDeathWatcher?.tell(.removeWatcher(watcherIdentity: myselfID))
+        }
+    }
+}
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: perform watch/unwatch
+
+extension LifecycleWatch {
+
+
+    /// Performed by the sending side of "watch", therefore the `watcher` should equal `context.myself`
+    public func termination<Watchee>(
+            of watchee: Watchee,
+            @_inheritActorContext @_implicitSelfCapture whenTerminated: @escaping @Sendable (AnyActorIdentity) -> (),
+            file: String = #file, line: UInt = #line
+    ) where // Watchee: DeathWatchable,
+            Watchee: DistributedActor {
+        traceLog_DeathWatch("issue watch: \(watchee) (from \(optional: myself))")
+
+        guard let watcheeAddress = watchee.id._unwrapActorAddress else {
+            fatalError("Cannot watch actor \(watchee), it is not managed by the cluster. Identity: \(watchee.id.underlying)")
+        }
+
+        guard let watcherAddress = myself?.id._unwrapActorAddress else {
+            fatalError("Cannot watch from actor \(optional: myself), it is not managed by the cluster. Identity: \(watchee.id.underlying)")
+        }
+
+        // watching ourselves is a no-op, since we would never be able to observe the Terminated message anyway:
+        guard watcheeAddress != watcherAddress else {
+            return
+        }
+
+        let addressableWatchee = system._resolveUntyped(context: .init(address: watcheeAddress, system: system))
+        let addressableWatcher = system._resolveUntyped(context: .init(address: watcherAddress, system: system))
+
+        if self.isWatching(watchee.id) {
+            // While we bail out early here, we DO override whichever value was set as the customized termination message.
+            // This is to enable being able to keep updating the context associated with a watched actor, e.g. if how
+            // we should react to its termination has changed since the last time watch() was invoked.
+            self.watching[watchee.id] = whenTerminated
+
+            return
+        } else {
+            // not yet watching, so let's add it:
+            self.watching[watchee.id] = whenTerminated
+
+            addressableWatchee._sendSystemMessage(.watch(watchee: addressableWatchee, watcher: addressableWatcher), file: file, line: line)
+            self.subscribeNodeTerminatedEvents(watchedAddress: watcheeAddress, file: file, line: line)
+        }
+    }
+
+    /// Reverts the watching of an previously watched actor.
+    ///
+    /// Unwatching a not-previously-watched actor has no effect.
+    ///
+    /// ### Semantics for in-flight Terminated signals
+    ///
+    /// After invoking `unwatch`, even if a `Signals.Terminated` signal was already enqueued at this actors
+    /// mailbox; this signal would NOT be delivered to the `onSignal` behavior, since the intent of no longer
+    /// watching the terminating actor takes immediate effect.
+    ///
+    /// #### Concurrency:
+    ///  - MUST NOT be invoked concurrently to the actors execution, i.e. from the "outside" of the current actor.
+    ///
+    /// - Returns: the passed in watchee reference for easy chaining `e.g. return context.unwatch(ref)`
+    public func unwatch<Watchee>(
+        watchee: Watchee,
+        file: String = #file, line: UInt = #line
+    ) -> Watchee where Watchee: DistributedActor {
+        traceLog_DeathWatch("issue unwatch: watchee: \(watchee) (from \(optional: myself))")
+        guard let watcheeAddress = watchee.id._unwrapActorAddress else {
+            return watchee
+        }
+        guard let watcherAddress = myself?.id._unwrapActorAddress else {
+            return watchee
+        }
+
+        // FIXME(distributed): we have to make this nicer, the ID itself must "be" the ref
+        let system = watchee.actorTransport._forceUnwrapActorSystem
+        let addressableWatchee = system._resolveUntyped(context: .init(address: watcheeAddress, system: system))
+        let addressableMyself = system._resolveUntyped(context: .init(address: watcherAddress, system: system))
+
+        // we could short circuit "if watchee == myself return" but it's not really worth checking since no-op anyway
+        if self.watching.removeValue(forKey: watchee.id) != nil {
+            addressableWatchee._sendSystemMessage(
+                    .unwatch(
+                            watchee: addressableWatchee, watcher: addressableMyself),
+                            file: file, line: line)
+        }
+
+        return watchee
+    }
+
+    /// - Returns `true` if the passed in actor ref is being watched
+    @usableFromInline
+    internal func isWatching(_ identity: AnyActorIdentity) -> Bool {
+        self.watching[identity] != nil
+    }
+
+    // ==== ------------------------------------------------------------------------------------------------------------
+    // MARK: react to watch or unwatch signals
+
+    public func becomeWatchedBy(
+            watcher: AddressableActorRef
+    ) {
+        guard watcher.address != myself?.id._unwrapActorAddress else {
+            traceLog_DeathWatch("Attempted to watch 'myself' [\(optional: myself)], which is a no-op, since such watch's terminated can never be observed. " +
+                    "Likely a programming error where the wrong actor ref was passed to watch(), please check your code.")
+            return
+        }
+
+        traceLog_DeathWatch("Become watched by: \(watcher.address)     inside: \(optional: myself)")
+        self.watchedBy[watcher.address.asAnyActorIdentity] = watcher
+    }
+
+    func removeWatchedBy(watcher: AddressableActorRef) {
+        traceLog_DeathWatch("Remove watched by: \(watcher.address)     inside: \(optional: myself)")
+        self.watchedBy.removeValue(forKey: watcher.address.asAnyActorIdentity)
+    }
+
+    /// Performs cleanup of references to the dead actor.
+    public func receiveTerminated(_ terminated: Signals.Terminated){
+//        // refs are compared ONLY by address, thus we can make such mock reference, and it will be properly remove the right "real" refs from the collections below
+//        let mockRefForEquality = ActorRef<Never>(.deadLetters(.init(.init(label: "x"), address: terminated.address, system: nil))).asAddressable
+        // let terminatedIdentity = terminated.address.asAnyActorIdentity
+        self.receiveTerminated(terminated.address.asAnyActorIdentity)
+    }
+
+    public func receiveTerminated(_ terminatedIdentity: AnyActorIdentity) {
+        // we remove the actor from both sets;
+        // 1) we don't need to watch it anymore, since it has just terminated,
+        let removedOnTerminationFn = self.watching.removeValue(forKey: terminatedIdentity)
+        // 2) we don't need to refer to it, since sending it .terminated notifications would be pointless.
+        _ = self.watchedBy.removeValue(forKey: terminatedIdentity)
+
+        guard let onTermination = removedOnTerminationFn else {
+            // if we had no stored/removed termination message, it means this actor was NOT watched actually.
+            // Meaning: don't deliver Signal/message to user actor.
+            return
+        }
+
+        Task {
+            // TODO(distributed): we should surface the additional information (node terminated, existence confirmed) too
+            await onTermination(terminatedIdentity)
+        }
+    }
+
+    /// Performs cleanup of any actor references that were located on the now terminated node.
+    ///
+    /// Causes `Terminated` signals to be triggered for any such watched remote actor.
+    ///
+    /// Does NOT immediately handle these `Terminated` signals, they are treated as any other normal signal would,
+    /// such that the user can have a chance to handle and react to them.
+    public func receiveNodeTerminated(_ terminatedNode: UniqueNode) {
+        // TODO: remove actors as we notify about them
+        for (watched, fn) in self.watching {
+            guard let watchedAddress = watched._unwrapActorAddress, watchedAddress.uniqueNode == terminatedNode else {
+                continue
+            }
+
+            // we KNOW an actor existed if it is local and not resolved as /dead; otherwise it may have existed
+            // for a remote ref we don't know for sure if it existed
+            // let existenceConfirmed = watched.refType.isLocal && !watched.address.path.starts(with: ._dead)
+            let existenceConfirmed = true // TODO: implement support for existence confirmed or drop it?
+
+            guard let address = self.myself?.id._unwrapActorAddress else {
+                return
+            }
+
+//            let ref = system._resolveUntyped(context: .init(address: address, system: system))
+//            ref._sendSystemMessage(.terminated(ref: watched, existenceConfirmed: existenceConfirmed, addressTerminated: true), file: #file, line: #line)
+            // fn(watched)
+            self.receiveTerminated(watched)
+        }
+    }
+
+    // ==== ----------------------------------------------------------------------------------------------------------------
+    // MARK: Myself termination
+
+    func notifyWatchersWeDied() {
+        traceLog_DeathWatch("[\(optional: myself)] notifyWatchers that we are terminating. Watchers: \(self.watchedBy)...")
+
+        for (watcherIdentity, watcherRef) in self.watchedBy {
+            traceLog_DeathWatch("[\(optional: myself)] Notify  \(watcherIdentity) (\(watcherRef)) that we died")
+            if let address = myself?.id._unwrapActorAddress {
+                let fakeRef = ActorRef<_Done>(.deadLetters(.init(.init(label: "x"), address: address, system: nil)))
+                watcherRef._sendSystemMessage(.terminated(ref: fakeRef.asAddressable, existenceConfirmed: true))
+            }
+        }
+    }
+
+    // ==== ------------------------------------------------------------------------------------------------------------
+    // MARK: Node termination
+
+    private func subscribeNodeTerminatedEvents(
+            watchedAddress: ActorAddress,
+            file: String = #file, line: UInt = #line) {
+//        guard watchedAddress._isRemote else {
+//            return
+//        }
+//        self.nodeDeathWatcher.tell(.remoteActorWatched(watcher: AddressableActorRef(myself), remoteNode: watchedAddress.uniqueNode), file: file, line: line)
+        guard let id = myself?.id else {
+            return
+        }
+
+        self.nodeDeathWatcher?.tell(  // different actor
+            .remoteDistributedActorWatched(
+                remoteNode: watchedAddress.uniqueNode,
+                watcherIdentity: id,
+                nodeTerminated: { [weak system] uniqueNode in
+                    guard let myselfRef = system?._resolveUntyped(context: .init(address: id._forceUnwrapActorAddress, system: system!)) else {
+                        return
+                    }
+                    myselfRef._sendSystemMessage(.nodeTerminated(uniqueNode), file: file, line: line)
+//                    // FIXME: OMG WE NEED whenLocal
+//                    if let myself = myself {
+//                        whenLocal(myself) { (isolated myself: LifecycleWatchSupport) in
+//                            myself.receiveNodeTerminated()
+//                        }
+//                    }
+                }))
+    }
+}

--- a/Sources/DistributedActors/Mailbox.swift
+++ b/Sources/DistributedActors/Mailbox.swift
@@ -313,7 +313,6 @@ internal final class Mailbox<Message: ActorMessage> {
             fatalError("""
                        !!! BUG !!! Tombstone was attempted to be enqueued at not terminating actor.
                        Address: \(self.address)
-                       Actor: \(self.shell)
                        System: \(self.shell?._system?.description ?? "<no system>")
                        """)
         }
@@ -387,11 +386,6 @@ internal final class Mailbox<Message: ActorMessage> {
             runResult = .shouldSuspend
         }
 
-
-//        if (shell.address.path == ActorPath._clusterShell) {
-//            print(">>>>> mailbox run = \(shell.address.fullDescription)")
-//        }
-
         // system messages run -----------------------------------------------------------------------------------------
 
         if status.hasSystemMessages {
@@ -399,9 +393,6 @@ internal final class Mailbox<Message: ActorMessage> {
                   runResult != .closed,
                   let message = self.systemMessages.dequeue() {
                 do {
-//                    if (shell.address.path.segments.last!.description == "cluster") {
-//                        pprint(">>>>> mailbox run system = \(shell.address) <<<<< \(message)")
-//                    }
                     try runResult = shell.interpretSystemMessage(message: message)
                 } catch {
                     shell.fail(error)

--- a/Sources/DistributedActors/Props.swift
+++ b/Sources/DistributedActors/Props.swift
@@ -37,8 +37,14 @@ public struct Props {
 
     public var metrics: MetricsProps
 
-    /// INTERNAL API: Allows spawning a "well known" actor. Use with great care, only if a single incarnation of actor will ever exist under the given path.
+    /// INTERNAL API: Allows spawning a "well known" actor. Use with great care,
+    /// only if a single incarnation of actor will ever exist under the given path.
     internal var _wellKnown: Bool = false
+
+    /// INTERNAL API: Marks that this ref is spawned in service of a 'distributed actor'.
+    /// This is a temporary solution until we move all the infrastructure onto distributed actors.
+    @usableFromInline
+    internal var _distributedActor: Bool = false
 
     public init(mailbox: MailboxProps = .default(), dispatcher: DispatcherProps = .default, supervision: SupervisionProps = .default, metrics: MetricsProps = .disabled) {
         self.mailbox = mailbox

--- a/Sources/DistributedActors/Refs+any.swift
+++ b/Sources/DistributedActors/Refs+any.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import _Distributed
 import struct NIO.ByteBuffer
 import protocol NIO.EventLoop
 
@@ -62,6 +63,10 @@ public struct AddressableActorRef: DeathWatchable, Hashable {
 
     public var address: ActorAddress {
         self.ref.address
+    }
+
+    public var asAnyActorIdentity: AnyActorIdentity {
+        self.address.asAnyActorIdentity
     }
 
     public var asAddressable: AddressableActorRef {

--- a/Sources/DistributedActors/Signals.swift
+++ b/Sources/DistributedActors/Signals.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import _Distributed
+
 /// Signals are additional messages which are passed using the system channel and may be handled by actors.
 /// They inform the actors about various lifecycle events which the actor may want to react to.
 ///
@@ -72,11 +74,18 @@ public enum Signals {
     open class Terminated: Signal, CustomStringConvertible {
         /// Address of the terminated actor.
         public let address: ActorAddress
+
+        /// Identity of the terminated distributed actor.
+        public var identity: AnyActorIdentity {
+            self.address.asAnyActorIdentity
+        }
+
         /// The existence of this actor has been confirmed prior to its termination.
         ///
         /// This is a "weak" information, i.e. even an existing actors' termination could still result in `existenceConfirmed` marked `false`,
         /// however this information will never wrongly be marked `true`.
         public let existenceConfirmed: Bool
+
         /// True if the actor was located on a remote node, and this entire node has terminated (marked as `MemberStatus.down`),
         /// meaning that no communication with any actor on this node will be possible anymore, resulting in this `Terminated` signal.
         public let nodeTerminated: Bool // TODO: Making this a `Reason` could be nicer.

--- a/Sources/DistributedActorsGenerator/DistributedActorAnalysis.swift
+++ b/Sources/DistributedActorsGenerator/DistributedActorAnalysis.swift
@@ -15,6 +15,7 @@
 import Foundation
 import Logging
 import SwiftSyntax
+import SwiftSyntaxParser
 
 let BLUE = "\u{001B}[0;34m"
 let RST = "\u{001B}[0;0m"
@@ -121,7 +122,7 @@ final class GatherDistributedActors: SyntaxVisitor {
         }
         self.wipDecl.imports = self.imports
         self.wipDecl.declaredWithin = self.nestingStack
-        self.log.info("Found 'distributed actor \(BLUE)\(self.wipDecl.fullName)\(RST)' (\(self.path.path(relativeTo: self.basePath)) in module \(self.moduleName)")
+        self.log.info("Found 'distributed actor \(BLUE)\(self.wipDecl.fullName)\(RST)' in module \(self.moduleName), path: \(self.path.path(relativeTo: self.basePath))")
 
         return .visitChildren
     }

--- a/Sources/DistributedActorsGenerator/GenerateActors.swift
+++ b/Sources/DistributedActorsGenerator/GenerateActors.swift
@@ -16,6 +16,7 @@ import ArgumentParser
 import Foundation
 import Logging
 import SwiftSyntax
+import SwiftSyntaxParser
 
 final class GenerateActors {
     var log: Logger

--- a/Tests/DistributedActorsDocumentationTests/XCTest+Async.swift
+++ b/Tests/DistributedActorsDocumentationTests/XCTest+Async.swift
@@ -21,7 +21,7 @@ extension XCTestCase {
     // FIXME(distributed): remove once XCTest supports async functions on Linux
     func runAsyncAndBlock(
             @_inheritActorContext @_implicitSelfCapture operation: __owned @Sendable @escaping () async throws -> Void,
-            _ timeout: TimeAmount = .seconds(3)) rethrows {
+            _ timeout: TimeAmount = .seconds(10)) rethrows {
         let finished = expectation(description: "finished")
         Task {
             try await operation()

--- a/Tests/DistributedActorsGeneratorTests/XCTest+Async.swift
+++ b/Tests/DistributedActorsGeneratorTests/XCTest+Async.swift
@@ -21,7 +21,7 @@ extension XCTestCase {
     // FIXME(distributed): remove once XCTest supports async functions on Linux
     func runAsyncAndBlock(
             @_inheritActorContext @_implicitSelfCapture operation: __owned @Sendable @escaping () async throws -> Void,
-            _ timeout: TimeAmount = .seconds(3)) rethrows {
+            _ timeout: TimeAmount = .seconds(10)) rethrows {
         let finished = expectation(description: "finished")
         Task {
             try await operation()

--- a/Tests/DistributedActorsTests/BehaviorMatchers.swift
+++ b/Tests/DistributedActorsTests/BehaviorMatchers.swift
@@ -29,7 +29,8 @@ internal extension Behavior {
                 return try 1 + nestingDepth0(onStart(context))
             case .intercept(let inner, _):
                 return try 1 + nestingDepth0(inner)
-            case .signalHandling(let onMessage, _):
+            case .signalHandling(let onMessage, _),
+                 .signalHandlingAsync(let onMessage, _):
                 return try 1 + nestingDepth0(onMessage)
             case .orElse(let first, let other):
                 return 1 + max(try nestingDepth0(first), try nestingDepth0(other))
@@ -70,6 +71,10 @@ internal extension Behavior {
                     "\(pad))\n"
             case .signalHandling(let handleMessage, let handleSignal):
                 return "\(pad)signalHandling(handleSignal:\(String(describing: handleSignal))\n" +
+                    (try prettyFormat0(handleMessage, depth: depth + 1)) +
+                    "\(pad))\n"
+            case .signalHandlingAsync(let handleMessage, let handleSignalAsync):
+                return "\(pad)signalHandlingAsync(handleSignal:\(String(describing: handleSignalAsync))\n" +
                     (try prettyFormat0(handleMessage, depth: depth + 1)) +
                     "\(pad))\n"
             case .orElse(let first, let second):

--- a/Tests/DistributedActorsTests/LifecycleWatchTests.swift
+++ b/Tests/DistributedActorsTests/LifecycleWatchTests.swift
@@ -1,0 +1,124 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2018-2021 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import _Distributed
+@testable import DistributedActors
+import DistributedActorsTestKit
+import Foundation
+import Logging
+import XCTest
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: Romeo
+
+distributed actor Romeo: LifecycleWatchSupport, CustomStringConvertible {
+    let probe: ActorTestProbe<String>
+
+    lazy var log = Logger(actor: self)
+
+    init(probe: ActorTestProbe<String>, transport: ActorTransport) {
+        defer { transport.actorReady(self) }
+        self.probe = probe
+        probe.tell("Romeo init")
+    }
+
+    deinit {
+        probe.tell("Romeo deinit")
+    }
+
+    distributed func greet(_ greeting: String) {
+        // nothing important here
+    }
+
+    nonisolated var description: String {
+        "\(Self.self)(\(id))"
+    }
+}
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: Juliet
+
+distributed actor Juliet: LifecycleWatchSupport, CustomStringConvertible {
+    let probe: ActorTestProbe<String>
+
+    init(probe: ActorTestProbe<String>, transport: ActorTransport) {
+        defer { transport.actorReady(self) }
+        self.probe = probe
+        probe.tell("Juliet init")
+    }
+
+    distributed func meetWatchCallback(
+        _ romeo: Romeo,
+        unwatch doUnwatch: Bool
+    ) async throws {
+        watchTermination(of: romeo) { terminatedIdentity in
+            probe.tell("Received terminated: \(terminatedIdentity)")
+        }
+        if doUnwatch {
+            unwatch(romeo)
+        }
+    }
+
+    nonisolated var description: String {
+        "\(Self.self)(\(id))"
+    }
+}
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: Tests
+
+final class DeathWatchDistributedTests: ActorSystemXCTestCase {
+
+    func test_watch_shouldTriggerTerminatedWhenWatchedActorDeinits() throws {
+        try runAsyncAndBlock {
+            let pj = testKit.spawnTestProbe(expecting: String.self)
+            let pr = testKit.spawnTestProbe(expecting: String.self)
+            let juliet = Juliet(probe: pj, transport: system)
+
+            func meet() async throws {
+                var romeo: Romeo? = Romeo(probe: pr, transport: system)
+
+                try await juliet.meetWatchCallback(romeo!, unwatch: false)
+                romeo = nil
+            }
+            try await meet()
+
+            try pj.expectMessage("Juliet init")
+            try pr.expectMessage("Romeo init")
+            try pr.expectMessage("Romeo deinit")
+            try pj.expectMessage("Received terminated: AnyActorIdentity(/user/Romeo-b)")
+        }
+    }
+
+    func test_watchThenUnwatch_shouldTriggerTerminatedWhenWatchedActorDeinits() throws {
+        try runAsyncAndBlock {
+            let pj = testKit.spawnTestProbe(expecting: String.self)
+            let pr = testKit.spawnTestProbe(expecting: String.self)
+            let juliet = Juliet(probe: pj, transport: system)
+
+            func meet() async throws {
+                var romeo: Romeo? = Romeo(probe: pr, transport: system)
+
+                try await juliet.meetWatchCallback(romeo!, unwatch: true)
+                romeo = nil
+            }
+            try await meet()
+
+            try pj.expectMessage("Juliet init")
+            try pr.expectMessage("Romeo init")
+            try pr.expectMessage("Romeo deinit")
+            try pj.expectNoMessage(for: .milliseconds(300))
+        }
+    }
+}

--- a/Tests/DistributedActorsTests/XCTest+Async.swift
+++ b/Tests/DistributedActorsTests/XCTest+Async.swift
@@ -21,7 +21,7 @@ extension XCTestCase {
     // FIXME(distributed): remove once XCTest supports async functions on Linux
     func runAsyncAndBlock(
             @_inheritActorContext @_implicitSelfCapture operation: __owned @Sendable @escaping () async throws -> Void,
-            _ timeout: TimeAmount = .seconds(3)) rethrows {
+            _ timeout: TimeAmount = .seconds(10)) rethrows {
         let finished = expectation(description: "finished")
         Task {
             try await operation()


### PR DESCRIPTION
Implements lifecycle watch / death watch for distributed actors.

This is not the best way we'd like to implement it -- we'll end up making a new context type that will be the identity, but this is good enough to show that it can work for now.