### PR TITLE
Fix the link to the screenshot of the Instruments

### DIFF
--- a/Instruments/README.md
+++ b/Instruments/README.md
@@ -23,4 +23,4 @@ as their visualizations help understand more about how the actor system is funct
 
 ## Screenshots (may be not super up to date)
 
-![](Screen Shot 2020-07-06 at 12.27.35.png)
+<img src="./Screen Shot 2020-07-06 at 12.27.35.png" />


### PR DESCRIPTION
Maybe this isn't meant to be seen in GitHub, which is fine to then close, but https://github.com/apple/swift-distributed-actors/tree/main/Instruments does not show the image