### PR TITLE
invoking docc from toolchains

### DIFF
--- a/scripts/docs/generate_docc.sh
+++ b/scripts/docs/generate_docc.sh
@@ -47,30 +47,13 @@ declare -r build_path_linux="$build_path/"
 declare -r docc_source_path="$root_path/.build/swift-docc"
 declare -r docc_render_source_path="$root_path/.build/swift-docc-render"
 
-# Prepare and build docc
-if [[ ! -d "$docc_source_path" ]]; then
-  git clone https://github.com/apple/swift-docc.git "$docc_source_path"
-  cd $docc_source_path
-
-  if [[ ! -d "$docc_source_path/$build_path" ]]; then
-    swift build -c release
-  fi
-else
-  echo "Assuming docc is built..."
+# invoking docc from toolchain
+if [-z ${TOOLCHAIN+x} ]; then   
+  echo "TOOLCHAIN is unset"; exit(1);
 fi
+export DOCC_HTML_DIR=${TOOLCHAIN}/usr/bin/docc
 
-
-if [[ ! -d "$docc_render_source_path" ]]; then
-  git clone https://github.com/apple/swift-docc-render.git "$docc_render_source_path"
-  cd $docc_render_source_path
-
-  npm install
-  npm run build
-else
-  echo "Assuming docc-render is built..."
-fi
-
-export DOCC_HTML_DIR=$docc_render_source_path/dist
+$TOOLCHAIN/usr/bin/docc
 
 # Build documentation
 


### PR DESCRIPTION
Adjusted the generate_docc.sh file to invoke docc from toolchains now.

### Motivation:

Now that the DocC ships in toolchains, I adjusted the generate_docc.sh file to invoke docC directly from toolchains. I am making this change in order to learn contributing effectively. I am trying to update the DocC.

### Modifications:
1) changed the prepare and build toolchain(earlier line no 50 to 73) code to directly access docc from toolchains.
2) modified and wrote
     export TOOLCHAIN=/Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2021-11-20-a.xctoolchain.  
     cd $TOOLCHAIN/usr/bin/docc

### Result:

- Resolves #856 
<img width="974" alt="Screenshot 2021-12-01 at 6 54 03 PM" src="https://user-images.githubusercontent.com/78029920/144242181-8536f3b6-303a-4a38-a0f6-f8384c025459.png">

