### PR TITLE
Fix a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ error: signalled(6): /Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-20
   Reason: tried: '/usr/lib/swift/libswift_Distributed.dylib' (no such file), '/usr/local/lib/libswift_Distributed.dylib' (no such file), '/usr/lib/libswift_Distributed.dylib' (no such file))
 ```
 
-Instead, you must find the `xctest` binary in XCode:
+Instead, you must find the `xctest` binary in Xcode:
 
 ```
 -> % find /Applications/Xcode-Latest.app  | grep xctest


### PR DESCRIPTION
Fix the typo in README.md

### Motivation:

https://lists.apple.com/archives/xcode-users/2007/Jan/msg00073.html

"The C language is case-sensitive. Compilers are case-sensitive. The Unix command line, ufs, and nfs file systems are case-sensitive. I'm case-sensitive too, especially about product names. The IDE is called Xcode. Big X, little c. Not XCode or xCode or X-Code. Remember that now." — Chris Espinosa
