### PR TITLE
Update the usage of docc

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,13 @@ As such, it is necessary to download and use nightly built toolchains to develop
 
 Distributed actors require "latest" nightly toolchains to build correctly.
 
-At this point in time, the **2021-10-26 nightly toolchain** is sufficient to build the project.
+At this point in time, the **2021-11-02 nightly toolchain** is sufficient to build the project.
 You can download it from [https://swift.org/download/](https://swift.org/download/).
 
 ```
 # Export the toolchain (nightly snapshot or pull-request generated toolchain), e.g.:
 
-export TOOLCHAIN=/Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2021-10-26-a.xctoolchain
+export TOOLCHAIN=/Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2021-11-02-a.xctoolchain
 
 # Just build the project
 $TOOLCHAIN/usr/bin/swift build --build-tests
@@ -272,18 +272,13 @@ Only an initial version of API documentation is available right now. This is mos
 library is expected to change intensely, along with the evolving language proposal on which this library depends.
 
 You can build API documentation by running the Swift DocC compiler. The [recently released DocC compiler](https://swift.org/blog/swift-docc/) is an official part of the Swift
-project, however it is so new, that it does not ship with official toolchains yet. Therefore, we provide scripts that
-automate the building and previewing documentation for you. Those will not be necessary once DocC begins to ship with  
-toolchains.
+project, and it ships with the recent nightly toolchains.
 
 Do build documentation run:
 
 ```bash
 ./scripts/docs/generate_docc.sh
 ```
-
-Upon first invocation, this will download and build the `docc` tool. Subsequent invocations will be fast, as only the 
-initial call has to download and build the tool itself. 
 
 And to preview and browse the documentation as a web-page, run: 
 

--- a/scripts/docs/generate_docc.sh
+++ b/scripts/docs/generate_docc.sh
@@ -35,47 +35,12 @@ modules=(
   DistributedActors
 )
 
-declare -r SWIFT="$TOOLCHAIN/usr/bin/swift"
-
-# all our public modules which we want to document, begin with `DistributedActors`
-modules=(
-  DistributedActors
-)
-
-declare -r build_path=".build/"
-declare -r build_path_linux="$build_path/"
-declare -r docc_source_path="$root_path/.build/swift-docc"
-declare -r docc_render_source_path="$root_path/.build/swift-docc-render"
-
-# Prepare and build docc
-if [[ ! -d "$docc_source_path" ]]; then
-  git clone https://github.com/apple/swift-docc.git "$docc_source_path"
-  cd $docc_source_path
-
-  if [[ ! -d "$docc_source_path/$build_path" ]]; then
-    swift build -c release
-  fi
-else
-  echo "Assuming docc is built..."
-fi
-
-
-if [[ ! -d "$docc_render_source_path" ]]; then
-  git clone https://github.com/apple/swift-docc-render.git "$docc_render_source_path"
-  cd $docc_render_source_path
-
-  npm install
-  npm run build
-else
-  echo "Assuming docc-render is built..."
-fi
-
-export DOCC_HTML_DIR=$docc_render_source_path/dist
-
 # Build documentation
 
 cd $root_path
 mkdir -p $root_path/.build/symbol-graphs
+
+declare -r SWIFT="$TOOLCHAIN/usr/bin/swift"
 
 for module in "${modules[@]}"; do
   echo "Building symbol-graph for module [$module]..."

--- a/scripts/docs/preview_docc.sh
+++ b/scripts/docs/preview_docc.sh
@@ -36,13 +36,10 @@ modules=(
   DistributedActorsTestKit
 )
 
-declare -r build_path_linux=".build/x86_64-unknown-linux-gnu"
-declare -r docc_source_path="$root_path/.build/swift-docc"
-declare -r docc_render_source_path="$root_path/.build/swift-docc-render"
+declare -r SWIFT_DOCC="$TOOLCHAIN/usr/bin/docc"
+export DOCC_HTML_DIR="$TOOLCHAIN/usr/share/docc/render"
 
-export DOCC_HTML_DIR="$docc_render_source_path/dist"
-
-./.build/swift-docc/.build/release/docc preview $root_path/Docs/DistributedActors.docc \
+$SWIFT_DOCC preview $root_path/Docs/DistributedActors.docc \
   --fallback-display-name DistributedActors \
   --fallback-bundle-identifier org.swift.preview.DistributedActors \
   --fallback-bundle-version "$version" \


### PR DESCRIPTION
- Remove docc and docc render build
- Update README.md to reflect docc change

### Motivation:

#856

#863 

### Modifications:

Update scripts/docs/generate_docc.sh and scripts/docs/preview_docc.sh

Update the README description about docc and update the recommend swift-nightly-toolchain to 2021-11-02

> Since the docc and docc-render ship with the toolchain from that tag https://github.com/apple/swift/pull/39723

### Result:

- Resolves #856 
