### PR TITLE
Down replaced cluster members

### DIFF
--- a/IntegrationTests/tests_04_cluster/it_Clustered_swim_ungraceful_shutdown/main.swift
+++ b/IntegrationTests/tests_04_cluster/it_Clustered_swim_ungraceful_shutdown/main.swift
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import DistributedActors
+
+var args = CommandLine.arguments
+args.removeFirst()
+
+guard args.count >= 1, let bindPort = Int(args[0]) else {
+    fatalError("Bind port must be provided")
+}
+
+print("Binding to port \(bindPort)")
+
+let system = ActorSystem("System") { settings in
+    settings.logging.logLevel = .info
+
+    settings.cluster.enabled = true
+    settings.cluster.bindPort = bindPort
+
+    settings.cluster.swim.probeInterval = .milliseconds(300)
+    settings.cluster.swim.pingTimeout = .milliseconds(100)
+
+    //settings.cluster.downingStrategy = .timeout()
+}
+
+let ref = try system.spawn(
+    "streamWatcher",
+    of: Cluster.Event.self,
+    .receive { context, event in
+        context.log.info("Event: \(event)")
+        return .same
+    }
+)
+system.cluster.events.subscribe(ref)
+
+if args.count >= 3, let joinPort = Int(args[2]) {
+    let joinHost = args[1]
+    print("Joining node \(joinHost):\(joinPort)")
+    system.cluster.join(node: Node(systemName: "System", host: joinHost, port: joinPort))
+}
+
+Thread.sleep(.seconds(120))

--- a/IntegrationTests/tests_04_cluster/it_Clustered_swim_ungraceful_shutdown/main.swift
+++ b/IntegrationTests/tests_04_cluster/it_Clustered_swim_ungraceful_shutdown/main.swift
@@ -20,6 +20,7 @@ args.removeFirst()
 guard args.count >= 2, let bindPort = Int(args[1]) else {
     fatalError("Node name and bind port must be provided")
 }
+
 let nodeName = args[0]
 
 print("Binding to port \(bindPort)")

--- a/IntegrationTests/tests_04_cluster/it_Clustered_swim_ungraceful_shutdown/main.swift
+++ b/IntegrationTests/tests_04_cluster/it_Clustered_swim_ungraceful_shutdown/main.swift
@@ -31,8 +31,6 @@ let system = ActorSystem("System") { settings in
 
     settings.cluster.swim.probeInterval = .milliseconds(300)
     settings.cluster.swim.pingTimeout = .milliseconds(100)
-
-    //settings.cluster.downingStrategy = .timeout()
 }
 
 let ref = try system.spawn(

--- a/IntegrationTests/tests_04_cluster/it_Clustered_swim_ungraceful_shutdown/main.swift
+++ b/IntegrationTests/tests_04_cluster/it_Clustered_swim_ungraceful_shutdown/main.swift
@@ -17,13 +17,14 @@ import DistributedActors
 var args = CommandLine.arguments
 args.removeFirst()
 
-guard args.count >= 1, let bindPort = Int(args[0]) else {
-    fatalError("Bind port must be provided")
+guard args.count >= 2, let bindPort = Int(args[1]) else {
+    fatalError("Node name and bind port must be provided")
 }
+let nodeName = args[0]
 
 print("Binding to port \(bindPort)")
 
-let system = ActorSystem("System") { settings in
+let system = ActorSystem(nodeName) { settings in
     settings.logging.logLevel = .info
 
     settings.cluster.enabled = true
@@ -43,10 +44,10 @@ let ref = try system.spawn(
 )
 system.cluster.events.subscribe(ref)
 
-if args.count >= 3, let joinPort = Int(args[2]) {
-    let joinHost = args[1]
+if args.count >= 4, let joinPort = Int(args[3]) {
+    let joinHost = args[2]
     print("Joining node \(joinHost):\(joinPort)")
-    system.cluster.join(node: Node(systemName: "System", host: joinHost, port: joinPort))
+    system.cluster.join(host: joinHost, port: joinPort)
 }
 
 Thread.sleep(.seconds(120))

--- a/IntegrationTests/tests_04_cluster/test_02_ungraceful_shutdown_recovery.sh
+++ b/IntegrationTests/tests_04_cluster/test_02_ungraceful_shutdown_recovery.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift Distributed Actors open source project
+##
+## Copyright (c) 2022 Apple Inc. and the Swift Distributed Actors project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+set -e
+#set -x # verbose
+
+declare -r my_path="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+declare -r root_path="$my_path/.."
+
+declare -r app_name='it_Clustered_swim_ungraceful_shutdown'
+
+source ${my_path}/shared.sh
+
+declare -r first_logs=/tmp/sact_first.out
+declare -r second_logs=/tmp/sact_second.out
+declare -r third_logs=/tmp/sact_third.out
+rm -f ${first_logs}
+rm -f ${second_logs}
+rm -f ${thrid_logs}
+
+stdbuf -i0 -o0 -e0 swift run it_Clustered_swim_ungraceful_shutdown 7337 > ${first_logs} 2>&1 &
+declare -r first_pid=$(echo $!)
+wait_log_exists ${first_logs} 'Binding to: ' 200 # since it might be compiling again...
+
+stdbuf -i0 -o0 -e0 swift run it_Clustered_swim_ungraceful_shutdown 8228 127.0.0.1 7337 > ${second_logs} 2>&1 &
+declare -r second_pid=$(echo $!)
+wait_log_exists ${second_logs} 'Binding to: ' 200 # since it might be compiling again...
+
+stdbuf -i0 -o0 -e0 swift run it_Clustered_swim_ungraceful_shutdown 9119 127.0.0.1 7337 > ${third_logs} 2>&1 &
+declare -r killed_pid=$(echo $!)
+wait_log_exists ${third_logs} 'Binding to: ' 200 # since it might be compiling again...
+
+echo "Waiting nodes to become .up..."
+wait_log_exists ${first_logs} 'Event: membershipChange(sact://System@127.0.0.1:8228 :: \[joining\] -> \[     up\])' 50
+wait_log_exists ${first_logs} 'Event: membershipChange(sact://System@127.0.0.1:9119 :: \[joining\] -> \[     up\])' 50
+echo 'Other two members seen .up, good...'
+
+# SIGKILL the third member, causing ungraceful shutdown
+kill -9 ${killed_pid}
+
+# Immediately restart the third process
+stdbuf -i0 -o0 -e0 swift run it_Clustered_swim_ungraceful_shutdown 9119 127.0.0.1 7337 > ${third_logs} 2>&1 &
+declare -r replacement_pid=$(echo $!)
+wait_log_exists ${third_logs} 'Binding to: ' 200 # just to be safe...
+
+# The original third node should go .down while the replacement becomes .up
+wait_log_exists ${first_logs} 'Event: membershipChange(sact://System@127.0.0.1:9119 :: \[     up\] -> \[   down\])' 50
+echo 'Killed member .down, good...'
+wait_log_exists ${first_logs} 'Event: membershipChange(sact://System@127.0.0.1:9119 :: \[joining\] -> \[     up\])' 50
+echo 'Replacement member .up, good...'
+
+# === cleanup ----------------------------------------------------------------------------------------------------------
+
+kill -9 ${first_pid}
+kill -9 ${second_pid}
+kill -9 ${replacement_pid}
+
+_killall ${app_name}

--- a/IntegrationTests/tests_04_cluster/test_02_ungraceful_shutdown_recovery.sh
+++ b/IntegrationTests/tests_04_cluster/test_02_ungraceful_shutdown_recovery.sh
@@ -25,40 +25,45 @@ source ${my_path}/shared.sh
 
 declare -r first_logs=/tmp/sact_first.out
 declare -r second_logs=/tmp/sact_second.out
-declare -r third_logs=/tmp/sact_third.out
+declare -r killed_logs=/tmp/sact_killed.out
+declare -r replacement_logs=/tmp/sact_replacement.out
 rm -f ${first_logs}
 rm -f ${second_logs}
-rm -f ${third_logs}
+rm -f ${killed_logs}
+rm -f ${replacement_logs}
 
-stdbuf -i0 -o0 -e0 swift run it_Clustered_swim_ungraceful_shutdown 7337 > ${first_logs} 2>&1 &
+stdbuf -i0 -o0 -e0 swift run it_Clustered_swim_ungraceful_shutdown Frist 7337 > ${first_logs} 2>&1 &
 declare -r first_pid=$(echo $!)
 wait_log_exists ${first_logs} 'Binding to: ' 200 # since it might be compiling again...
 
-stdbuf -i0 -o0 -e0 swift run it_Clustered_swim_ungraceful_shutdown 8228 127.0.0.1 7337 > ${second_logs} 2>&1 &
+stdbuf -i0 -o0 -e0 swift run it_Clustered_swim_ungraceful_shutdown Second 8228 127.0.0.1 7337 > ${second_logs} 2>&1 &
 declare -r second_pid=$(echo $!)
 wait_log_exists ${second_logs} 'Binding to: ' 200 # since it might be compiling again...
 
-stdbuf -i0 -o0 -e0 swift run it_Clustered_swim_ungraceful_shutdown 9119 127.0.0.1 7337 > ${third_logs} 2>&1 &
+stdbuf -i0 -o0 -e0 swift run it_Clustered_swim_ungraceful_shutdown Killed 9119 127.0.0.1 7337 > ${killed_logs} 2>&1 &
 declare -r killed_pid=$(echo $!)
-wait_log_exists ${third_logs} 'Binding to: ' 200 # since it might be compiling again...
+wait_log_exists ${killed_logs} 'Binding to: ' 200 # since it might be compiling again...
 
 echo "Waiting nodes to become .up..."
-wait_log_exists ${first_logs} 'Event: membershipChange(sact://System@127.0.0.1:8228 :: \[joining\] -> \[     up\])' 50
-wait_log_exists ${first_logs} 'Event: membershipChange(sact://System@127.0.0.1:9119 :: \[joining\] -> \[     up\])' 50
+wait_log_exists ${first_logs} 'Event: membershipChange(sact://Second@127.0.0.1:8228 :: \[joining\] -> \[     up\])' 50
+wait_log_exists ${first_logs} 'Event: membershipChange(sact://Killed@127.0.0.1:9119 :: \[joining\] -> \[     up\])' 50
 echo 'Other two members seen .up, good...'
 
+sleep 1
+
 # SIGKILL the third member, causing ungraceful shutdown
+echo "Killing PID ${killed_pid}"
 kill -9 ${killed_pid}
 
 # Immediately restart the third process
-stdbuf -i0 -o0 -e0 swift run it_Clustered_swim_ungraceful_shutdown 9119 127.0.0.1 7337 > ${third_logs} 2>&1 &
+stdbuf -i0 -o0 -e0 swift run it_Clustered_swim_ungraceful_shutdown Replacement 9119 127.0.0.1 7337 >> ${replacement_logs} 2>&1 &
 declare -r replacement_pid=$(echo $!)
-wait_log_exists ${third_logs} 'Binding to: ' 200 # just to be safe...
+wait_log_exists ${replacement_logs} 'Binding to: ' 200 # just to be safe...
 
 # The original third node should go .down while the replacement becomes .up
-wait_log_exists ${first_logs} 'Event: membershipChange(sact://System@127.0.0.1:9119 :: \[     up\] -> \[   down\])' 50
+wait_log_exists ${first_logs} 'Event: membershipChange(sact://Killed@127.0.0.1:9119 :: \[     up\] -> \[   down\])' 50
 echo 'Killed member .down, good...'
-wait_log_exists ${first_logs} 'Event: membershipChange(sact://System@127.0.0.1:9119 :: \[joining\] -> \[     up\])' 50
+wait_log_exists ${first_logs} 'Event: membershipChange(sact://Replacement@127.0.0.1:9119 :: \[joining\] -> \[     up\])' 50
 echo 'Replacement member .up, good...'
 
 # === cleanup ----------------------------------------------------------------------------------------------------------

--- a/IntegrationTests/tests_04_cluster/test_02_ungraceful_shutdown_recovery.sh
+++ b/IntegrationTests/tests_04_cluster/test_02_ungraceful_shutdown_recovery.sh
@@ -28,7 +28,7 @@ declare -r second_logs=/tmp/sact_second.out
 declare -r third_logs=/tmp/sact_third.out
 rm -f ${first_logs}
 rm -f ${second_logs}
-rm -f ${thrid_logs}
+rm -f ${third_logs}
 
 stdbuf -i0 -o0 -e0 swift run it_Clustered_swim_ungraceful_shutdown 7337 > ${first_logs} 2>&1 &
 declare -r first_pid=$(echo $!)

--- a/Package.swift
+++ b/Package.swift
@@ -197,6 +197,13 @@ var targets: [PackageDescription.Target] = [
         ],
         path: "IntegrationTests/tests_04_cluster/it_Clustered_swim_suspension_reachability"
     ),
+    .target(
+        name: "it_Clustered_swim_ungraceful_shutdown",
+        dependencies: [
+            "DistributedActors",
+        ],
+        path: "IntegrationTests/tests_04_cluster/it_Clustered_swim_ungraceful_shutdown"
+    ),
 
     // ==== ----------------------------------------------------------------------------------------------------------------
     // MARK: Performance / Benchmarks

--- a/Sources/DistributedActors/Cluster/Cluster+Membership.swift
+++ b/Sources/DistributedActors/Cluster/Cluster+Membership.swift
@@ -286,7 +286,11 @@ extension Cluster.Membership {
 
         if let previousMember = self.member(change.node.node) {
             // we are joining "over" an existing incarnation of a node; causing the existing node to become .down immediately
-            _ = self.removeCompletely(previousMember.uniqueNode) // the replacement event will handle the down notifications
+            if previousMember.status < .down {
+                _ = self.mark(previousMember.uniqueNode, as: .down)
+            } else {
+                _ = self.removeCompletely(previousMember.uniqueNode) // the replacement event will handle the down notifications
+            }
             self._members[change.node] = change.member
 
             // emit a replacement membership change, this will cause down cluster events for previous member

--- a/Sources/DistributedActors/Cluster/ClusterShellState.swift
+++ b/Sources/DistributedActors/Cluster/ClusterShellState.swift
@@ -392,8 +392,6 @@ extension ClusterShellState {
 
         let change: Cluster.MembershipChange?
         if let replacedMember = self.membership.member(handshake.remoteNode.node) {
-            //self.membership.mark(replacedMember.uniqueNode, as: .down)
-            //self._latestGossip.pruneMember(replacedMember)
             change = self.membership.applyMembershipChange(Cluster.MembershipChange(replaced: replacedMember, by: Cluster.Member(node: handshake.remoteNode, status: .joining)))
         } else {
             change = self.membership.applyMembershipChange(Cluster.MembershipChange(member: Cluster.Member(node: handshake.remoteNode, status: .joining)))

--- a/Sources/DistributedActors/Cluster/ClusterShellState.swift
+++ b/Sources/DistributedActors/Cluster/ClusterShellState.swift
@@ -392,6 +392,8 @@ extension ClusterShellState {
 
         let change: Cluster.MembershipChange?
         if let replacedMember = self.membership.member(handshake.remoteNode.node) {
+            //self.membership.mark(replacedMember.uniqueNode, as: .down)
+            //self._latestGossip.pruneMember(replacedMember)
             change = self.membership.applyMembershipChange(Cluster.MembershipChange(replaced: replacedMember, by: Cluster.Member(node: handshake.remoteNode, status: .joining)))
         } else {
             change = self.membership.applyMembershipChange(Cluster.MembershipChange(member: Cluster.Member(node: handshake.remoteNode, status: .joining)))

--- a/Tests/DistributedActorsTests/MembershipTests.swift
+++ b/Tests/DistributedActorsTests/MembershipTests.swift
@@ -134,7 +134,7 @@ final class MembershipTests: XCTestCase {
         )
 
         membership.members(atLeast: .joining).count.shouldEqual(3)
-        membership.members(atLeast: .down).count.shouldEqual(1  )
+        membership.members(atLeast: .down).count.shouldEqual(1)
         let memberNode = membership.uniqueMember(change.member.uniqueNode)
         memberNode?.status.shouldEqual(Cluster.MemberStatus.up)
     }

--- a/Tests/DistributedActorsTests/MembershipTests.swift
+++ b/Tests/DistributedActorsTests/MembershipTests.swift
@@ -133,7 +133,8 @@ final class MembershipTests: XCTestCase {
             Cluster.MembershipChange(member: self.memberB, toStatus: .down)
         )
 
-        membership.members(atLeast: .joining).count.shouldEqual(2)
+        membership.members(atLeast: .joining).count.shouldEqual(3)
+        membership.members(atLeast: .down).count.shouldEqual(1  )
         let memberNode = membership.uniqueMember(change.member.uniqueNode)
         memberNode?.status.shouldEqual(Cluster.MemberStatus.up)
     }
@@ -349,7 +350,7 @@ final class MembershipTests: XCTestCase {
     // ==== ----------------------------------------------------------------------------------------------------------------
     // MARK: Replacements
 
-    func test_join_overAnExistingMode_replacement() {
+    func test_join_overAnExistingNode_replacement() {
         var membership = self.initialMembership
         let secondReplacement = Cluster.Member(node: UniqueNode(node: self.nodeB.node, nid: .random()), status: .joining)
         let change = membership.join(secondReplacement.uniqueNode)!
@@ -359,9 +360,9 @@ final class MembershipTests: XCTestCase {
         var secondDown = self.memberB
         secondDown.status = .down
 
-        members.count.shouldEqual(3)
+        members.count.shouldEqual(4)
         members.shouldContain(secondReplacement)
-        members.shouldNotContain(self.memberB) // was replaced
+        members.shouldContain(secondDown) // replaced node should be .down
     }
 
     func test_mark_replacement() throws {


### PR DESCRIPTION
Make sure a previous cluster member is marked as `.down` before replacing it

### Motivation:

* Resolve #866 

### Modifications:

* When processing a `MemberChange` that replaces an existing node, mark the node as `.down` if it hasn't been already
* Add an integration test for #866 (confirmed failure before this change.

### Result:

- Resolves #866
