### PR TITLE
Update SwiftSyntax for Swift 5.6.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -307,7 +307,7 @@ dependencies.append(
 )
 #elseif swift(>=5.6)
 dependencies.append(
-    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50600.0"))
+    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50600.1"))
 )
 #elseif swift(>=5.5)
 dependencies.append(


### PR DESCRIPTION
0.50600.1 fixes the unsafe build flags.

This is only for the legacy release/0.x branch.