### PR TITLE
Update Plugin implementation

### DIFF
--- a/Plugins/DistributedActorsGeneratorPlugin/Plugin.swift
+++ b/Plugins/DistributedActorsGeneratorPlugin/Plugin.swift
@@ -15,28 +15,28 @@
 import PackagePlugin
 
 @main struct MyPlugin: BuildToolPlugin {
-    func createBuildCommands(context: TargetBuildContext) throws -> [Command] {
+    func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
+        guard let target = target as? SourceModuleTarget else { return [] }
         let generatorPath = try context.tool(named: "DistributedActorsGenerator").path
-
-        let inputFiles = context.inputFiles.map { $0.path }.filter { $0.extension?.lowercased() == "swift" }
+        let inputFiles = target.sourceFiles.map { $0.path }.filter { $0.extension?.lowercased() == "swift" }
 
         let buckets = 5 // # of buckets for consistent hashing
         let outputFiles = !inputFiles.isEmpty ? (0 ..< buckets).map {
             context.pluginWorkDirectory.appending("GeneratedDistributedActors_\($0).swift")
         } : []
 
-        let command = Command.buildCommand(
-            displayName: "Generating distributed actors for target '\(context.targetName)'",
-            executable: generatorPath,
-            arguments: [
-                "--source-directory", context.targetDirectory.string,
-                "--target-directory", context.pluginWorkDirectory.string,
-                "--buckets", "\(buckets)",
-            ],
-            inputFiles: inputFiles,
-            outputFiles: outputFiles
-        )
-
-        return [command]
+        return [
+            .buildCommand(
+                displayName: "Generating distributed actors for target '\(target.name)'",
+                executable: generatorPath,
+                arguments: [
+                    "--source-directory", target.directory.string,
+                    "--target-directory", context.pluginWorkDirectory.string,
+                    "--buckets", "\(buckets)",
+                ],
+                inputFiles: inputFiles,
+                outputFiles: outputFiles
+            )
+        ]
     }
 }


### PR DESCRIPTION
Update DistributedActorsGeneratorPlugin implementation to fit the release PackagePlugin API 

### Motivation:

Make the plugin target compile under swift-5.6 

### Modifications:

Update DistributedActorsGeneratorPlugin implementation

### Result:

Make the plugin target compile the swift-5.6 

### Reference

> https://github.com/apple/swift-package-manager/blob/7a75eb8cfdba5a8c73914db3ad08e83b8051e68d/Fixtures/Miscellaneous/Plugins/MySourceGenPlugin/Plugins/MySourceGenBuildToolPlugin/plugin.swift#L8-L9
