### PR TITLE
Adapt codebase for Swift 5.6 release version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -68,7 +68,7 @@ var targets: [PackageDescription.Target] = [
         name: "GenActorsLib",
         dependencies: [
             "DistributedActors",
-            .product(name: "SwiftSyntax", package: "SwiftSyntax"),
+            .product(name: "SwiftSyntaxParser", package: "SwiftSyntax"),
             .product(name: "Logging", package: "swift-log"),
             .product(name: "ArgumentParser", package: "swift-argument-parser"),
 
@@ -307,7 +307,7 @@ dependencies.append(
 )
 #elseif swift(>=5.6)
 dependencies.append(
-    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50600.0"))
+    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50600.1"))
 )
 #elseif swift(>=5.5)
 dependencies.append(

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,12 @@ var globalConcurrencyFlags: [String] = []
 // ])
 // #endif
 
+#if swift(>=5.6)
+var swiftSyntaxDep="SwiftSyntaxParser"
+#else
+var swiftSyntaxDep="SwiftSyntax"
+#endif
+
 if ProcessInfo.processInfo.environment["SACT_WARNINGS_AS_ERRORS"] != nil {
     print("SACT_WARNINGS_AS_ERRORS enabled, passing `-warnings-as-errors`")
     var allUnsafeFlags = globalConcurrencyFlags
@@ -68,7 +74,7 @@ var targets: [PackageDescription.Target] = [
         name: "GenActorsLib",
         dependencies: [
             "DistributedActors",
-            .product(name: "SwiftSyntaxParser", package: "SwiftSyntax"),
+            .product(name: swiftSyntaxDep, package: "SwiftSyntax"),
             .product(name: "Logging", package: "swift-log"),
             .product(name: "ArgumentParser", package: "swift-argument-parser"),
 

--- a/Package.swift
+++ b/Package.swift
@@ -19,9 +19,9 @@ var globalConcurrencyFlags: [String] = []
 // #endif
 
 #if swift(>=5.6)
-var swiftSyntaxDep="SwiftSyntaxParser"
+let swiftSyntaxDependencyName = "SwiftSyntaxParser"
 #else
-var swiftSyntaxDep="SwiftSyntax"
+let swiftSyntaxDependencyName = "SwiftSyntax"
 #endif
 
 if ProcessInfo.processInfo.environment["SACT_WARNINGS_AS_ERRORS"] != nil {
@@ -74,7 +74,7 @@ var targets: [PackageDescription.Target] = [
         name: "GenActorsLib",
         dependencies: [
             "DistributedActors",
-            .product(name: swiftSyntaxDep, package: "SwiftSyntax"),
+            .product(name: swiftSyntaxDependencyName, package: "SwiftSyntax"),
             .product(name: "Logging", package: "swift-log"),
             .product(name: "ArgumentParser", package: "swift-argument-parser"),
 

--- a/Sources/GenActorsLib/GenerateActors.swift
+++ b/Sources/GenActorsLib/GenerateActors.swift
@@ -18,6 +18,7 @@ import Files
 import Foundation
 import Logging
 import SwiftSyntax
+import SwiftSyntaxParser
 
 final class GenerateActors {
     var log: Logger

--- a/Sources/GenActorsLib/GenerateActors.swift
+++ b/Sources/GenActorsLib/GenerateActors.swift
@@ -17,8 +17,11 @@ import DistributedActors
 import Files
 import Foundation
 import Logging
-import SwiftSyntax
+#if swift(>=5.6)
 import SwiftSyntaxParser
+#else
+import SwiftSyntax
+#endif
 
 final class GenerateActors {
     var log: Logger

--- a/Tests/GenActorsTests/ClassStructEtcActorable/ClassStructEtc+Actorable.swift
+++ b/Tests/GenActorsTests/ClassStructEtcActorable/ClassStructEtc+Actorable.swift
@@ -14,7 +14,7 @@
 
 import DistributedActors
 
-class ClassActorable: Actorable {
+final class ClassActorable: Actorable {
     // @actor
     func hello() -> String {
         "Hello."


### PR DESCRIPTION
Adapt codebase for Swift 5.6 release version

### Motivation:

I wanted to try out Distributed Actors library on my Mac having Swift 5.6 release installed but it could not even compile. So I decided to fix the code base. 

### Modifications:

I applied the following fixes to the codebase,
- Fixed and updated SwiftSyntax dependency in Package.swift
- Fixed SwiftSyntax import in GenActions Swift source
- Made a test class final to meet a requirement imposed by Actorable protocol.

### Result:

The whole codebase now compiles with Swift 5.6. Also the full test suite is passed. All the changes made on a MacBook Pro mid 2015 running the latest macOS (Monterey 12.3.1) and Xcode 13.3.