### PR TITLE
[ser] Invocation serialization should use the Serialization infra

### DIFF
--- a/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
+++ b/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
@@ -774,6 +774,7 @@ extension OpLogDistributedReceptionist {
             } catch {
                 log.error("Failed to pushOps: \(pushOps)", metadata: [
                     "receptionist/peer": "\(peer.id)",
+                    "error": "\(error)"
                 ])
             }
         }

--- a/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
+++ b/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
@@ -774,7 +774,7 @@ extension OpLogDistributedReceptionist {
             } catch {
                 log.error("Failed to pushOps: \(pushOps)", metadata: [
                     "receptionist/peer": "\(peer.id)",
-                    "error": "\(error)"
+                    "error": "\(error)",
                 ])
             }
         }

--- a/Sources/DistributedActors/InvocationBehavior.swift
+++ b/Sources/DistributedActors/InvocationBehavior.swift
@@ -40,10 +40,10 @@ enum InvocationBehavior {
                     context.system.personalDeadLetters(type: InvocationMessage.self, recipient: context.address).tell(message)
                     return .stop
                 }
-                
+
                 await context.system.receiveInvocation(actor: instance, message: message)
                 return .same
-            }.receiveSignal { context, signal in
+            }.receiveSignal { _, signal in
 
                 // We received a signal, but our target actor instance was already released;
                 // This should not really happen, but let's handle it by stopping the behavior.

--- a/Sources/DistributedActors/LifecycleMonitoring/LifecycleWatch.swift
+++ b/Sources/DistributedActors/LifecycleMonitoring/LifecycleWatch.swift
@@ -165,7 +165,7 @@ public extension LifecycleWatchContainer {
         @_inheritActorContext @_implicitSelfCapture whenTerminated: @escaping @Sendable(ClusterSystem.ActorID) -> Void,
         file: String = #file, line: UInt = #line
     ) where Watchee: DistributedActor, Watchee.ActorSystem == ClusterSystem {
-        traceLog_DeathWatch("issue watch: \(watchee) (from \(watcherID))")
+        traceLog_DeathWatch("issue watch: \(watchee) (from \(self.watcherID))")
 
         let watcherAddress: ActorAddress = self.watcherID
         let watcheeAddress: ActorAddress = watchee.id
@@ -213,7 +213,7 @@ public extension LifecycleWatchContainer {
         watchee: Watchee,
         file: String = #file, line: UInt = #line
     ) -> Watchee where Watchee: DistributedActor, Watchee.ActorSystem == ClusterSystem {
-        traceLog_DeathWatch("issue unwatch: watchee: \(watchee) (from \(watcherID)")
+        traceLog_DeathWatch("issue unwatch: watchee: \(watchee) (from \(self.watcherID)")
         let watcheeAddress = watchee.id
         let watcherAddress = self.watcherID
 
@@ -248,17 +248,17 @@ public extension LifecycleWatchContainer {
         watcher: AddressableActorRef
     ) {
         guard watcher.address != self.watcherID else {
-            traceLog_DeathWatch("Attempted to watch 'myself' [\(watcherID)], which is a no-op, since such watch's terminated can never be observed. " +
+            traceLog_DeathWatch("Attempted to watch 'myself' [\(self.watcherID)], which is a no-op, since such watch's terminated can never be observed. " +
                 "Likely a programming error where the wrong actor ref was passed to watch(), please check your code.")
             return
         }
 
-        traceLog_DeathWatch("Become watched by: \(watcher.address)     inside: \(watcherID)")
+        traceLog_DeathWatch("Become watched by: \(watcher.address)     inside: \(self.watcherID)")
         self.watchedBy[watcher.address] = watcher
     }
 
     internal func removeWatchedBy(watcher: AddressableActorRef) {
-        traceLog_DeathWatch("Remove watched by: \(watcher.address)     inside: \(watcherID)")
+        traceLog_DeathWatch("Remove watched by: \(watcher.address)     inside: \(self.watcherID)")
         self.watchedBy.removeValue(forKey: watcher.address)
     }
 
@@ -317,7 +317,7 @@ public extension LifecycleWatchContainer {
     // MARK: Myself termination
 
     internal func notifyWatchersWeDied() {
-        traceLog_DeathWatch("[\(watcherID)] notifyWatchers that we are terminating. Watchers: \(self.watchedBy)...")
+        traceLog_DeathWatch("[\(self.watcherID)] notifyWatchers that we are terminating. Watchers: \(self.watchedBy)...")
 
         for (watcherID, watcherRef) in self.watchedBy {
             traceLog_DeathWatch("[\(watcherID)] Notify  \(watcherID) (\(watcherRef)) that we died")

--- a/Sources/DistributedActors/Serialization/Serialization+Context.swift
+++ b/Sources/DistributedActors/Serialization/Serialization+Context.swift
@@ -116,8 +116,6 @@ public protocol CodableSerializationContext {
 }
 
 public extension Decoder {
-    // Cannot conform it to DecoderSerializationContext:
-    //     error: extension of protocol 'Decoder' cannot have an inheritance clause
     var actorSerializationContext: Serialization.Context? {
         self.userInfo[.actorSerializationContext] as? Serialization.Context
     }

--- a/Sources/DistributedActors/Serialization/Serialization+Invocation.swift
+++ b/Sources/DistributedActors/Serialization/Serialization+Invocation.swift
@@ -13,19 +13,19 @@
 //===----------------------------------------------------------------------===//
 
 import Distributed
+import Foundation // for Codable
 import Logging
 import NIO
 import NIOFoundationCompat
 import SwiftProtobuf
-import Foundation // for Codable
 
 public struct ClusterInvocationEncoder: DistributedTargetInvocationEncoder {
     public typealias SerializationRequirement = any Codable
     var arguments: [Data] = []
     var throwing: Bool = false
-    
+
     let system: ClusterSystem
-    
+
     init(system: ClusterSystem) {
         self.system = system
     }
@@ -74,7 +74,7 @@ public struct ClusterInvocationDecoder: DistributedTargetInvocationDecoder {
 
         let argumentData = self.message.arguments[self.argumentIdx]
         self.argumentIdx += 1
-        
+
         // FIXME: make incoming manifest
         let manifest = try self.system.serialization.outboundManifest(Argument.self)
 

--- a/Sources/DistributedActors/Serialization/Serialization.swift
+++ b/Sources/DistributedActors/Serialization/Serialization.swift
@@ -339,7 +339,7 @@ public extension Serialization {
     /// Container for serialization output.
     ///
     /// Describing what serializer was used to serialize the value, and its serialized bytes
-    public struct Serialized {
+    struct Serialized {
         public let manifest: Serialization.Manifest
         public let buffer: Serialization.Buffer
     }

--- a/Tests/DistributedActorsTests/Cluster/Reception/OpLogDistributedReceptionistClusteredTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/Reception/OpLogDistributedReceptionistClusteredTests.swift
@@ -35,10 +35,10 @@ distributed actor StringForwarder: CustomStringConvertible {
         self.probe = probe
     }
 
-    distributed func forward(message: String) {
-//    distributed func forward(message: String) -> String {
+//    distributed func forward(message: String) {
+    distributed func forward(message: String) -> String {
         self.probe.tell("forwarded:\(message)")
-//        return "echo:\(message)"
+        return "echo:\(message)"
     }
 
     nonisolated var description: String {
@@ -116,7 +116,7 @@ final class OpLogDistributedReceptionistClusteredTests: ClusteredActorSystemsXCT
 
             // check if we can interact with it
             let echo = try await found.forward(message: "test")
-            // echo.shouldEqual("echo:test")
+            echo.shouldEqual("echo:test")
             try probe.expectMessage("forwarded:test")
         }.value
     }
@@ -159,7 +159,7 @@ final class OpLogDistributedReceptionistClusteredTests: ClusteredActorSystemsXCT
 
                 // check if we can interact with it
                 let echo = try await found.forward(message: "test")
-//                echo.shouldEqual("echo:test")
+                echo.shouldEqual("echo:test")
                 try probe.expectMessage("forwarded:test")
             }.value
         }

--- a/Tests/DistributedActorsTests/Cluster/Reception/OpLogDistributedReceptionistClusteredTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/Reception/OpLogDistributedReceptionistClusteredTests.swift
@@ -85,42 +85,40 @@ final class OpLogDistributedReceptionistClusteredTests: ClusteredActorSystemsXCT
     // MARK: Sync
 
     func test_shouldReplicateRegistrations() async throws {
-        try runAsyncAndBlock {
-            let (local, remote) = await self.setUpPair()
-            let testKit: ActorTestKit = self.testKit(local)
-            try self.joinNodes(node: local, with: remote)
+        let (local, remote) = await self.setUpPair()
+        let testKit: ActorTestKit = self.testKit(local)
+        try self.joinNodes(node: local, with: remote)
 
-            let probe = testKit.makeTestProbe(expecting: String.self)
+        let probe = testKit.makeTestProbe(expecting: String.self)
 
-            // Create forwarder on 'local'
-            let forwarder = StringForwarder(probe: probe, actorSystem: local)
+        // Create forwarder on 'local'
+        let forwarder = StringForwarder(probe: probe, actorSystem: local)
 
-            // subscribe on `remote`
-            let subscriberProbe = testKit.makeTestProbe("subscriber", expecting: StringForwarder.self)
-            let subscriptionTask = Task {
-                for try await forwarder in await remote.receptionist.subscribe(to: .stringForwarders) {
-                    subscriberProbe.tell(forwarder)
-                }
+        // subscribe on `remote`
+        let subscriberProbe = testKit.makeTestProbe("subscriber", expecting: StringForwarder.self)
+        let subscriptionTask = Task {
+            for try await forwarder in await remote.receptionist.subscribe(to: .stringForwarders) {
+                subscriberProbe.tell(forwarder)
             }
-            defer {
-                subscriptionTask.cancel()
-            }
-
-            // register on `local`
-            await local.receptionist.register(forwarder, with: .stringForwarders)
-
-            try await Task {
-                let found = try subscriberProbe.expectMessage()
-
-                // we expect only one actor
-                try subscriberProbe.expectNoMessage(for: .milliseconds(200))
-
-                // check if we can interact with it
-                let echo = try await found.forward(message: "test")
-//                echo.shouldEqual("echo:test")
-                try probe.expectMessage("forwarded:test")
-            }.value
         }
+        defer {
+            subscriptionTask.cancel()
+        }
+
+        // register on `local`
+        await local.receptionist.register(forwarder, with: .stringForwarders)
+
+        try await Task {
+            let found = try subscriberProbe.expectMessage()
+
+            // we expect only one actor
+            try subscriberProbe.expectNoMessage(for: .milliseconds(200))
+
+            // check if we can interact with it
+            let echo = try await found.forward(message: "test")
+            // echo.shouldEqual("echo:test")
+            try probe.expectMessage("forwarded:test")
+        }.value
     }
 
     func test_shouldSyncPeriodically() async throws {

--- a/Tests/DistributedActorsTests/DistributedReceptionistTests.swift
+++ b/Tests/DistributedActorsTests/DistributedReceptionistTests.swift
@@ -50,7 +50,7 @@ final class DistributedReceptionistTests: ActorSystemXCTestCase {
     func test_receptionist_mustHaveWellKnownAddress() throws {
         let opLogReceptionist = system.receptionist
         let receptionistAddress = opLogReceptionist.id
-        
+
         receptionistAddress.detailedDescription.shouldEqual("/system/receptionist")
         receptionistAddress.incarnation.shouldEqual(.wellKnown)
     }


### PR DESCRIPTION
Some tests were failing with `error=missingSerializationContext(DistributedActors.VersionVector, details: "DistributedActors.Serialization.Context not available in Foundation.(unknown context at $18e133fb8).__JSONEncoder.userInfo, but is necessary encode message: [[actor:/system/receptionist: 1]]:DistributedActors.VersionVector"` since invocation encoder/decoder did not properly use the `Serialization` infra.

Fixing this silly omission, fixes all those tests.

I'll do some more cleanup there in a bit but first want a green CI back.