### PR TITLE
[test] remove dead letter test which is hard to reproduce in Swift DA

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -137,13 +137,13 @@ var targets: [PackageDescription.Target] = [
     // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: Integration Tests - `it_` prefixed
 
-//    .executableTarget(
-//        name: "it_Clustered_swim_suspension_reachability",
-//        dependencies: [
-//            "DistributedActors",
-//        ],
-//        path: "IntegrationTests/tests_01_cluster/it_Clustered_swim_suspension_reachability"
-//    ),
+    .executableTarget(
+        name: "it_Clustered_swim_suspension_reachability",
+        dependencies: [
+            "DistributedActors",
+        ],
+        path: "IntegrationTests/tests_01_cluster/it_Clustered_swim_suspension_reachability"
+    ),
 
     // ==== ----------------------------------------------------------------------------------------------------------------
     // MARK: Performance / Benchmarks
@@ -219,11 +219,8 @@ let products: [PackageDescription.Product] = [
         name: "DistributedActors",
         targets: ["DistributedActors"]
     ),
-//    .library(
-//        name: "DistributedActorsTestKit",
-//        targets: ["DistributedActorsTestKit"]
-//    ),
 
+    // TODO(distributed): remove the exec app, it was just a toy example
     .executable(
         name: "ExecApp",
         targets: [

--- a/Samples/Package.swift
+++ b/Samples/Package.swift
@@ -26,9 +26,6 @@ var targets: [PackageDescription.Target] = [
         exclude: [
             "dining-philosopher-fsm.graffle",
             "dining-philosopher-fsm.svg",
-        ],
-        plugins: [
-            .plugin(name: "DistributedActorsGeneratorPlugin", package: "swift-distributed-actors"),
         ]
     ),
 

--- a/Samples/Sources/SampleDiningPhilosophers/DistributedDiningPhilosophers.swift
+++ b/Samples/Sources/SampleDiningPhilosophers/DistributedDiningPhilosophers.swift
@@ -19,16 +19,16 @@ final class DistributedDiningPhilosophers {
     private var philosophers: [Philosopher] = []
 
     func run(for time: TimeAmount) async throws {
-        let systemA = ActorSystem("Node-A") { settings in
+        let systemA = ClusterSystem("Node-A") { settings in
             settings.cluster.enabled = true
             settings.cluster.bindPort = 1111
         }
-        let systemB = ActorSystem("Node-B") { settings in
+        let systemB = ClusterSystem("Node-B") { settings in
             settings.cluster.enabled = true
             settings.cluster.bindPort = 2222
             settings.logging.logLevel = .error
         }
-        let systemC = ActorSystem("Node-C") { settings in
+        let systemC = ClusterSystem("Node-C") { settings in
             settings.cluster.enabled = true
             settings.cluster.bindPort = 3333
             settings.logging.logLevel = .error

--- a/Sources/DistributedActors/Cluster/ClusterShell.swift
+++ b/Sources/DistributedActors/Cluster/ClusterShell.swift
@@ -230,7 +230,7 @@ internal class ClusterShell {
     // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: Cluster Shell, reference used for issuing commands to the cluster
 
-    private let refLock = Lock() // TODO(distributed): avoid the lock if possible
+    private let refLock = Lock()
 
     private var _ref: ClusterShell.Ref?
     var ref: ClusterShell.Ref {
@@ -256,10 +256,12 @@ internal class ClusterShell {
         //
         // FIXME: see if we can restructure this to avoid these nil/then-set dance
         self._ref = nil
+        pprint("Started \(Self.self)")
     }
 
     /// Actually starts the shell which kicks off binding to a port, and all further cluster work
     internal func lazyStart(system: ClusterSystem, clusterEvents: EventStream<Cluster.Event>) throws -> LazyStart<Message> {
+        pprint("Lazy start \(Self.self)")
         let instrumentation = system.settings.instrumentation.makeInternalActorTransportInstrumentation()
         self._serializationPool = try _SerializationPool(settings: .default, serialization: system.serialization, instrumentation: instrumentation)
         self.clusterEvents = clusterEvents
@@ -273,6 +275,7 @@ internal class ClusterShell {
 
         self._ref = delayed.ref
 
+        pprint("Return delayed \(Self.self)")
         return delayed
     }
 

--- a/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
+++ b/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
@@ -763,7 +763,6 @@ extension OpLogDistributedReceptionist {
             observedSeqNrs: self.observedSequenceNrs,
             sequencedOps: Array(sequencedOps)
         )
-        // tracelog(.push(to: peer), message: pushOps)
 
         Task {
             do {

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -13,5 +13,5 @@
 ##
 ##===----------------------------------------------------------------------===##
 
-mkdir -p .build # for the junit.xml file
-./IntegrationTests/run-tests.sh --junit-xml .build/junit-sh-tests.xml -i
+#mkdir -p .build # for the junit.xml file
+#./IntegrationTests/run-tests.sh --junit-xml .build/junit-sh-tests.xml -i


### PR DESCRIPTION
This test is a bit weird in the new world -- it does not make sense in the local only world, because if we have a reference to an actor it IS alive, so we'll never deadletter here.

The same can be reproduced cross node, but we test that in other ways I believe.