### PR TITLE
Resolve racy initialization where system actors need to reach for .cluster

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ import PackageDescription
 var globalSwiftSettings: [SwiftSetting]
 
 var globalConcurrencyFlags: [String] = [
-    "-Xfrontend", "-disable-availability-checking",
+    "-Xfrontend", "-disable-availability-checking", // TODO(distributed): remove this flag
 ]
 
 // TODO: currently disabled warnings as errors because of Sendable check noise and work in progress on different toolchains

--- a/Samples/Package.swift
+++ b/Samples/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 var globalSwiftSettings: [SwiftSetting]
 
 var globalConcurrencyFlags: [String] = [
-    "-Xfrontend", "-enable-experimental-distributed",
+    "-Xfrontend", "-disable-availability-checking", // TODO(distributed): remove this flag
 ]
 
 globalSwiftSettings = [

--- a/Samples/Package.swift
+++ b/Samples/Package.swift
@@ -35,7 +35,6 @@ var targets: [PackageDescription.Target] = [
     .testTarget(
         name: "NoopTests",
         dependencies: [
-            .product(name: "DistributedActorsTestKit", package: "swift-distributed-actors"),
         ],
         path: "Tests/NoopTests"
     ),

--- a/Samples/Sources/SampleDiningPhilosophers/DiningPhilosophers.swift
+++ b/Samples/Sources/SampleDiningPhilosophers/DiningPhilosophers.swift
@@ -22,20 +22,20 @@ final class DiningPhilosophers {
         let system = ActorSystem("Philosophers")
 
         // prepare 5 forks, the resources, that the philosophers will compete for:
-        let fork1 = Fork(name: "fork-1", transport: system)
-        let fork2 = Fork(name: "fork-2", transport: system)
-        let fork3 = Fork(name: "fork-3", transport: system)
-        let fork4 = Fork(name: "fork-4", transport: system)
-        let fork5 = Fork(name: "fork-5", transport: system)
+        let fork1 = Fork(name: "fork-1", actorSystem: system)
+        let fork2 = Fork(name: "fork-2", actorSystem: system)
+        let fork3 = Fork(name: "fork-3", actorSystem: system)
+        let fork4 = Fork(name: "fork-4", actorSystem: system)
+        let fork5 = Fork(name: "fork-5", actorSystem: system)
         self.forks = [fork1, fork2, fork3, fork4, fork5]
 
         // 5 philosophers, sitting in a circle, with the forks between them:
         self.philosophers = [
-            Philosopher(name: "Konrad", leftFork: fork5, rightFork: fork1, transport: system),
-            Philosopher(name: "Dario", leftFork: fork1, rightFork: fork2, transport: system),
-            Philosopher(name: "Johannes", leftFork: fork2, rightFork: fork3, transport: system),
-            Philosopher(name: "Cory", leftFork: fork3, rightFork: fork4, transport: system),
-            Philosopher(name: "Erik", leftFork: fork4, rightFork: fork5, transport: system),
+            Philosopher(name: "Konrad", leftFork: fork5, rightFork: fork1, actorSystem: system),
+            Philosopher(name: "Dario", leftFork: fork1, rightFork: fork2, actorSystem: system),
+            Philosopher(name: "Johannes", leftFork: fork2, rightFork: fork3, actorSystem: system),
+            Philosopher(name: "Cory", leftFork: fork3, rightFork: fork4, actorSystem: system),
+            Philosopher(name: "Erik", leftFork: fork4, rightFork: fork5, actorSystem: system),
         ]
 
         _Thread.sleep(time)

--- a/Samples/Sources/SampleDiningPhilosophers/DiningPhilosophers.swift
+++ b/Samples/Sources/SampleDiningPhilosophers/DiningPhilosophers.swift
@@ -18,8 +18,8 @@ final class DiningPhilosophers {
     private var forks: [Fork] = []
     private var philosophers: [Philosopher] = []
 
-    func run(for time: TimeAmount) throws {
-        let system = ActorSystem("Philosophers")
+    func run(for time: TimeAmount) async throws {
+        let system = await ClusterSystem("Philosophers")
 
         // prepare 5 forks, the resources, that the philosophers will compete for:
         let fork1 = Fork(name: "fork-1", actorSystem: system)

--- a/Samples/Sources/SampleDiningPhilosophers/DistributedDiningPhilosophers.swift
+++ b/Samples/Sources/SampleDiningPhilosophers/DistributedDiningPhilosophers.swift
@@ -55,25 +55,25 @@ final class DistributedDiningPhilosophers {
 
         // prepare 5 forks, the resources, that the philosophers will compete for:
         // Node A
-        let fork1 = Fork(name: "fork-1", transport: systemA)
+        let fork1 = Fork(name: "fork-1", actorSystem: systemA)
         // Node B
-        let fork2 = Fork(name: "fork-2", transport: systemB)
-        let fork3 = Fork(name: "fork-3", transport: systemB)
+        let fork2 = Fork(name: "fork-2", actorSystem: systemB)
+        let fork3 = Fork(name: "fork-3", actorSystem: systemB)
         // Node C
-        let fork4 = Fork(name: "fork-4", transport: systemC)
-        let fork5 = Fork(name: "fork-5", transport: systemC)
+        let fork4 = Fork(name: "fork-4", actorSystem: systemC)
+        let fork5 = Fork(name: "fork-5", actorSystem: systemC)
         self.forks = [fork1, fork2, fork3, fork4, fork5]
 
         // 5 philosophers, sitting in a circle, with the forks between them:
         self.philosophers = [
             // Node A
-            Philosopher(name: "Konrad", leftFork: fork5, rightFork: fork1, transport: systemA),
+            Philosopher(name: "Konrad", leftFork: fork5, rightFork: fork1, actorSystem: systemA),
             // Node B
-            Philosopher(name: "Dario", leftFork: fork1, rightFork: fork2, transport: systemB),
-            Philosopher(name: "Johannes", leftFork: fork2, rightFork: fork3, transport: systemB),
+            Philosopher(name: "Dario", leftFork: fork1, rightFork: fork2, actorSystem: systemB),
+            Philosopher(name: "Johannes", leftFork: fork2, rightFork: fork3, actorSystem: systemB),
             // Node C
-            Philosopher(name: "Cory", leftFork: fork3, rightFork: fork4, transport: systemC),
-            Philosopher(name: "Erik", leftFork: fork4, rightFork: fork5, transport: systemC),
+            Philosopher(name: "Cory", leftFork: fork3, rightFork: fork4, actorSystem: systemC),
+            Philosopher(name: "Erik", leftFork: fork4, rightFork: fork5, actorSystem: systemC),
         ]
 
         try systemA.park(atMost: time)

--- a/Samples/Sources/SampleDiningPhilosophers/DistributedDiningPhilosophers.swift
+++ b/Samples/Sources/SampleDiningPhilosophers/DistributedDiningPhilosophers.swift
@@ -19,18 +19,15 @@ final class DistributedDiningPhilosophers {
     private var philosophers: [Philosopher] = []
 
     func run(for time: TimeAmount) async throws {
-        let systemA = ClusterSystem("Node-A") { settings in
-            settings.cluster.enabled = true
-            settings.cluster.bindPort = 1111
+        let systemA = await ClusterSystem("Node-A") { settings in
+            settings.bindPort = 1111
         }
-        let systemB = ClusterSystem("Node-B") { settings in
-            settings.cluster.enabled = true
-            settings.cluster.bindPort = 2222
+        let systemB = await ClusterSystem("Node-B") { settings in
+            settings.bindPort = 2222
             settings.logging.logLevel = .error
         }
-        let systemC = ClusterSystem("Node-C") { settings in
-            settings.cluster.enabled = true
-            settings.cluster.bindPort = 3333
+        let systemC = await ClusterSystem("Node-C") { settings in
+            settings.bindPort = 3333
             settings.logging.logLevel = .error
         }
         let systems = [systemA, systemB, systemC]
@@ -38,9 +35,9 @@ final class DistributedDiningPhilosophers {
         print("~~~~~~~ started \(systems.count) actor systems ~~~~~~~")
 
         // TODO: Joining to be simplified by having "seed nodes" (that a node should join)
-        systemA.cluster.join(node: systemB.settings.cluster.node)
-        systemA.cluster.join(node: systemC.settings.cluster.node)
-        systemC.cluster.join(node: systemB.settings.cluster.node)
+        systemA.cluster.join(node: systemB.settings.node)
+        systemA.cluster.join(node: systemC.settings.node)
+        systemC.cluster.join(node: systemB.settings.node)
 
         print("waiting for cluster to form...")
         while !(

--- a/Samples/Sources/SampleDiningPhilosophers/Fork.swift
+++ b/Samples/Sources/SampleDiningPhilosophers/Fork.swift
@@ -26,7 +26,7 @@ distributed actor Fork: CustomStringConvertible {
     private let name: String
     private var isTaken: Bool = false
 
-    init(name: String, transport: ActorTransport) {
+    init(name: String, actorSystem: ActorSystem) {
         self.name = name
     }
 

--- a/Samples/Sources/SampleDiningPhilosophers/Fork.swift
+++ b/Samples/Sources/SampleDiningPhilosophers/Fork.swift
@@ -27,6 +27,7 @@ distributed actor Fork: CustomStringConvertible {
     private var isTaken: Bool = false
 
     init(name: String, actorSystem: ActorSystem) {
+        self.actorSystem = actorSystem
         self.name = name
     }
 
@@ -45,10 +46,6 @@ distributed actor Fork: CustomStringConvertible {
             throw ForkError.puttingBackNotTakenFork
         }
         self.isTaken = false
-    }
-
-    public nonisolated var description: String {
-        "\(Self.self)(\(self.id.underlying))"
     }
 }
 

--- a/Samples/Sources/SampleDiningPhilosophers/Philosopher.swift
+++ b/Samples/Sources/SampleDiningPhilosophers/Philosopher.swift
@@ -26,7 +26,7 @@ distributed actor Philosopher: CustomStringConvertible {
 
     private lazy var timers = DistributedActors.ActorTimers<Philosopher>(self)
 
-    init(name: String, leftFork: Fork, rightFork: Fork, transport: ActorTransport) {
+    init(name: String, leftFork: Fork, rightFork: Fork, actorSystem: ActorSystem) {
         self.name = name
         self.leftFork = leftFork
         self.rightFork = rightFork

--- a/Samples/Sources/SampleDiningPhilosophers/Philosopher.swift
+++ b/Samples/Sources/SampleDiningPhilosophers/Philosopher.swift
@@ -27,12 +27,11 @@ distributed actor Philosopher: CustomStringConvertible {
     private lazy var timers = DistributedActors.ActorTimers<Philosopher>(self)
 
     init(name: String, leftFork: Fork, rightFork: Fork, actorSystem: ActorSystem) {
+        self.actorSystem = actorSystem
         self.name = name
         self.leftFork = leftFork
         self.rightFork = rightFork
         self.log.info("\(self.name) joined the table!")
-
-        assert(self.log[metadataKey: "cluster/node"] != nil, "was: \(self.id)")
 
         Task {
 //            context.watch(self.leftFork)
@@ -149,12 +148,6 @@ distributed actor Philosopher: CustomStringConvertible {
         self.timers.startSingle(key: .becomeHungry, delay: .seconds(3)) {
             await self.stopEating()
         }
-    }
-}
-
-extension Philosopher {
-    public nonisolated var description: String {
-        "\(Self.self)(\(self.id.underlying))"
     }
 }
 

--- a/Samples/Sources/SampleDiningPhilosophers/SamplePrettyLogHandler.swift
+++ b/Samples/Sources/SampleDiningPhilosophers/SamplePrettyLogHandler.swift
@@ -142,3 +142,9 @@ struct SamplePrettyLogHandler: LogHandler {
         }
     }
 }
+
+extension DistributedActor where Self: CustomStringConvertible {
+    public nonisolated var description: String {
+        "\(Self.self)(\(self.id))"
+    }
+}

--- a/Samples/Sources/SampleDiningPhilosophers/boot.swift
+++ b/Samples/Sources/SampleDiningPhilosophers/boot.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import DistributedActors
+import Distributed
 import Logging
 import NIO
 
@@ -26,6 +27,8 @@ import NIO
  * The implementation is based on the following take on the problem:
  * http://www.dalnefre.com/wp/2010/08/dining-philosophers-in-humus
  */
+
+typealias DefaultDistributedActorSystem = ClusterSystem
 
 @main enum Main {
     static func main() async {

--- a/Samples/Sources/SampleDiningPhilosophers/boot.swift
+++ b/Samples/Sources/SampleDiningPhilosophers/boot.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import DistributedActors
 import Distributed
+import DistributedActors
 import Logging
 import NIO
 
@@ -46,7 +46,7 @@ typealias DefaultDistributedActorSystem = ClusterSystem
         case "dist":
             try! await DistributedDiningPhilosophers().run(for: time)
         default:
-            try! DiningPhilosophers().run(for: time)
+            try! await DiningPhilosophers().run(for: time)
         }
     }
 }

--- a/Samples/Tests/NoopTests/SampleTest.swift
+++ b/Samples/Tests/NoopTests/SampleTest.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import DistributedActors
 import XCTest
 
 final class SampleTest: XCTestCase {

--- a/Sources/DistributedActors/Cluster/ClusterShell.swift
+++ b/Sources/DistributedActors/Cluster/ClusterShell.swift
@@ -38,7 +38,7 @@ internal class ClusterShell {
     private var selfNode: UniqueNode {
         self.settings.uniqueBindNode
     }
-    
+
     private let settings: ClusterSystemSettings
 
     // ~~~~~~ HERE BE DRAGONS, shared concurrently modified concurrent state ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
+++ b/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
@@ -240,7 +240,7 @@ public distributed actor OpLogDistributedReceptionist: DistributedReceptionist, 
     }
 
     // FIXME(swift 6): initializer must become async
-    init(settings: ReceptionistSettings, system: ActorSystem) {
+    init(settings: ReceptionistSettings, system: ActorSystem) async {
         self.actorSystem = system
         self.instrumentation = system.settings.instrumentation.makeReceptionistInstrumentation()
 
@@ -254,7 +254,7 @@ public distributed actor OpLogDistributedReceptionist: DistributedReceptionist, 
         self.appliedSequenceNrs = .empty
 
         // === listen to cluster events ------------------
-        self.eventsListeningTask = Task {
+        self.eventsListeningTask = Task.detached {
             try await self.whenLocal { __secretlyKnownToBeLocal in // TODO(distributed): this is annoying, we must track "known to be local" in typesystem instead
                 for try await event in system.cluster.events {
                     __secretlyKnownToBeLocal.onClusterEvent(event: event)

--- a/Sources/DistributedActors/ClusterSystem.swift
+++ b/Sources/DistributedActors/ClusterSystem.swift
@@ -96,12 +96,11 @@ public class ClusterSystem: DistributedActorSystem, @unchecked Sendable {
     internal var _receptionist: SystemReceptionist {
         guard let ref = _receptionistRef.load()?.value else {
             print("XXX lock for `_receptionist`")
-            initLock.lock()
+            self.initLock.lock()
             defer {
                 print("XXX UNLOCK for `_receptionist`")
                 initLock.unlock()
             }
-
 
             return _receptionist
         }
@@ -113,12 +112,11 @@ public class ClusterSystem: DistributedActorSystem, @unchecked Sendable {
     public var receptionist: OpLogDistributedReceptionist {
         guard let value = _receptionistStore.load() else {
             print("XXX lock for `receptionist`")
-            initLock.lock()
+            self.initLock.lock()
             defer {
                 print("XXX UNLOCK for `receptionist`")
                 initLock.unlock()
             }
-
 
             return self.receptionist
         }
@@ -133,7 +131,7 @@ public class ClusterSystem: DistributedActorSystem, @unchecked Sendable {
 
     // ==== ----------------------------------------------------------------------------------------------------------------
     // MARK: Cluster
-    
+
     internal final class Box<T> {
         var value: T
         init(_ value: T) {
@@ -146,7 +144,7 @@ public class ClusterSystem: DistributedActorSystem, @unchecked Sendable {
     internal var _cluster: ClusterShell? {
         guard let box = _clusterStore.load() else {
             print("XXX lock for `_cluster`")
-            initLock.lock()
+            self.initLock.lock()
             defer {
                 print("XXX UNLOCK for `_cluster`")
                 initLock.unlock()
@@ -160,7 +158,7 @@ public class ClusterSystem: DistributedActorSystem, @unchecked Sendable {
     public var cluster: ClusterControl {
         guard let box = _clusterControlStore.load() else {
             print("XXX lock for `cluster`")
-            initLock.lock()
+            self.initLock.lock()
             defer {
                 print("XXX UNLOCK for `cluster`")
                 initLock.unlock()
@@ -175,7 +173,7 @@ public class ClusterSystem: DistributedActorSystem, @unchecked Sendable {
     internal var _nodeDeathWatcher: NodeDeathWatcherShell.Ref? {
         guard let box = _nodeDeathWatcherStore.load() else {
             print("XXX lock for `_nodeDeathWatcher`")
-            initLock.lock()
+            self.initLock.lock()
             defer {
                 print("XXX UNLOCK for `_nodeDeathWatcher`")
                 initLock.unlock()
@@ -284,12 +282,12 @@ public class ClusterSystem: DistributedActorSystem, @unchecked Sendable {
         // vvv~~~~~~~~~~~~~~~~~~~ all properties initialized, self can be shared ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~vvv //
 
         print("XXX LOCK INITIALIZING...")
-        initLock.lock()
+        self.initLock.lock()
         defer {
             print("XXX UNLOCK INITIALIZING >>>")
             initLock.unlock()
         }
-        
+
         // serialization
         let serialization = Serialization(settings: settings, system: self)
         _ = self._serialization.storeIfNilThenLoad(serialization)

--- a/Sources/DistributedActors/DistributedActor+Messages.swift
+++ b/Sources/DistributedActors/DistributedActor+Messages.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Distributed
-@preconcurrency import struct Foundation.Data
+import struct Foundation.Data
 
 // FIXME(distributed): we need to get rid of this all of this... probably means having to remove the entire Ref based infrastructure
 

--- a/Sources/ExecApp/boot.swift
+++ b/Sources/ExecApp/boot.swift
@@ -40,7 +40,8 @@ enum Main {
         print("RESOLVE:")
         let resolved = try Greeter.resolve(id: greeter.id, using: system)
         print("Resolved: \(resolved)")
-        try await resolved.hi(name: "Caplin")
+        let greeting = try await resolved.hi(name: "Caplin")
+        print("Got remote greeting: \(greeting)")
 
         // ------------------------------------------
         print("REMOTE:")

--- a/Tests/DistributedActorsTests/ActorLeakingTests.swift
+++ b/Tests/DistributedActorsTests/ActorLeakingTests.swift
@@ -257,18 +257,18 @@ final class ActorLeakingTests: ActorSystemXCTestCase {
             if message == "shutdown" {
                 context.system.shutdown()
             }
-            p.tell("system:\(context.system.name)")
+            p.tell("system:\(context.system)")
             return .same
         })
 
         ref.tell("x")
-        try p.expectMessage("system:FreeMe")
+        try p.expectMessage("system:ClusterSystem(FreeMe, sact://FreeMe@127.0.0.1:7337)")
 
         // clear the strong reference from "user land"
         system = nil
 
         ref.tell("x")
-        try p.expectMessage("system:FreeMe")
+        try p.expectMessage("system:ClusterSystem(FreeMe, sact://FreeMe@127.0.0.1:7337)")
 
         ref.tell("shutdown") // since we lost the `system` reference here we'll ask the actor to stop the system
 

--- a/Tests/DistributedActorsTests/Cluster/RemoteActorRefProviderTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/RemoteActorRefProviderTests.swift
@@ -31,7 +31,10 @@ final class RemoteActorRefProviderTests: ActorSystemXCTestCase {
         let guardian = _Guardian(parent: theOne, name: "user", localNode: system.cluster.uniqueNode, system: system)
         let localProvider = LocalActorRefProvider(root: guardian)
 
-        let clusterShell = ClusterShell(selfNode: self.localNode)
+        var settings = ClusterSystemSettings(name: "\(Self.self)")
+        settings.node = self.localNode.node
+        settings.nid = self.localNode.nid
+        let clusterShell = ClusterShell(settings: settings)
         let provider = RemoteActorRefProvider(settings: system.settings, cluster: clusterShell, localProvider: localProvider)
 
         let node = UniqueNode(node: .init(systemName: "system", host: "3.3.3.3", port: 2322), nid: .random())


### PR DESCRIPTION
Resolves https://github.com/apple/swift-distributed-actors/issues/840

This does lock during init, and we can clean it up more nicely, but the locks are rarely hit and we only need them during initialization of the system actors. It is FINE if they're blocked for those few millis as the system actors initialize.

We'd have to do better to run the cluster on a single thread, but we'll do that if we ever need to.