### PR TITLE
Fix typos in doc comments

### DIFF
--- a/Sources/DistributedActors/Props.swift
+++ b/Sources/DistributedActors/Props.swift
@@ -25,7 +25,7 @@ import NIO
 /// overriding a previously existing one), while functions starting with `with...` are replacement functions, always
 /// replacing the entire inner props with the new one
 ///
-/// Naming mnemonic: "_Props" are what an theater actor may use during a performance.
+/// Naming mnemonic: "_Props" are what a theater actor may use during a performance.
 /// For example, a skull would be a classic example of a "prop" used while performing the William Shakespeare's
 /// Hamlet Act III, scene 1, saying "To be, or not to be, that is the question: [...]." In the same sense,
 /// props for Swift Distributed Actors are accompanying objects/settings, which help the actor perform its duties.

--- a/Sources/DistributedActors/Props.swift
+++ b/Sources/DistributedActors/Props.swift
@@ -20,7 +20,7 @@ import NIO
 
 /// `_Props` configure an Actors' properties such as mailbox, dispatcher as well as supervision semantics.
 ///
-/// `_Props` can easily changed in-line using the fluent APIs provided.
+/// `_Props` can be easily changed in-line using the fluent APIs provided.
 /// Functions starting with `add...` are additive, i.e. they add another setting of the same kind to the props (possibly
 /// overriding a previously existing one), while functions starting with `with...` are replacement functions, always
 /// replacing the entire inner props with the new one

--- a/Sources/DistributedActors/Supervision.swift
+++ b/Sources/DistributedActors/Supervision.swift
@@ -42,7 +42,7 @@ public struct _SupervisionProps {
 }
 
 public extension _Props {
-    /// Creates a new `_Props` appending an supervisor for the selected `Error` type, useful for setting a few options in-line when spawning actors.
+    /// Creates a new `_Props` appending a supervisor for the selected `Error` type, useful for setting a few options in-line when spawning actors.
     ///
     /// Note that order in which overlapping selectors/types are added to the chain matters.
     ///
@@ -55,7 +55,7 @@ public extension _Props {
         return props
     }
 
-    /// Creates a new `_Props` appending an supervisor for the selected failure type, useful for setting a few options in-line when spawning actors.
+    /// Creates a new `_Props` appending a supervisor for the selected failure type, useful for setting a few options in-line when spawning actors.
     ///
     /// Note that order in which overlapping selectors/types are added to the chain matters.
     ///
@@ -66,7 +66,7 @@ public extension _Props {
         self.supervision(strategy: strategy, forErrorType: _Supervise.internalErrorTypeFor(selector: selector))
     }
 
-    /// Creates a new `_Props` appending an supervisor for the selected `Error` type, useful for setting a few options in-line when spawning actors.
+    /// Creates a new `_Props` appending a supervisor for the selected `Error` type, useful for setting a few options in-line when spawning actors.
     ///
     /// Note that order in which overlapping selectors/types are added to the chain matters.
     ///
@@ -79,7 +79,7 @@ public extension _Props {
         return props
     }
 
-    /// Creates a new `_Props` appending an supervisor for the selected failure type, useful for setting a few options in-line when spawning actors.
+    /// Creates a new `_Props` appending a supervisor for the selected failure type, useful for setting a few options in-line when spawning actors.
     ///
     /// Note that order in which overlapping selectors/types are added to the chain matters.
     ///

--- a/Sources/DistributedActorsConcurrencyHelpers/lock.swift
+++ b/Sources/DistributedActorsConcurrencyHelpers/lock.swift
@@ -53,7 +53,7 @@ public final class Lock {
 
     /// Release the lock.
     ///
-    /// Whenver possible, consider using `withLock` instead of this method and
+    /// Whenever possible, consider using `withLock` instead of this method and
     /// `lock`, to simplify lock handling.
     public func unlock() {
         let err = pthread_mutex_unlock(self.mutex)


### PR DESCRIPTION
`can easily changed in-line` -> `can be easily changed in-line`
`an theater` -> `a theater`
`an supervisor` -> `a supervisor`
`Whenver` -> `Whenever`