### PR TITLE
[format] Update to swiftformat 0.48.8 and enable extensionacl=on-decls

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,6 +1,6 @@
 # file options
 
---swiftversion 5.2
+--swiftversion 5.4
 --exclude .build
 --exclude "**/*.pb.swift"
 --exclude "**/*+GenActor.swift"

--- a/.swiftformat
+++ b/.swiftformat
@@ -23,3 +23,7 @@
 --disable redundantInit
 --disable redundantGet
 --disable redundantReturn
+
+# we want to have fine grained control over extensions by marking each function
+# explicitly, rather than it being forced onto the extension entirely.
+--extensionacl on-declarations

--- a/Samples/Sources/SampleDiningPhilosophers/DistributedDiningPhilosophers.swift
+++ b/Samples/Sources/SampleDiningPhilosophers/DistributedDiningPhilosophers.swift
@@ -43,7 +43,8 @@ final class DistributedDiningPhilosophers {
         while !(
             systemA.cluster.membershipSnapshot.count(withStatus: .up) == systems.count &&
                 systemB.cluster.membershipSnapshot.count(withStatus: .up) == systems.count &&
-                systemC.cluster.membershipSnapshot.count(withStatus: .up) == systems.count) {
+                systemC.cluster.membershipSnapshot.count(withStatus: .up) == systems.count)
+        {
             let nanosInSecond: UInt64 = 1_000_000_000
             try await Task.sleep(nanoseconds: 1 * nanosInSecond)
         }

--- a/Sources/ActorSingletonPlugin/ActorSingletonPlugin.swift
+++ b/Sources/ActorSingletonPlugin/ActorSingletonPlugin.swift
@@ -95,8 +95,8 @@ extension ActorSingletonPlugin: Plugin {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Singleton refs and actors
 
-public extension ClusterSystem {
-    var singleton: ActorSingletonControl {
+extension ClusterSystem {
+    public var singleton: ActorSingletonControl {
         .init(self)
     }
 }

--- a/Sources/DistributedActors/ActorAddress.swift
+++ b/Sources/DistributedActors/ActorAddress.swift
@@ -200,10 +200,10 @@ extension ActorAddress {
     }
 }
 
-public extension ActorAddress {
+extension ActorAddress {
     /// :nodoc:
     @inlinable
-    var _isLocal: Bool {
+    public var _isLocal: Bool {
         switch self._location {
         case .local: return true
         default: return false
@@ -212,20 +212,20 @@ public extension ActorAddress {
 
     /// :nodoc:
     @inlinable
-    var _isRemote: Bool {
+    public var _isRemote: Bool {
         !self._isLocal
     }
 
     /// :nodoc:
     @inlinable
-    var _asRemote: Self {
+    public var _asRemote: Self {
         let remote = Self(remote: self.uniqueNode, path: self.path, incarnation: self.incarnation)
         return remote
     }
 
     /// :nodoc:
     @inlinable
-    var _asLocal: Self {
+    public var _asLocal: Self {
         let local = Self(local: self.uniqueNode, path: self.path, incarnation: self.incarnation)
         return local
     }
@@ -379,10 +379,10 @@ extension ActorPath: CustomStringConvertible {
     }
 }
 
-public extension ActorPath {
-    static let _root: ActorPath = .init() // also known as "/"
-    static let _user: ActorPath = try! ActorPath(root: "user")
-    static let _system: ActorPath = try! ActorPath(root: "system")
+extension ActorPath {
+    public static let _root: ActorPath = .init() // also known as "/"
+    public static let _user: ActorPath = try! ActorPath(root: "user")
+    public static let _system: ActorPath = try! ActorPath(root: "system")
 
     internal func makeLocalAddress(on node: UniqueNode, incarnation: ActorIncarnation) -> ActorAddress {
         .init(local: node, path: self, incarnation: incarnation)
@@ -408,14 +408,14 @@ public protocol _PathRelationships {
     func appending(segment: ActorPathSegment) -> Self
 }
 
-public extension _PathRelationships {
+extension _PathRelationships {
     /// Combines the base path with a child segment returning the concatenated path.
     internal static func / (base: Self, child: ActorPathSegment) -> Self {
         base.appending(segment: child)
     }
 
     /// Checks whether this path starts with the passed in `path`.
-    func starts(with path: ActorPath) -> Bool {
+    public func starts(with path: ActorPath) -> Bool {
         self.segments.starts(with: path.segments)
     }
 
@@ -427,7 +427,7 @@ public extension _PathRelationships {
     ///
     /// - Parameter path: The path that is suspected to be the parent of `self`
     /// - Returns: `true` if this [ActorPath] is a direct descendant of `maybeParentPath`, `false` otherwise
-    func isChildPathOf(_ maybeParentPath: _PathRelationships) -> Bool {
+    public func isChildPathOf(_ maybeParentPath: _PathRelationships) -> Bool {
         Array(self.segments.dropLast()) == maybeParentPath.segments // TODO: more efficient impl, without the copying
     }
 
@@ -439,7 +439,7 @@ public extension _PathRelationships {
     ///
     /// - Parameter path: The path that is suspected to be a child of `self`
     /// - Returns: `true` if this [ActorPath] is a direct ancestor of `maybeChildPath`, `false` otherwise
-    func isParentOf(_ maybeChildPath: _PathRelationships) -> Bool {
+    public func isParentOf(_ maybeChildPath: _PathRelationships) -> Bool {
         maybeChildPath.isChildPathOf(self)
     }
 
@@ -569,18 +569,18 @@ public struct ActorIncarnation: Equatable, Hashable, ExpressibleByIntegerLiteral
     }
 }
 
-public extension ActorIncarnation {
+extension ActorIncarnation {
     /// To be used ONLY by special actors whose existence is wellKnown and identity never-changing.
     /// Examples: `/system/deadLetters` or `/system/cluster`.
-    static let wellKnown: ActorIncarnation = .init(0)
+    public static let wellKnown: ActorIncarnation = .init(0)
 
-    static func random() -> ActorIncarnation {
+    public static func random() -> ActorIncarnation {
         ActorIncarnation(UInt32.random(in: UInt32(1) ... UInt32.max))
     }
 }
 
-internal extension ActorIncarnation {
-    init?(_ value: String?) {
+extension ActorIncarnation {
+    internal init?(_ value: String?) {
         guard let int = (value.flatMap {
             Int($0)
         }), int >= 0 else {
@@ -765,8 +765,8 @@ extension UniqueNodeID: CustomStringConvertible {
     }
 }
 
-public extension UniqueNodeID {
-    static func random() -> UniqueNodeID {
+extension UniqueNodeID {
+    public static func random() -> UniqueNodeID {
         UniqueNodeID(UInt64.random(in: 1 ... .max))
     }
 }

--- a/Sources/DistributedActors/ActorContext.swift
+++ b/Sources/DistributedActors/ActorContext.swift
@@ -126,7 +126,8 @@ public class _ActorContext<Message: ActorMessage> /* TODO(sendable): NOTSendable
         file: String = #file, line: UInt = #line,
         _ behavior: _Behavior<M>
     ) throws -> _ActorRef<M>
-        where M: ActorMessage {
+        where M: ActorMessage
+    {
         _undefined()
     }
 
@@ -144,7 +145,8 @@ public class _ActorContext<Message: ActorMessage> /* TODO(sendable): NOTSendable
         file: String = #file, line: UInt = #line,
         _ behavior: _Behavior<M>
     ) throws -> _ActorRef<M>
-        where M: ActorMessage {
+        where M: ActorMessage
+    {
         _undefined()
     }
 
@@ -330,7 +332,8 @@ public class _ActorContext<Message: ActorMessage> /* TODO(sendable): NOTSendable
     /// being silently dropped. This can be useful when not all messages `From` have a valid representation in
     /// `Message`, or if not all `From` messages are of interest for this particular actor.
     public final func messageAdapter<From>(_ adapt: @escaping (From) -> Message?) -> _ActorRef<From>
-        where From: ActorMessage {
+        where From: ActorMessage
+    {
         return self.messageAdapter(from: From.self, adapt: adapt)
     }
 
@@ -346,7 +349,8 @@ public class _ActorContext<Message: ActorMessage> /* TODO(sendable): NOTSendable
     /// being silently dropped. This can be useful when not all messages `From` have a valid representation in
     /// `Message`, or if not all `From` messages are of interest for this particular actor.
     public func messageAdapter<From>(from type: From.Type, adapt: @escaping (From) -> Message?) -> _ActorRef<From>
-        where From: ActorMessage {
+        where From: ActorMessage
+    {
         return _undefined()
     }
 
@@ -361,7 +365,8 @@ public class _ActorContext<Message: ActorMessage> /* TODO(sendable): NOTSendable
     /// with an existing `_SubReceiveId`, it replaces the old one. All references will remain valid and point to
     /// the new behavior.
     public func subReceive<SubMessage>(_: _SubReceiveId<SubMessage>, _: SubMessage.Type, _: @escaping (SubMessage) throws -> Void) -> _ActorRef<SubMessage>
-        where SubMessage: ActorMessage {
+        where SubMessage: ActorMessage
+    {
         return _undefined()
     }
 

--- a/Sources/DistributedActors/ActorLogging.swift
+++ b/Sources/DistributedActors/ActorLogging.swift
@@ -73,16 +73,16 @@ internal final class LoggingContext {
 /// such as it's path or node on which it resides.
 ///
 /// The preferred way of obtaining a logger for an actor or system is `context.log` or `system.log`, rather than creating new ones.
-public extension Logger {
+extension Logger {
     /// Create a logger specific to this actor.
-    init<Act: DistributedActor>(actor: Act) where Act.ActorSystem == ClusterSystem {
+    public init<Act: DistributedActor>(actor: Act) where Act.ActorSystem == ClusterSystem {
         var log = Logger(label: "\(actor.id)")
         log[metadataKey: "actor/path"] = "\(actor.id.path)"
         log[metadataKey: "actor/id"] = "\(actor.id)"
         self = log
     }
 
-    static func make<T>(context: _ActorContext<T>) -> Logger {
+    public static func make<T>(context: _ActorContext<T>) -> Logger {
         Logger.make(context.log, path: context.path)
     }
 
@@ -283,12 +283,12 @@ public struct LogMessage {
     let line: UInt
 }
 
-public extension Logger.MetadataValue {
-    static func pretty<T>(_ value: T) -> Logger.Metadata.Value where T: CustomPrettyStringConvertible {
+extension Logger.MetadataValue {
+    public static func pretty<T>(_ value: T) -> Logger.Metadata.Value where T: CustomPrettyStringConvertible {
         Logger.MetadataValue.stringConvertible(CustomPrettyStringConvertibleMetadataValue(value))
     }
 
-    static func pretty<T>(_ value: T) -> Logger.Metadata.Value {
+    public static func pretty<T>(_ value: T) -> Logger.Metadata.Value {
         if let pretty = value as? CustomPrettyStringConvertible {
             return Logger.MetadataValue.stringConvertible(CustomPrettyStringConvertibleMetadataValue(pretty))
         } else {
@@ -309,12 +309,12 @@ struct CustomPrettyStringConvertibleMetadataValue: CustomStringConvertible {
     }
 }
 
-public extension Optional where Wrapped == Logger.MetadataValue {
-    static func lazyStringConvertible(_ makeValue: @escaping () -> CustomStringConvertible) -> Logger.Metadata.Value {
+extension Optional where Wrapped == Logger.MetadataValue {
+    public static func lazyStringConvertible(_ makeValue: @escaping () -> CustomStringConvertible) -> Logger.Metadata.Value {
         .stringConvertible(LazyMetadataBox { makeValue() })
     }
 
-    static func lazyString(_ makeValue: @escaping () -> String) -> Logger.Metadata.Value {
+    public static func lazyString(_ makeValue: @escaping () -> String) -> Logger.Metadata.Value {
         self.lazyStringConvertible(makeValue)
     }
 }
@@ -350,10 +350,10 @@ internal class LazyMetadataBox: CustomStringConvertible {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Logger extensions
 
-public extension Logger {
+extension Logger {
     /// Allows passing in a `Logger.Level?` and not log if it was `nil`.
     @inlinable
-    func log(
+    public func log(
         level: Logger.Level?,
         _ message: @autoclosure () -> Logger.Message,
         metadata: @autoclosure () -> Logger.Metadata? = nil,

--- a/Sources/DistributedActors/ActorMessage+Protobuf.swift
+++ b/Sources/DistributedActors/ActorMessage+Protobuf.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 
 public protocol Any_ProtobufRepresentable: ActorMessage, SerializationRepresentable {}
 
-public extension Any_ProtobufRepresentable {
-    static var defaultSerializerID: Serialization.SerializerID? {
+extension Any_ProtobufRepresentable {
+    public static var defaultSerializerID: Serialization.SerializerID? {
         ._ProtobufRepresentable
     }
 }
@@ -47,8 +47,8 @@ public protocol _ProtobufRepresentable: _AnyPublic_ProtobufRepresentable {
 // Implementation note:
 // This conformance is a bit weird, and it is not usually going to be invoked through Codable
 // however it could, so we allow for this use case.
-public extension _ProtobufRepresentable {
-    init(from decoder: Decoder) throws {
+extension _ProtobufRepresentable {
+    public init(from decoder: Decoder) throws {
         guard let context = decoder.actorSerializationContext else {
             throw SerializationError.missingSerializationContext(decoder, Self.self)
         }
@@ -61,7 +61,7 @@ public extension _ProtobufRepresentable {
         try self.init(fromProto: proto, context: context)
     }
 
-    func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Encoder) throws {
         guard let context = encoder.actorSerializationContext else {
             throw SerializationError.missingSerializationContext(encoder, self)
         }
@@ -134,13 +134,13 @@ extension Internal_ProtobufRepresentable {
     }
 }
 
-public extension _ProtobufRepresentable {
-    init(context: Serialization.Context, from buffer: Serialization.Buffer, using manifest: Serialization.Manifest) throws {
+extension _ProtobufRepresentable {
+    public init(context: Serialization.Context, from buffer: Serialization.Buffer, using manifest: Serialization.Manifest) throws {
         let proto = try ProtobufRepresentation(serializedData: buffer.readData())
         try self.init(fromProto: proto, context: context)
     }
 
-    func serialize(context: Serialization.Context) throws -> Serialization.Buffer {
+    public func serialize(context: Serialization.Context) throws -> Serialization.Buffer {
         try .data(self.toProto(context: context).serializedData())
     }
 }

--- a/Sources/DistributedActors/ActorMessages.swift
+++ b/Sources/DistributedActors/ActorMessages.swift
@@ -164,20 +164,20 @@ public struct NonTransportableAnyError: Error, NonTransportableActorMessage {
 /// - Warning: Attempting to send such message over the network will fail at runtime (and log an error or warning).
 public protocol NonTransportableActorMessage: ActorMessage {}
 
-public extension NonTransportableActorMessage {
-    init(from decoder: Swift.Decoder) throws {
+extension NonTransportableActorMessage {
+    public init(from decoder: Swift.Decoder) throws {
         fatalError("Attempted to decode NonTransportableActorMessage message: \(Self.self)! This should never happen.")
     }
 
-    func encode(to encoder: Swift.Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         fatalError("Attempted to encode NonTransportableActorMessage message: \(Self.self)! This should never happen.")
     }
 
-    init(context: Serialization.Context, from buffer: inout ByteBuffer, using manifest: Serialization.Manifest) throws {
+    public init(context: Serialization.Context, from buffer: inout ByteBuffer, using manifest: Serialization.Manifest) throws {
         fatalError("Attempted to deserialize NonTransportableActorMessage message: \(Self.self)! This should never happen.")
     }
 
-    func serialize(context: Serialization.Context, to bytes: inout ByteBuffer) throws {
+    public func serialize(context: Serialization.Context, to bytes: inout ByteBuffer) throws {
         fatalError("Attempted to serialize NonTransportableActorMessage message: \(Self.self)! This should never happen.")
     }
 }

--- a/Sources/DistributedActors/ActorNaming.swift
+++ b/Sources/DistributedActors/ActorNaming.swift
@@ -17,7 +17,7 @@ import DistributedActorsConcurrencyHelpers
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Actor Name
 
-public extension ActorNaming {
+extension ActorNaming {
     /// Default actor naming strategy; whereas the name MUST be unique under a given path.
     ///
     /// I.e. if a parent actor spawns `.unique(worker)`
@@ -25,7 +25,7 @@ public extension ActorNaming {
     /// This naming is used by the `ExpressibleByStringLiteral` and `ExpressibleByStringInterpolation` conversions.
     ///
     /// - Faults: when passed in name contains illegal characters. See `ActorNaming` for detailed rules about actor naming.
-    static func unique(_ name: String) -> ActorNaming {
+    public static func unique(_ name: String) -> ActorNaming {
         ActorNaming.validateUserProvided(nameOrPrefix: name)
         return .init(unchecked: .unique(name))
     }
@@ -35,13 +35,13 @@ public extension ActorNaming {
     /// actor, it may name them with subsequent numbers or letters of a limited alphabet.
     ///
     /// - Faults: when passed in name contains illegal characters. See `ActorNaming` for detailed rules about actor naming.
-    static func prefixed(with prefix: String) -> ActorNaming {
+    public static func prefixed(with prefix: String) -> ActorNaming {
         ActorNaming.validateUserProvided(nameOrPrefix: prefix)
         return .init(unchecked: .prefixed(prefix: prefix, suffixScheme: .letters))
     }
 
     /// Shorthand for defining "anonymous" actor names, which carry
-    static var anonymous: ActorNaming {
+    public static var anonymous: ActorNaming {
         .init(unchecked: .prefixed(prefix: "$anonymous", suffixScheme: .letters))
     }
 

--- a/Sources/DistributedActors/ActorRefProvider.swift
+++ b/Sources/DistributedActors/ActorRefProvider.swift
@@ -79,7 +79,8 @@ extension RemoteActorRefProvider {
         dispatcher: MessageDispatcher, props: _Props,
         startImmediately: Bool
     ) throws -> _ActorRef<Message>
-        where Message: ActorMessage {
+        where Message: ActorMessage
+    {
         // spawn is always local, thus we delegate to the underlying provider
         return try self.localProvider._spawn(system: system, behavior: behavior, address: address, dispatcher: dispatcher, props: props, startImmediately: startImmediately)
     }
@@ -143,7 +144,8 @@ internal struct LocalActorRefProvider: _ActorRefProvider {
         dispatcher: MessageDispatcher, props: _Props,
         startImmediately: Bool
     ) throws -> _ActorRef<Message>
-        where Message: ActorMessage {
+        where Message: ActorMessage
+    {
         return try self.root.makeChild(path: address.path) {
             // the cell that holds the actual "actor", though one could say the cell *is* the actor...
             let actor: _ActorShell<Message> = _ActorShell(

--- a/Sources/DistributedActors/ActorTags.swift
+++ b/Sources/DistributedActors/ActorTags.swift
@@ -63,9 +63,9 @@ public protocol ActorTag: Sendable where Value == Key.Value {
     var value: Value { get }
 }
 
-public extension ActorTag {
-    var keyType: Key.Type { Key.self }
-    var id: String { Key.id }
+extension ActorTag {
+    public var keyType: Key.Type { Key.self }
+    public var id: String { Key.id }
 }
 
 public protocol ActorTagKey: Sendable {

--- a/Sources/DistributedActors/Adapters.swift
+++ b/Sources/DistributedActors/Adapters.swift
@@ -165,7 +165,7 @@ extension _ActorRefAdapter {
 
     public func _resolve<Message>(context: ResolveContext<Message>) -> _ActorRef<Message> {
         guard context.selectorSegments.first == nil,
-            self.address.incarnation == context.address.incarnation
+              self.address.incarnation == context.address.incarnation
         else {
             return context.personalDeadLetters
         }
@@ -382,7 +382,7 @@ extension SubReceiveAdapter {
 
     public func _resolve<Message>(context: ResolveContext<Message>) -> _ActorRef<Message> {
         guard context.selectorSegments.first == nil,
-            self.address.incarnation == context.address.incarnation
+              self.address.incarnation == context.address.incarnation
         else {
             return context.personalDeadLetters
         }

--- a/Sources/DistributedActors/Behaviors.swift
+++ b/Sources/DistributedActors/Behaviors.swift
@@ -29,19 +29,19 @@ public struct _Behavior<Message: ActorMessage>: @unchecked Sendable {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Message Handling
 
-public extension _Behavior {
+extension _Behavior {
     /// Defines a behavior that will be executed with an incoming message by its hosting actor.
     /// Additionally exposes `ActorContext` which can be used to e.g. log messages, spawn child actors etc.
     ///
     /// - SeeAlso: `receiveMessage` convenience behavior for when you do not need to access the `ActorContext`.
-    static func receive(_ handle: @escaping (_ActorContext<Message>, Message) throws -> _Behavior<Message>) -> _Behavior {
+    public static func receive(_ handle: @escaping (_ActorContext<Message>, Message) throws -> _Behavior<Message>) -> _Behavior {
         _Behavior(underlying: .receive(handle))
     }
 
     /// Defines a behavior that will be executed with an incoming message by its hosting actor.
     ///
     /// - SeeAlso: `receive` convenience if you also need to access the `ActorContext`.
-    static func receiveMessage(_ handle: @escaping (Message) throws -> _Behavior<Message>) -> _Behavior {
+    public static func receiveMessage(_ handle: @escaping (Message) throws -> _Behavior<Message>) -> _Behavior {
         _Behavior(underlying: .receiveMessage(handle))
     }
 }
@@ -126,7 +126,7 @@ extension _Behavior {
     func receiveSignalAsync(
         context: _ActorContext<Message>,
         signal: _Signal,
-        handleSignal: @escaping @Sendable(
+        handleSignal: @escaping @Sendable (
             _ActorContext<Message>,
             _Signal
         ) async throws -> _Behavior<Message>
@@ -164,19 +164,19 @@ extension _Behavior {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Most often used next-Behaviors
 
-public extension _Behavior {
+extension _Behavior {
     /// Defines that the "same" behavior should remain in use for handling the next message.
     ///
     /// Note: prefer returning `.same` rather than "the same instance" of a behavior, as `.same` is internally optimized
     /// to avoid allocating and swapping behavior states when no changes are needed to be made.
-    static var same: _Behavior<Message> {
+    public static var same: _Behavior<Message> {
         _Behavior(underlying: .same)
     }
 
     /// Causes a message to be assumed unhandled by the runtime.
     /// Unhandled messages are logged by default, and other behaviors may use this information to implement `apply1.orElse(apply2)` style logic.
     // TODO: and their logging rate should be configurable
-    static var unhandled: _Behavior<Message> {
+    public static var unhandled: _Behavior<Message> {
         _Behavior(underlying: .unhandled)
     }
 
@@ -187,7 +187,7 @@ public extension _Behavior {
     /// in the sense that we did handle it, however simply chose to ignore it.
     ///
     /// Returning `ignore` implies remaining the same behavior, the same way as would returning `.same`.
-    static var ignore: _Behavior<Message> {
+    public static var ignore: _Behavior<Message> {
         _Behavior(underlying: .ignore)
     }
 }
@@ -195,7 +195,7 @@ public extension _Behavior {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Lifecycle Behaviors
 
-public extension _Behavior {
+extension _Behavior {
     /// Runs once the actor has been started, also exposing the `ActorContext`
     ///
     /// #### Example usage
@@ -216,7 +216,7 @@ public extension _Behavior {
     ///
     /// This can be used to obtain the context, logger or perform actions right when the actor starts
     /// (e.g. send an initial message, or subscribe to some event stream, configure receive timeouts, etc.).
-    static func setup(_ onStart: @escaping (_ActorContext<Message>) throws -> _Behavior<Message>) -> _Behavior {
+    public static func setup(_ onStart: @escaping (_ActorContext<Message>) throws -> _Behavior<Message>) -> _Behavior {
         _Behavior(underlying: .setup(onStart))
     }
 
@@ -226,7 +226,7 @@ public extension _Behavior {
     /// the same signal handler (chain) to process all events.
     ///
     /// - SeeAlso: `stop(_:)` and `stop(postStop:) overloads for adding cleanup code to be executed upon receipt of _PostStop signal.
-    static var stop: _Behavior<Message> {
+    public static var stop: _Behavior<Message> {
         _Behavior.stop(postStop: nil, reason: .stopMyself)
     }
 
@@ -234,7 +234,7 @@ public extension _Behavior {
     /// and the actor itself will stop. Return this behavior to stop your actors. This is a convenience overload that
     /// allows users to specify a closure that will only be called on receipt of `_PostStop` and therefore does not
     /// need to get the signal passed in. It also does not need to return a new behavior, as the actor is already stopping.
-    static func stop(_ postStop: @escaping (_ActorContext<Message>) throws -> Void) -> _Behavior<Message> {
+    public static func stop(_ postStop: @escaping (_ActorContext<Message>) throws -> Void) -> _Behavior<Message> {
         _Behavior.stop(
             postStop: _Behavior.receiveSignal { context, signal in
                 if signal is _Signals._PostStop {
@@ -251,7 +251,7 @@ public extension _Behavior {
     /// set, it will be used to handle the `_PostStop` signal after the actor has stopped. Otherwise the last
     /// assigned behavior will be used. This allows users to use the same signal handler (chain) to process
     /// all events.
-    static func stop(postStop: _Behavior<Message>) -> _Behavior<Message> {
+    public static func stop(postStop: _Behavior<Message>) -> _Behavior<Message> {
         _Behavior(underlying: .stop(postStop: postStop, reason: .stopMyself))
     }
 }
@@ -259,12 +259,12 @@ public extension _Behavior {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: _Behavior Combinators
 
-public extension _Behavior {
+extension _Behavior {
     /// Creates a new _Behavior which on an incoming message will first execute the first (current) behavior,
     /// and if it returns `.unhandled` applies the alternative behavior passed in here.
     ///
     /// If the alternative behavior contains a `.setup` or other deferred behavior, it will be canonicalized on its first execution // TODO: make a test for it
-    func orElse(_ alternativeBehavior: _Behavior<Message>) -> _Behavior<Message> {
+    public func orElse(_ alternativeBehavior: _Behavior<Message>) -> _Behavior<Message> {
         _Behavior(underlying: .orElse(first: self, second: alternativeBehavior))
     }
 }
@@ -272,7 +272,7 @@ public extension _Behavior {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Signal receiving behaviors
 
-public extension _Behavior {
+extension _Behavior {
     /// Allows reacting to `Signal`s, such as lifecycle events.
     ///
     /// Note that this behavior _adds_ the ability to handle signals in addition to an existing message handling behavior
@@ -294,7 +294,7 @@ public extension _Behavior {
     ///
     /// - SeeAlso: `Signals` for a listing of signals that may be handled using this behavior.
     /// - SeeAlso: `receiveSpecificSignal` for convenience version of this behavior, simplifying handling a single type of `Signal`.
-    func receiveSignal(_ handle: @escaping (_ActorContext<Message>, _Signal) throws -> _Behavior<Message>) -> _Behavior<Message> {
+    public func receiveSignal(_ handle: @escaping (_ActorContext<Message>, _Signal) throws -> _Behavior<Message>) -> _Behavior<Message> {
         _Behavior(
             underlying: .signalHandling(
                 handleMessage: self,
@@ -303,8 +303,8 @@ public extension _Behavior {
         )
     }
 
-    func _receiveSignalAsync(
-        _ handle: @escaping @Sendable(_ActorContext<Message>, _Signal) async throws -> _Behavior<Message>
+    public func _receiveSignalAsync(
+        _ handle: @escaping @Sendable (_ActorContext<Message>, _Signal) async throws -> _Behavior<Message>
     ) -> _Behavior<Message> {
         _Behavior(
             underlying: .signalHandlingAsync(
@@ -335,7 +335,7 @@ public extension _Behavior {
     ///
     /// - SeeAlso: `Signals` for a listing of signals that may be handled using this behavior.
     /// - SeeAlso: `receiveSpecificSignal` for convenience version of this behavior, simplifying handling a single type of `Signal`.
-    static func receiveSignal(_ handle: @escaping (_ActorContext<Message>, _Signal) throws -> _Behavior<Message>) -> _Behavior<Message> {
+    public static func receiveSignal(_ handle: @escaping (_ActorContext<Message>, _Signal) throws -> _Behavior<Message>) -> _Behavior<Message> {
         _Behavior(
             underlying: .signalHandling(
                 handleMessage: .unhandled,
@@ -359,7 +359,7 @@ public extension _Behavior {
     ///
     /// - SeeAlso: `Signals` for a listing of signals that may be handled using this behavior.
     /// - SeeAlso: `receiveSignal` which allows receiving multiple types of signals.
-    func receiveSpecificSignal<SpecificSignal: _Signal>(_: SpecificSignal.Type, _ handle: @escaping (_ActorContext<Message>, SpecificSignal) throws -> _Behavior<Message>) -> _Behavior<Message> {
+    public func receiveSpecificSignal<SpecificSignal: _Signal>(_: SpecificSignal.Type, _ handle: @escaping (_ActorContext<Message>, SpecificSignal) throws -> _Behavior<Message>) -> _Behavior<Message> {
         // TODO: better type printout so we know we only handle SpecificSignal with this one
         self.receiveSignal { context, signal in
             switch signal {
@@ -386,7 +386,7 @@ public extension _Behavior {
     ///
     /// - SeeAlso: `Signals` for a listing of signals that may be handled using this behavior.
     /// - SeeAlso: `receiveSignal` which allows receiving multiple types of signals.
-    static func receiveSpecificSignal<SpecificSignal: _Signal>(_: SpecificSignal.Type, _ handle: @escaping (_ActorContext<Message>, SpecificSignal) throws -> _Behavior<Message>) -> _Behavior<Message> {
+    public static func receiveSpecificSignal<SpecificSignal: _Signal>(_: SpecificSignal.Type, _ handle: @escaping (_ActorContext<Message>, SpecificSignal) throws -> _Behavior<Message>) -> _Behavior<Message> {
         _Behavior(
             underlying: .signalHandling(
                 handleMessage: .unhandled,
@@ -406,18 +406,18 @@ public extension _Behavior {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Internal behavior creators
 
-internal extension _Behavior {
+extension _Behavior {
     /// Allows handling signals such as termination or lifecycle events.
     @usableFromInline
-    static func signalHandling(handleMessage: _Behavior<Message>, handleSignal: @escaping (_ActorContext<Message>, _Signal) throws -> _Behavior<Message>) -> _Behavior<Message> {
+    internal static func signalHandling(handleMessage: _Behavior<Message>, handleSignal: @escaping (_ActorContext<Message>, _Signal) throws -> _Behavior<Message>) -> _Behavior<Message> {
         _Behavior(underlying: .signalHandling(handleMessage: handleMessage, handleSignal: handleSignal))
     }
 
     /// Allows handling signals such as termination or lifecycle events.
     @usableFromInline
-    static func signalHandlingAsync(
+    internal static func signalHandlingAsync(
         handleMessage: _Behavior<Message>,
-        handleSignal: @escaping @Sendable(_ActorContext<Message>, _Signal) async throws -> _Behavior<Message>
+        handleSignal: @escaping @Sendable (_ActorContext<Message>, _Signal) async throws -> _Behavior<Message>
     ) -> _Behavior<Message> {
         _Behavior(underlying: .signalHandlingAsync(handleMessage: handleMessage, handleSignal: handleSignal))
     }
@@ -426,7 +426,7 @@ internal extension _Behavior {
     ///
     /// MUST be canonicalized (to .suspended before storing in an `ActorCell`, as thr suspend behavior CAN NOT handle messages.
     @usableFromInline
-    static func suspend<T>(handler: @escaping (Result<T, Error>) throws -> _Behavior<Message>) -> _Behavior<Message> {
+    internal static func suspend<T>(handler: @escaping (Result<T, Error>) throws -> _Behavior<Message>) -> _Behavior<Message> {
         _Behavior(underlying: .suspend(handler: { result in
             try handler(result.map { $0 as! T }) // cast here is okay, as user APIs are typed, so we should always get a T
         }))
@@ -438,13 +438,13 @@ internal extension _Behavior {
     /// This usually happens when an async operation that caused the suspension
     /// is completed.
     @usableFromInline
-    static func suspended(previousBehavior: _Behavior<Message>, handler: @escaping (Result<Any, Error>) throws -> _Behavior<Message>) -> _Behavior<Message> {
+    internal static func suspended(previousBehavior: _Behavior<Message>, handler: @escaping (Result<Any, Error>) throws -> _Behavior<Message>) -> _Behavior<Message> {
         _Behavior(underlying: .suspended(previousBehavior: previousBehavior, handler: handler))
     }
 
     /// Creates internal representation of stopped behavior, see `stop(_:)` for public api.
     @usableFromInline
-    static func stop(postStop: _Behavior<Message>? = nil, reason: StopReason) -> _Behavior<Message> {
+    internal static func stop(postStop: _Behavior<Message>? = nil, reason: StopReason) -> _Behavior<Message> {
         _Behavior(underlying: .stop(postStop: postStop, reason: reason))
     }
 
@@ -453,7 +453,7 @@ internal extension _Behavior {
     /// - parameters
     ///   - error: cause of the actor's failing.
     @usableFromInline
-    func fail(cause: _Supervision.Failure) -> _Behavior<Message> {
+    internal func fail(cause: _Supervision.Failure) -> _Behavior<Message> {
         _Behavior(underlying: __Behavior<Message>.failed(behavior: self, cause: cause))
     }
 }
@@ -463,10 +463,10 @@ internal enum __Behavior<Message: ActorMessage> {
     case setup(_ onStart: (_ActorContext<Message>) throws -> _Behavior<Message>)
 
     case receive(_ handle: (_ActorContext<Message>, Message) throws -> _Behavior<Message>)
-    case receiveAsync(_ handle: @Sendable(_ActorContext<Message>, Message) async throws -> _Behavior<Message>)
+    case receiveAsync(_ handle: @Sendable (_ActorContext<Message>, Message) async throws -> _Behavior<Message>)
 
     case receiveMessage(_ handle: (Message) throws -> _Behavior<Message>)
-    case receiveMessageAsync(_ handle: @Sendable(Message) async throws -> _Behavior<Message>)
+    case receiveMessageAsync(_ handle: @Sendable (Message) async throws -> _Behavior<Message>)
 
     indirect case stop(postStop: _Behavior<Message>?, reason: StopReason)
     indirect case failed(behavior: _Behavior<Message>, cause: _Supervision.Failure)
@@ -477,7 +477,7 @@ internal enum __Behavior<Message: ActorMessage> {
     )
     indirect case signalHandlingAsync(
         handleMessage: _Behavior<Message>,
-        handleSignal: @Sendable(_ActorContext<Message>, _Signal) async throws -> _Behavior<Message>
+        handleSignal: @Sendable (_ActorContext<Message>, _Signal) async throws -> _Behavior<Message>
     )
     case same
     case ignore
@@ -526,10 +526,10 @@ public enum IllegalBehaviorError<Message: ActorMessage>: Error {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Intercepting Messages
 
-public extension _Behavior {
+extension _Behavior {
     /// Intercepts all incoming messages and signals, allowing to transform them before they are delivered to the wrapped behavior.
     // TODO: more docs
-    static func intercept(behavior: _Behavior<Message>, with interceptor: _Interceptor<Message>) -> _Behavior<Message> {
+    public static func intercept(behavior: _Behavior<Message>, with interceptor: _Interceptor<Message>) -> _Behavior<Message> {
         _Behavior(underlying: .intercept(behavior: behavior, with: interceptor))
     }
 }
@@ -596,13 +596,13 @@ extension _Interceptor {
 // MARK: _Behavior interpretation
 
 /// Offers the capability to interpret messages and signals
-public extension _Behavior {
+extension _Behavior {
     /// Interpret the passed in message.
     ///
     /// Note: The returned behavior MUST be `_Behavior.canonicalize`-ed in the vast majority of cases.
     // Implementation note: We don't do so here automatically in order to keep interpretations transparent and testable.
     @inlinable
-    func interpretMessage(context: _ActorContext<Message>, message: Message, file: StaticString = #file, line: UInt = #line) throws -> _Behavior<Message> {
+    public func interpretMessage(context: _ActorContext<Message>, message: Message, file: StaticString = #file, line: UInt = #line) throws -> _Behavior<Message> {
         switch self.underlying {
         case .receiveMessage(let recv): return try recv(message)
         case .receiveMessageAsync(let recv): return self.receiveMessageAsync(recv, message)
@@ -649,7 +649,7 @@ public extension _Behavior {
 
     /// Attempts interpreting signal using the current behavior, or returns `_Behavior.unhandled` if no `_Behavior.signalHandling` was found.
     @inlinable
-    func interpretSignal(context: _ActorContext<Message>, signal: _Signal) throws -> _Behavior<Message> {
+    public func interpretSignal(context: _ActorContext<Message>, signal: _Signal) throws -> _Behavior<Message> {
         // This switch does not use a `default:` clause on purpose!
         // This is to enforce having to consider consider how a signal should be interpreted if a new behavior case is added.
         switch self.underlying {
@@ -708,9 +708,9 @@ public extension _Behavior {
 // MARK: Internal tools to work with Behaviors
 
 /// Internal operations for behavior manipulation
-internal extension _Behavior {
+extension _Behavior {
     @inlinable
-    func interpretOrElse(
+    internal func interpretOrElse(
         context: _ActorContext<Message>,
         first: _Behavior<Message>, orElse second: _Behavior<Message>, message: Message,
         file: StaticString = #file, line: UInt = #line
@@ -724,7 +724,7 @@ internal extension _Behavior {
 
     /// Applies `interpretMessage` to an iterator of messages, while canonicalizing the behavior after every reduction.
     @inlinable
-    func interpretMessages<Iterator: IteratorProtocol>(context: _ActorContext<Message>, messages: inout Iterator) throws -> _Behavior<Message> where Iterator.Element == Message {
+    internal func interpretMessages<Iterator: IteratorProtocol>(context: _ActorContext<Message>, messages: inout Iterator) throws -> _Behavior<Message> where Iterator.Element == Message {
         var currentBehavior: _Behavior<Message> = self
         while currentBehavior.isStillAlive {
             if let message = messages.next() {
@@ -741,7 +741,7 @@ internal extension _Behavior {
     /// Validate if a _Behavior is legal to be used as "initial" behavior (when an Actor is spawned),
     /// since certain behaviors do not make sense as initial behavior.
     @inlinable
-    func validateAsInitial() throws {
+    internal func validateAsInitial() throws {
         switch self.underlying {
         case .same: throw IllegalBehaviorError.notAllowedAsInitial(self)
         case .unhandled: throw IllegalBehaviorError.notAllowedAsInitial(self)
@@ -751,12 +751,12 @@ internal extension _Behavior {
 
     /// Same as `validateAsInitial`, however useful in chaining expressions as it returns itself when the validation has passed successfully.
     @inlinable
-    func validatedAsInitial() throws -> _Behavior<Message> {
+    internal func validatedAsInitial() throws -> _Behavior<Message> {
         try self.validateAsInitial()
         return self
     }
 
-    func validateAsInitialFatal(file: String = #file, line: UInt = #line) {
+    internal func validateAsInitialFatal(file: String = #file, line: UInt = #line) {
         switch self.underlying {
         case .same, .unhandled: fatalError("Illegal initial behavior! Attempted to spawn(\(self)) at \(file):\(line)")
         default: return
@@ -765,7 +765,7 @@ internal extension _Behavior {
 
     /// Shorthand for checking if the current behavior is a `.unhandled`
     @inlinable
-    var isUnhandled: Bool {
+    internal var isUnhandled: Bool {
         switch self.underlying {
         case .unhandled: return true
         default: return false
@@ -774,7 +774,7 @@ internal extension _Behavior {
 
     /// Shorthand for checking if the `_Behavior` is `.stop` or `.failed`.
     @inlinable
-    var isTerminal: Bool {
+    internal var isTerminal: Bool {
         switch self.underlying {
         case .stop, .failed: return true
         default: return false
@@ -783,12 +783,12 @@ internal extension _Behavior {
 
     /// Shorthand for checking if the `_Behavior` is NOT `.stop` or `.failed`.
     @inlinable
-    var isStillAlive: Bool {
+    internal var isStillAlive: Bool {
         !self.isTerminal
     }
 
     @inlinable
-    var isSuspend: Bool {
+    internal var isSuspend: Bool {
         switch self.underlying {
         case .suspend: return true
         default: return false
@@ -796,7 +796,7 @@ internal extension _Behavior {
     }
 
     @inlinable
-    var isSuspended: Bool {
+    internal var isSuspended: Bool {
         switch self.underlying {
         case .suspended: return true
         default: return false
@@ -804,7 +804,7 @@ internal extension _Behavior {
     }
 
     @inlinable
-    var isSame: Bool {
+    internal var isSame: Bool {
         switch self.underlying {
         case .same: return true
         default: return false
@@ -812,7 +812,7 @@ internal extension _Behavior {
     }
 
     @inlinable
-    var isSetup: Bool {
+    internal var isSetup: Bool {
         switch self.underlying {
         case .setup: return true
         default: return false
@@ -822,7 +822,7 @@ internal extension _Behavior {
     /// Returns `false` if canonicalizing behavior is known to not create a change in behavior.
     /// For example `.same` or semantically equivalent behaviors.
     @inlinable
-    var isChanging: Bool {
+    internal var isChanging: Bool {
         switch self.underlying {
         case .same, .ignore, .unhandled: return false
         default: return true
@@ -838,7 +838,7 @@ internal extension _Behavior {
     /// - Throws: `IllegalBehaviorError.tooDeeplyNestedBehavior` when a too deeply nested behavior is found,
     ///           in order to avoid attempting to start an possibly infinitely deferred behavior.
     @inlinable
-    func canonicalize(_ context: _ActorContext<Message>, next: _Behavior<Message>) throws -> _Behavior<Message> {
+    internal func canonicalize(_ context: _ActorContext<Message>, next: _Behavior<Message>) throws -> _Behavior<Message> {
         guard self.isStillAlive else {
             return self // ignore, we're already dead and cannot become any other behavior
         }
@@ -911,7 +911,7 @@ internal extension _Behavior {
     ///           in order to avoid attempting to start an possibly infinitely deferred behavior.
     // TODO: make not recursive perhaps since could blow up on large chain?
     @inlinable
-    func start(context: _ActorContext<Message>) throws -> _Behavior<Message> {
+    internal func start(context: _ActorContext<Message>) throws -> _Behavior<Message> {
         let failAtDepth = context.system.settings.actor.maxBehaviorNestingDepth
 
         func start0(_ behavior: _Behavior<Message>, depth: Int) throws -> _Behavior<Message> {
@@ -952,7 +952,7 @@ internal extension _Behavior {
     /// - Parameter predicate: used to check if any behavior in the stack has a specific property
     /// - Returns: `true` if a behavior exists that matches the predicate, `false` otherwise
     @inlinable
-    func existsInStack(_ predicate: (_Behavior<Message>) -> Bool) -> Bool {
+    internal func existsInStack(_ predicate: (_Behavior<Message>) -> Bool) -> Bool {
         if predicate(self) {
             return true
         }

--- a/Sources/DistributedActors/Cluster/Cluster+Event.swift
+++ b/Sources/DistributedActors/Cluster/Cluster+Event.swift
@@ -15,11 +15,11 @@
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Cluster Events
 
-public extension Cluster {
+extension Cluster {
     /// Represents cluster events, most notably regarding membership and reachability of other members of the cluster.
     ///
     /// Inspect them directly, or `apply` to a `Membership` copy in order to be able to react to membership state of the cluster.
-    enum Event: ActorMessage, Equatable {
+    public enum Event: ActorMessage, Equatable {
         case snapshot(Membership)
         case membershipChange(MembershipChange)
         case reachabilityChange(ReachabilityChange)
@@ -29,10 +29,10 @@ public extension Cluster {
 
 // ==== ----------------------------------------------------------------------------------------------------------------
 
-public extension Cluster {
+extension Cluster {
     /// Represents a change made to a `Membership`, it can be received from gossip and shall be applied to local memberships,
     /// or may originate from local decisions (such as joining or downing).
-    struct MembershipChange: Hashable {
+    public struct MembershipChange: Hashable {
         /// Current member that is part of the membership after this change
         public internal(set) var member: Member
 
@@ -119,36 +119,36 @@ public extension Cluster {
     }
 }
 
-public extension Cluster.MembershipChange {
+extension Cluster.MembershipChange {
     /// Is a "replace" operation, meaning a new node with different UID has replaced a previousNode.
     /// This can happen upon a service reboot, with stable network address -- the new node then "replaces" the old one,
     /// and the old node shall be removed from the cluster as a result of this.
-    var isReplacement: Bool {
+    public var isReplacement: Bool {
         self.replaced != nil
     }
 
-    var isJoining: Bool {
+    public var isJoining: Bool {
         self.status.isJoining
     }
 
-    var isUp: Bool {
+    public var isUp: Bool {
         self.status.isUp
     }
 
-    var isDown: Bool {
+    public var isDown: Bool {
         self.status.isDown
     }
 
-    func isAtLeast(_ status: Cluster.MemberStatus) -> Bool {
+    public func isAtLeast(_ status: Cluster.MemberStatus) -> Bool {
         self.status >= status
     }
 
-    var isLeaving: Bool {
+    public var isLeaving: Bool {
         self.status.isLeaving
     }
 
     /// Slight rewording of API, as this is the membership _change_, thus it is a "removal", while the `toStatus` is "removed"
-    var isRemoval: Bool {
+    public var isRemoval: Bool {
         self.status.isRemoved
     }
 }
@@ -171,9 +171,9 @@ extension Cluster.MembershipChange: CustomStringConvertible {
 
 // ==== ----------------------------------------------------------------------------------------------------------------
 
-public extension Cluster {
+extension Cluster {
     /// Emitted when the reachability of a member changes, as determined by a failure detector (e.g. `SWIM`).
-    struct ReachabilityChange: Equatable {
+    public struct ReachabilityChange: Equatable {
         public let member: Cluster.Member
 
         public init(member: Member) {
@@ -199,9 +199,9 @@ public extension Cluster {
 
 // ==== ----------------------------------------------------------------------------------------------------------------
 
-public extension Cluster {
+extension Cluster {
     /// Emitted when a change in leader is decided.
-    struct LeadershipChange: Hashable {
+    public struct LeadershipChange: Hashable {
         // let role: Role if this leader was of a specific role, carry the info here? same for DC?
         public let oldLeader: Cluster.Member?
         public let newLeader: Cluster.Member?

--- a/Sources/DistributedActors/Cluster/Cluster+Member.swift
+++ b/Sources/DistributedActors/Cluster/Cluster+Member.swift
@@ -15,12 +15,12 @@
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Cluster Member
 
-public extension Cluster {
+extension Cluster {
     /// A `Member` is a node that is participating in a clustered system.
     ///
     /// It carries `Cluster.MemberStatus` and reachability information.
     /// Its identity is the underlying `UniqueNode`, other fields are not taken into account when comparing members.
-    struct Member: Hashable {
+    public struct Member: Hashable {
         /// Unique node of this cluster member.
         public let uniqueNode: UniqueNode
 
@@ -123,7 +123,7 @@ extension Cluster.Member: Equatable {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Cluster.Member Ordering
 
-public extension Cluster.Member {
+extension Cluster.Member {
     /// Orders nodes by their `.upNumber` which is assigned by the leader when moving a node from joining to up.
     /// This ordering is useful to find the youngest or "oldest" node.
     ///
@@ -131,13 +131,13 @@ public extension Cluster.Member {
     /// few core nodes which become "old" and tons of ad-hoc spun up nodes which are always "young" as they are spawned
     /// and stopped on demand. Putting certain types of workloads onto "old(est)" nodes in such clusters has the benefit
     /// of most likely not needing to balance/move work off them too often (in face of many ad-hoc worker spawns).
-    static let ageOrdering: (Cluster.Member, Cluster.Member) -> Bool = { l, r in
+    public static let ageOrdering: (Cluster.Member, Cluster.Member) -> Bool = { l, r in
         (l._upNumber ?? 0) < (r._upNumber ?? 0)
     }
 
     /// An ordering by the members' `node` properties, e.g. 1.1.1.1 is "lower" than 2.2.2.2.
     /// This ordering somewhat unusual, however always consistent and used to select a leader -- see `LowestReachableMember`.
-    static let lowestAddressOrdering: (Cluster.Member, Cluster.Member) -> Bool = { l, r in
+    public static let lowestAddressOrdering: (Cluster.Member, Cluster.Member) -> Bool = { l, r in
         l.uniqueNode < r.uniqueNode
     }
 }
@@ -159,9 +159,9 @@ extension Cluster.Member: Codable {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Cluster.MemberStatus
 
-public extension Cluster {
+extension Cluster {
     /// Describes the status of a member within the clusters lifecycle.
-    enum MemberStatus: String, CaseIterable, Comparable {
+    public enum MemberStatus: String, CaseIterable, Comparable {
         /// Describes a node which is connected to at least one other member in the cluster,
         /// it may want to serve some traffic, however should await the leader moving it to .up
         /// before it takes on serious work.
@@ -213,33 +213,33 @@ public extension Cluster {
     }
 }
 
-public extension Cluster.MemberStatus {
+extension Cluster.MemberStatus {
     /// Convenience function to check if a status is `.joining`
-    var isJoining: Bool {
+    public var isJoining: Bool {
         self == .joining
     }
 
     /// Convenience function to check if a status is `.up`
-    var isUp: Bool {
+    public var isUp: Bool {
         self == .up
     }
 
     /// Convenience function to check if a status is `.leaving`
-    var isLeaving: Bool {
+    public var isLeaving: Bool {
         self == .leaving
     }
 
     /// Convenience function to check if a status is `.down`
-    var isDown: Bool {
+    public var isDown: Bool {
         self == .down
     }
 
-    func isAtLeast(_ status: Cluster.MemberStatus) -> Bool {
+    public func isAtLeast(_ status: Cluster.MemberStatus) -> Bool {
         self >= status
     }
 
     /// Convenience function to check if a status is `.removed`
-    var isRemoved: Bool {
+    public var isRemoved: Bool {
         self == .removed
     }
 }
@@ -251,12 +251,12 @@ extension Cluster.MemberStatus: Codable {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Cluster.MemberStatus Ordering
 
-public extension Cluster.MemberStatus {
-    static let lifecycleOrdering: (Cluster.Member, Cluster.Member) -> Bool = { $0.status < $1.status }
+extension Cluster.MemberStatus {
+    public static let lifecycleOrdering: (Cluster.Member, Cluster.Member) -> Bool = { $0.status < $1.status }
 }
 
-public extension Cluster.MemberStatus {
-    static func < (lhs: Cluster.MemberStatus, rhs: Cluster.MemberStatus) -> Bool {
+extension Cluster.MemberStatus {
+    public static func < (lhs: Cluster.MemberStatus, rhs: Cluster.MemberStatus) -> Bool {
         switch lhs {
         case .joining:
             return rhs != .joining
@@ -275,7 +275,7 @@ public extension Cluster.MemberStatus {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Cluster.MemberReachability
 
-public extension Cluster {
+extension Cluster {
     /// Reachability indicates a failure detectors assessment of the member node's reachability,
     /// i.e. whether or not the node is responding to health check messages.
     ///
@@ -283,7 +283,7 @@ public extension Cluster {
     /// and `.unreachable` states multiple times during the lifetime of a member.
     ///
     /// - SeeAlso: `SWIM` for a distributed failure detector implementation which may issue unreachable events.
-    enum MemberReachability: String, Equatable {
+    public enum MemberReachability: String, Equatable {
         /// The member is reachable and responding to failure detector probing properly.
         case reachable
         /// Failure detector has determined this node as not reachable.
@@ -292,12 +292,12 @@ public extension Cluster {
     }
 }
 
-public extension Cluster.MemberReachability {
-    var isReachable: Bool {
+extension Cluster.MemberReachability {
+    public var isReachable: Bool {
         self == .reachable
     }
 
-    var isUnreachable: Bool {
+    public var isUnreachable: Bool {
         self == .unreachable
     }
 }

--- a/Sources/DistributedActors/Cluster/Cluster+Membership.swift
+++ b/Sources/DistributedActors/Cluster/Cluster+Membership.swift
@@ -17,7 +17,7 @@ import Foundation
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Cluster Membership
 
-public extension Cluster {
+extension Cluster {
     /// `Membership` represents the set of members of this cluster.
     ///
     /// Membership changes are driven by nodes joining and leaving the cluster.
@@ -32,7 +32,7 @@ public extension Cluster {
     ///
     /// ### Member state transitions
     /// Members can only move "forward" along their status lifecycle, refer to `Cluster.MemberStatus` docs for a diagram of legal transitions.
-    struct Membership: ExpressibleByArrayLiteral {
+    public struct Membership: ExpressibleByArrayLiteral {
         public typealias ArrayLiteralElement = Cluster.Member
 
         public static var empty: Cluster.Membership {
@@ -239,9 +239,10 @@ extension Cluster.Membership: Hashable {
         }
         for (lNode, lMember) in lhs._members {
             if let rMember = rhs._members[lNode],
-                lMember.uniqueNode != rMember.uniqueNode ||
-                lMember.status != rMember.status ||
-                lMember.reachability != rMember.reachability {
+               lMember.uniqueNode != rMember.uniqueNode ||
+               lMember.status != rMember.status ||
+               lMember.reachability != rMember.reachability
+            {
                 return false
             }
         }
@@ -276,14 +277,14 @@ extension Cluster.Membership: Codable {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Cluster.Membership operations, such as joining, leaving, removing
 
-public extension Cluster.Membership {
+extension Cluster.Membership {
     /// Interpret and apply passed in membership change as the appropriate join/leave/down action.
     ///
     /// Applying a new node status that becomes a "replacement" of an existing member, returns a `Cluster.MembershipChange` that is a "replacement".
     ///
     /// - Returns: the resulting change that was applied to the membership; note that this may be `nil`,
     ///   if the change did not cause any actual change to the membership state (e.g. signaling a join of the same node twice).
-    mutating func applyMembershipChange(_ change: Cluster.MembershipChange) -> Cluster.MembershipChange? {
+    public mutating func applyMembershipChange(_ change: Cluster.MembershipChange) -> Cluster.MembershipChange? {
         if case .removed = change.status {
             return self.removeCompletely(change.node)
         }
@@ -323,7 +324,7 @@ public extension Cluster.Membership {
     /// this function will return `nil`. It is guaranteed that if a non-nil value is returned, the old leader is different from the new leader.
     ///
     /// - Throws: `Cluster.MembershipError` when attempt is made to mark a non-member as leader. First add the leader as member, then promote it.
-    mutating func applyLeadershipChange(to leader: Cluster.Member?) throws -> Cluster.LeadershipChange? {
+    public mutating func applyLeadershipChange(to leader: Cluster.Member?) throws -> Cluster.LeadershipChange? {
         guard let wannabeLeader = leader else {
             if let oldLeader = self.leader {
                 // no more leader
@@ -356,25 +357,25 @@ public extension Cluster.Membership {
     }
 
     /// Alias for `applyLeadershipChange(to:)`
-    mutating func applyLeadershipChange(_ change: Cluster.LeadershipChange?) throws -> Cluster.LeadershipChange? {
+    public mutating func applyLeadershipChange(_ change: Cluster.LeadershipChange?) throws -> Cluster.LeadershipChange? {
         try self.applyLeadershipChange(to: change?.newLeader)
     }
 
     /// - Returns: the changed member if the change was a transition (unreachable -> reachable, or back),
     ///            or `nil` if the reachability is the same as already known by the membership.
-    mutating func applyReachabilityChange(_ change: Cluster.ReachabilityChange) -> Cluster.Member? {
+    public mutating func applyReachabilityChange(_ change: Cluster.ReachabilityChange) -> Cluster.Member? {
         self.mark(change.member.uniqueNode, reachability: change.member.reachability)
     }
 
     /// Returns the change; e.g. if we replaced a node the change `from` will be populated and perhaps a connection should
     /// be closed to that now-replaced node, since we have replaced it with a new node.
-    mutating func join(_ node: UniqueNode) -> Cluster.MembershipChange? {
+    public mutating func join(_ node: UniqueNode) -> Cluster.MembershipChange? {
         var change = Cluster.MembershipChange(member: Cluster.Member(node: node, status: .joining))
         change.previousStatus = nil
         return self.applyMembershipChange(change)
     }
 
-    func joining(_ node: UniqueNode) -> Cluster.Membership {
+    public func joining(_ node: UniqueNode) -> Cluster.Membership {
         var membership = self
         _ = membership.join(node)
         return membership
@@ -385,7 +386,7 @@ public extension Cluster.Membership {
     /// Handles replacement nodes properly, by emitting a "replacement" change, and marking the replaced node as `MemberStatus.down`.
     ///
     /// If the membership not aware of this address the update is treated as a no-op.
-    mutating func mark(_ node: UniqueNode, as status: Cluster.MemberStatus) -> Cluster.MembershipChange? {
+    public mutating func mark(_ node: UniqueNode, as status: Cluster.MemberStatus) -> Cluster.MembershipChange? {
         if let existingExactMember = self.uniqueMember(node) {
             guard existingExactMember.status < status else {
                 // this would be a "move backwards" which we do not do; membership only moves forward
@@ -424,7 +425,7 @@ public extension Cluster.Membership {
     /// Returns new membership while marking an existing member with the specified status.
     ///
     /// If the membership not aware of this node the update is treated as a no-op.
-    func marking(_ node: UniqueNode, as status: Cluster.MemberStatus) -> Cluster.Membership {
+    public func marking(_ node: UniqueNode, as status: Cluster.MemberStatus) -> Cluster.Membership {
         var membership = self
         _ = membership.mark(node, as: status)
         return membership
@@ -433,7 +434,7 @@ public extension Cluster.Membership {
     /// Mark node with passed in `reachability`
     ///
     /// - Returns: the changed member if the reachability was different than the previously stored one.
-    mutating func mark(_ node: UniqueNode, reachability: Cluster.MemberReachability) -> Cluster.Member? {
+    public mutating func mark(_ node: UniqueNode, reachability: Cluster.MemberReachability) -> Cluster.Member? {
         guard var member = self._members.removeValue(forKey: node) else {
             // no such member
             return nil
@@ -456,7 +457,7 @@ public extension Cluster.Membership {
     ///
     /// - Warning: When removing nodes from cluster one MUST also prune the seen tables (!) of the gossip.
     ///            Rather than calling this function directly, invoke `Cluster.Gossip.removeMember()` which performs all needed cleanups.
-    mutating func removeCompletely(_ node: UniqueNode) -> Cluster.MembershipChange? {
+    public mutating func removeCompletely(_ node: UniqueNode) -> Cluster.MembershipChange? {
         if let member = self._members[node] {
             self._members.removeValue(forKey: node)
             return .init(member: member, toStatus: .removed)
@@ -466,14 +467,14 @@ public extension Cluster.Membership {
     }
 
     /// Returns new membership while removing an existing member, identified by the passed in node.
-    func removingCompletely(_ node: UniqueNode) -> Cluster.Membership {
+    public func removingCompletely(_ node: UniqueNode) -> Cluster.Membership {
         var membership = self
         _ = membership.removeCompletely(node)
         return membership
     }
 }
 
-public extension Cluster.Membership {
+extension Cluster.Membership {
     /// Special merge function that only moves members "forward" however never removes them, as removal MUST ONLY be
     /// issued specifically by a leader working on the assumption that the `incoming` Membership is KNOWN to be "ahead",
     /// and e.g. if any nodes are NOT present in the incoming membership, they shall be considered `.removed`.
@@ -501,7 +502,7 @@ public extension Cluster.Membership {
     /// Warning: Leaders are not "merged", they get elected by each node (!).
     ///
     /// - Returns: any membership changes that occurred (and have affected the current membership).
-    mutating func mergeFrom(incoming: Cluster.Membership, myself: UniqueNode?) -> [Cluster.MembershipChange] {
+    public mutating func mergeFrom(incoming: Cluster.Membership, myself: UniqueNode?) -> [Cluster.MembershipChange] {
         var changes: [Cluster.MembershipChange] = []
 
         // Set of nodes whose members are currently .down, and not present in the incoming gossip.
@@ -572,14 +573,14 @@ public extension Cluster.Membership {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Applying Cluster.Event to Membership
 
-public extension Cluster.Membership {
+extension Cluster.Membership {
     /// Applies any kind of `Cluster.Event` to the `Membership`, modifying it appropriately.
     /// This apply does not yield detailed information back about the type of change performed,
     /// and is useful as a catch-all to keep a `Membership` copy up-to-date, but without reacting on any specific transition.
     ///
     /// - SeeAlso: `apply(_:)`, `applyLeadershipChange(to:)`, `applyReachabilityChange(_:)` to receive specific diffs reporting about the effect
     /// a change had on the membership.
-    mutating func apply(event: Cluster.Event) throws {
+    public mutating func apply(event: Cluster.Event) throws {
         switch event {
         case .snapshot(let snapshot):
             self = snapshot
@@ -650,8 +651,8 @@ extension MembershipDiff: CustomDebugStringConvertible {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Errors
 
-public extension Cluster {
-    enum MembershipError: Error {
+extension Cluster {
+    public enum MembershipError: Error {
         case nonMemberLeaderSelected(Cluster.Membership, wannabeLeader: Cluster.Member)
     }
 }

--- a/Sources/DistributedActors/Cluster/ClusterShell.swift
+++ b/Sources/DistributedActors/Cluster/ClusterShell.swift
@@ -1084,7 +1084,8 @@ extension ClusterShell {
         // on the other connection; and the terminated one may yield an error (e.g. truncation error during proto parsing etc),
         // however that error is harmless - as we associated with the "other" right connection.
         if let existingAssociation = self.getSpecificExistingAssociation(with: reject.targetNode),
-            existingAssociation.isAssociating {
+           existingAssociation.isAssociating
+        {
             state.log.warning(
                 "Handshake rejected by [\(reject.targetNode)], it was associating and is now tombstoned",
                 metadata: state.metadataForHandshakes(uniqueNode: reject.targetNode, error: nil)
@@ -1094,7 +1095,8 @@ extension ClusterShell {
         }
 
         if let existingAssociation = self.getAnyExistingAssociation(with: reject.targetNode.node),
-            existingAssociation.isAssociated || existingAssociation.isTombstone {
+           existingAssociation.isAssociated || existingAssociation.isTombstone
+        {
             state.log.debug(
                 "Handshake rejected by [\(reject.targetNode)], however existing association with node exists. Could be that a concurrent handshake was failed on purpose.",
                 metadata: state.metadataForHandshakes(uniqueNode: reject.targetNode, error: nil)
@@ -1117,7 +1119,8 @@ extension ClusterShell {
         // on the other connection; and the terminated one may yield an error (e.g. truncation error during proto parsing etc),
         // however that error is harmless - as we associated with the "other" right connection.
         if let existingAssociation = self.getAnyExistingAssociation(with: node),
-            existingAssociation.isAssociated || existingAssociation.isTombstone {
+           existingAssociation.isAssociated || existingAssociation.isTombstone
+        {
             state.log.debug(
                 "Handshake failed, however existing association with node exists. Could be that a concurrent handshake was failed on purpose.",
                 metadata: state.metadataForHandshakes(node: node, error: error)
@@ -1194,8 +1197,8 @@ extension ClusterShell {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Shutdown
 
-private extension ClusterShell {
-    func onShutdownCommand(_ context: _ActorContext<Message>, state: ClusterShellState, signalOnceUnbound: BlockingReceptacle<Void>) -> _Behavior<Message> {
+extension ClusterShell {
+    private func onShutdownCommand(_ context: _ActorContext<Message>, state: ClusterShellState, signalOnceUnbound: BlockingReceptacle<Void>) -> _Behavior<Message> {
         // we exit the death-pact with any children we spawned, even if they fail now, we don't mind because we're shutting down
         context.children.forEach { ref in
             context.unwatch(ref)

--- a/Sources/DistributedActors/Cluster/Leadership.swift
+++ b/Sources/DistributedActors/Cluster/Leadership.swift
@@ -177,7 +177,7 @@ extension Leadership {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: LowestAddressReachableMember election strategy
 
-public extension Leadership {
+extension Leadership {
     /// Simple strategy which does not require any additional coordination from members to select a leader.
     ///
     /// All `MemberStatus.joining`, `MemberStatus.up` _reachable_ members are sorted by their addresses,
@@ -221,7 +221,7 @@ public extension Leadership {
     ///
     // TODO: In situations which need strong guarantees, this leadership election scheme does NOT provide strong enough
     /// guarantees, and you should consider using another scheme or consensus based modes.
-    struct LowestReachableMember: LeaderElection {
+    public struct LowestReachableMember: LeaderElection {
         let minimumNumberOfMembersToDecide: Int
         let loseLeadershipIfBelowMinNrOfMembers: Bool
 
@@ -313,8 +313,8 @@ public extension Leadership {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Leadership settings
 
-public extension ClusterSystemSettings {
-    enum LeadershipSelectionSettings {
+extension ClusterSystemSettings {
+    public enum LeadershipSelectionSettings {
         /// No automatic leader selection, you can write your own logic and issue a `Cluster.LeadershipChange` `Cluster.Event` to the `system.cluster.events` event stream.
         case none
         /// All nodes get ordered by their node addresses and the "lowest" is always selected as a leader.

--- a/Sources/DistributedActors/Cluster/MembershipGossip/Cluster+MembershipGossip.swift
+++ b/Sources/DistributedActors/Cluster/MembershipGossip/Cluster+MembershipGossip.swift
@@ -83,7 +83,8 @@ extension Cluster {
             // 1.2) Protect from zombies: Any nodes that we know are dead or down, we should not accept any information from
             let incomingConcurrentDownMembers = incoming.membership.members(atLeast: .down)
             for pruneFromIncomingBeforeMerge in incomingConcurrentDownMembers
-                where self.membership.uniqueMember(pruneFromIncomingBeforeMerge.uniqueNode) == nil {
+                where self.membership.uniqueMember(pruneFromIncomingBeforeMerge.uniqueNode) == nil
+            {
                 _ = incoming.pruneMember(pruneFromIncomingBeforeMerge)
             }
 
@@ -104,7 +105,8 @@ extension Cluster {
 
             // 3) if any removals happened, we need to prune the removed nodes from the seen table
             for change in changes
-                where change.status.isRemoved && change.member.uniqueNode != self.owner {
+                where change.status.isRemoved && change.member.uniqueNode != self.owner
+            {
                 self.seen.prune(change.member.uniqueNode)
             }
 

--- a/Sources/DistributedActors/Cluster/NodeDeathWatcher.swift
+++ b/Sources/DistributedActors/Cluster/NodeDeathWatcher.swift
@@ -43,7 +43,7 @@ internal final class NodeDeathWatcherInstance: NodeDeathWatcher {
     struct WatcherAndCallback: Hashable {
         /// Address of the local watcher which had issued this watch
         let watcherID: ClusterSystem.ActorID
-        let callback: @Sendable(UniqueNode) async -> Void
+        let callback: @Sendable (UniqueNode) async -> Void
 
         func hash(into hasher: inout Hasher) {
             hasher.combine(self.watcherID)
@@ -89,7 +89,7 @@ internal final class NodeDeathWatcherInstance: NodeDeathWatcher {
     func onActorWatched(
         on remoteNode: UniqueNode,
         by watcher: ClusterSystem.ActorID,
-        whenTerminated nodeTerminatedFn: @escaping @Sendable(UniqueNode) async -> Void
+        whenTerminated nodeTerminatedFn: @escaping @Sendable (UniqueNode) async -> Void
     ) {
         guard !self.nodeTombstones.contains(remoteNode) else {
             // the system the watcher is attempting to watch has terminated before the watch has been processed,
@@ -173,7 +173,7 @@ enum NodeDeathWatcherShell {
     /// it would be possible however to allow implementing the raw protocol by user actors if we ever see the need for it.
     internal enum Message: NonTransportableActorMessage {
         case remoteActorWatched(watcher: AddressableActorRef, remoteNode: UniqueNode)
-        case remoteDistributedActorWatched(remoteNode: UniqueNode, watcherID: ClusterSystem.ActorID, nodeTerminated: @Sendable(UniqueNode) async -> Void)
+        case remoteDistributedActorWatched(remoteNode: UniqueNode, watcherID: ClusterSystem.ActorID, nodeTerminated: @Sendable (UniqueNode) async -> Void)
         case removeWatcher(watcherID: ClusterSystem.ActorID)
         case membershipSnapshot(Cluster.Membership)
         case membershipChange(Cluster.MembershipChange)

--- a/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
+++ b/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
@@ -346,7 +346,8 @@ extension OpLogDistributedReceptionist: LifecycleWatch {
     public nonisolated func subscribe<Guest>(
         to key: DistributedReception.Key<Guest>
     ) async -> DistributedReception.GuestListing<Guest>
-        where Guest: DistributedActor, Guest.ActorSystem == ClusterSystem {
+        where Guest: DistributedActor, Guest.ActorSystem == ClusterSystem
+    {
         let res = await self.whenLocal { _ in
             DistributedReception.GuestListing<Guest>(receptionist: self, key: key)
         }
@@ -379,14 +380,16 @@ extension OpLogDistributedReceptionist: LifecycleWatch {
     }
 
     public nonisolated func lookup<Guest>(_ key: DistributedReception.Key<Guest>) async -> Set<Guest>
-        where Guest: DistributedActor, Guest.ActorSystem == ClusterSystem {
+        where Guest: DistributedActor, Guest.ActorSystem == ClusterSystem
+    {
         await self.whenLocal { __secretlyKnownToBeLocal in
             await __secretlyKnownToBeLocal._lookup(key)
         } ?? []
     }
 
     private func _lookup<Guest>(_ key: DistributedReception.Key<Guest>) async -> Set<Guest>
-        where Guest: DistributedActor, Guest.ActorSystem == ClusterSystem {
+        where Guest: DistributedActor, Guest.ActorSystem == ClusterSystem
+    {
         let registrations = self.storage.registrations(forKey: key.asAnyKey) ?? []
 
         // self.instrumentation.listingPublished(key: message._key, subscribers: 1, registrations: registrations.count) // TODO(distributed): make the instrumentation calls compatible with distributed actor based types
@@ -513,7 +516,8 @@ extension OpLogDistributedReceptionist {
         // we will do so below in any case, regardless if we are behind or not; See (4) for ACKing the peer
         for replica in push.observedSeqNrs.replicaIDs
             where replica != peerReplicaId && replica != myselfReplicaID &&
-            self.observedSequenceNrs[replica] < push.observedSeqNrs[replica] {
+            self.observedSequenceNrs[replica] < push.observedSeqNrs[replica]
+        {
             switch replica.storage {
             case .actorAddress(let id):
                 self.sendAckOps(receptionistID: id)
@@ -687,7 +691,8 @@ extension OpLogDistributedReceptionist {
             /// - if we are NOT in the middle of receiving ops, we share our observed versions and ack as means of spreading information about the seen SeqNrs
             ///   - this may cause the other peer to pull (ack) from any other peer receptionist, if it notices it is "behind" with regards to any of them. // FIXME: what if a peer notices "twice" so we also need to prevent a timer from resending that ack?
             if let periodicAckAllowedAgainDeadline = self.nextPeriodicAckPermittedDeadline[peer.id],
-                periodicAckAllowedAgainDeadline.hasTimeLeft() {
+               periodicAckAllowedAgainDeadline.hasTimeLeft()
+            {
                 // we still cannot send acks to this peer, it is in the middle of a message exchange with us already
                 continue
             }
@@ -963,7 +968,7 @@ extension OpLogDistributedReceptionist {
             super.init()
         }
 
-        public override func encode(to encoder: Encoder) throws {
+        override public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(self.peer, forKey: .peer)
             try container.encode(self.observedSeqNrs, forKey: .observedSeqNrs)
@@ -1012,7 +1017,7 @@ extension OpLogDistributedReceptionist {
             super.init()
         }
 
-        public override func encode(to encoder: Encoder) throws {
+        override public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(self.until, forKey: .until)
             try container.encode(self.otherObservedSeqNrs, forKey: .otherObservedSeqNrs)

--- a/Sources/DistributedActors/Cluster/Reception/_OperationLogClusterReceptionistBehavior.swift
+++ b/Sources/DistributedActors/Cluster/Reception/_OperationLogClusterReceptionistBehavior.swift
@@ -323,7 +323,8 @@ extension _OperationLogClusterReceptionist {
         // we will do so below in any case, regardless if we are behind or not; See (4) for ACKing the peer
         for replica in push.observedSeqNrs.replicaIDs
             where replica != peerReplicaId && replica != myselfReplicaID &&
-            self.observedSequenceNrs[replica] < push.observedSeqNrs[replica] {
+            self.observedSequenceNrs[replica] < push.observedSeqNrs[replica]
+        {
             switch replica.storage {
             case .actorAddress(let address):
                 self.sendAckOps(context, receptionistAddress: address)
@@ -460,7 +461,8 @@ extension _OperationLogClusterReceptionist {
             /// - if we are NOT in the middle of receiving ops, we share our observed versions and ack as means of spreading information about the seen SeqNrs
             ///   - this may cause the other peer to pull (ack) from any other peer receptionist, if it notices it is "behind" with regards to any of them. // FIXME: what if a peer notices "twice" so we also need to prevent a timer from resending that ack?
             if let periodicAckAllowedAgainDeadline = self.nextPeriodicAckPermittedDeadline[peer],
-                periodicAckAllowedAgainDeadline.hasTimeLeft() {
+               periodicAckAllowedAgainDeadline.hasTimeLeft()
+            {
                 // we still cannot send acks to this peer, it is in the middle of a message exchange with us already
                 continue
             }
@@ -714,7 +716,7 @@ extension _OperationLogClusterReceptionist {
             super.init()
         }
 
-        public override func encode(to encoder: Encoder) throws {
+        override public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(self.peer, forKey: .peer)
             try container.encode(self.observedSeqNrs, forKey: .observedSeqNrs)
@@ -763,7 +765,7 @@ extension _OperationLogClusterReceptionist {
             super.init()
         }
 
-        public override func encode(to encoder: Encoder) throws {
+        override public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(self.until, forKey: .until)
             try container.encode(self.otherObservedSeqNrs, forKey: .otherObservedSeqNrs)

--- a/Sources/DistributedActors/Cluster/SWIM/SWIM+Messages.swift
+++ b/Sources/DistributedActors/Cluster/SWIM/SWIM+Messages.swift
@@ -15,14 +15,14 @@
 import ClusterMembership
 import SWIM
 
-public extension SWIM {
-    enum Message: ActorMessage {
+extension SWIM {
+    public enum Message: ActorMessage {
         case remote(SWIM.RemoteMessage)
         case local(SWIM.LocalMessage)
         case _testing(SWIM._TestingMessage)
     }
 
-    enum RemoteMessage: ActorMessage {
+    public enum RemoteMessage: ActorMessage {
         case ping(pingOrigin: SWIM.PingOriginRef, payload: SWIM.GossipPayload, sequenceNumber: SWIM.SequenceNumber)
 
         /// "Ping Request" requests a SWIM probe.
@@ -31,7 +31,7 @@ public extension SWIM {
         case pingResponse(SWIM.PingResponse)
     }
 
-    enum LocalMessage: NonTransportableActorMessage {
+    public enum LocalMessage: NonTransportableActorMessage {
         /// Periodic message used to wake up SWIM and perform a random ping probe among its members.
         case protocolPeriodTick
 
@@ -75,7 +75,7 @@ public extension SWIM {
         case confirmDead(UniqueNode)
     }
 
-    enum _TestingMessage: NonTransportableActorMessage {
+    public enum _TestingMessage: NonTransportableActorMessage {
         /// FOR TESTING: Expose the entire membership state
         case _getMembershipState(replyTo: _ActorRef<[SWIM.Member]>)
     }

--- a/Sources/DistributedActors/Cluster/SWIM/SWIMPeer+Actor.swift
+++ b/Sources/DistributedActors/Cluster/SWIM/SWIMPeer+Actor.swift
@@ -18,12 +18,12 @@ import struct Dispatch.DispatchTime
 import enum Dispatch.DispatchTimeInterval
 import SWIM
 
-public extension SWIM {
-    typealias PeerRef = _ActorRef<SWIM.Message>
+extension SWIM {
+    public typealias PeerRef = _ActorRef<SWIM.Message>
 
-    typealias Ref = _ActorRef<SWIM.Message>
-    typealias PingOriginRef = _ActorRef<SWIM.Message> // same type, but actually an `ask` actor
-    typealias PingRequestOriginRef = _ActorRef<SWIM.Message> // same type, but actually an `ask` actor
+    public typealias Ref = _ActorRef<SWIM.Message>
+    public typealias PingOriginRef = _ActorRef<SWIM.Message> // same type, but actually an `ask` actor
+    public typealias PingRequestOriginRef = _ActorRef<SWIM.Message> // same type, but actually an `ask` actor
 
     internal typealias Shell = SWIMActorShell
 }
@@ -41,8 +41,8 @@ extension _ActorRef: SWIMAddressablePeer where Message: _AnySWIMMessage {
     }
 }
 
-public extension SWIMPeer {
-    func ping(
+extension SWIMPeer {
+    public func ping(
         payload: SWIM.GossipPayload,
         timeout: DispatchTimeInterval,
         sequenceNumber: SWIM.SequenceNumber,
@@ -82,7 +82,7 @@ public extension SWIMPeer {
         }
     }
 
-    func pingRequest(
+    public func pingRequest(
         target: SWIMPeer,
         payload: SWIM.GossipPayload,
         timeout: DispatchTimeInterval,

--- a/Sources/DistributedActors/Cluster/Transport/TransportPipelines.swift
+++ b/Sources/DistributedActors/Cluster/Transport/TransportPipelines.swift
@@ -827,11 +827,11 @@ extension ClusterShell {
     }
 }
 
-internal extension EventLoop {
+extension EventLoop {
     /// Traverses over a collection and applies the given closure to all elements, while maintaining sequential execution order,
     /// i.e. each element will only be processed once the future returned from the previous call is completed. A failed future
     /// will cause the processing to end and the returned future will be failed.
-    func traverseIgnore<T>(over elements: [T], _ closure: @escaping (T) -> EventLoopFuture<Void>) -> EventLoopFuture<Void> {
+    internal func traverseIgnore<T>(over elements: [T], _ closure: @escaping (T) -> EventLoopFuture<Void>) -> EventLoopFuture<Void> {
         guard let first = elements.first else {
             return self.makeSucceededFuture(())
         }

--- a/Sources/DistributedActors/ClusterSystem.swift
+++ b/Sources/DistributedActors/ClusterSystem.swift
@@ -515,7 +515,8 @@ extension ClusterSystem: _ActorRefFactory {
     public func _spawnSystemActor<Message>(
         _ naming: ActorNaming, _ behavior: _Behavior<Message>, props: _Props = _Props()
     ) throws -> _ActorRef<Message>
-        where Message: ActorMessage {
+        where Message: ActorMessage
+    {
         try self.serialization._ensureSerializer(Message.self)
         return try self._spawn(using: self.systemProvider, behavior, name: naming, props: props)
     }
@@ -533,7 +534,8 @@ extension ClusterSystem: _ActorRefFactory {
     internal func _prepareSystemActor<Message>(
         _ naming: ActorNaming, _ behavior: _Behavior<Message>, props: _Props = _Props()
     ) throws -> LazyStart<Message>
-        where Message: ActorMessage {
+        where Message: ActorMessage
+    {
         // try self._serialization._ensureSerializer(Message.self)
         let ref = try self._spawn(using: self.systemProvider, behavior, name: naming, props: props, startImmediately: false)
         return LazyStart(ref: ref)
@@ -545,7 +547,8 @@ extension ClusterSystem: _ActorRefFactory {
         _ behavior: _Behavior<Message>, name naming: ActorNaming, props: _Props = _Props(),
         startImmediately: Bool = true
     ) throws -> _ActorRef<Message>
-        where Message: ActorMessage {
+        where Message: ActorMessage
+    {
         try behavior.validateAsInitial()
 
         let incarnation: ActorIncarnation = props._wellKnown ? .wellKnown : .random()
@@ -588,7 +591,8 @@ extension ClusterSystem: _ActorRefFactory {
         _ behavior: _Behavior<Message>, address: ActorAddress, props: _Props = _Props(),
         startImmediately: Bool = true
     ) throws -> _ActorRef<Message>
-        where Message: ActorMessage {
+        where Message: ActorMessage
+    {
         try behavior.validateAsInitial()
 
         let dispatcher: MessageDispatcher
@@ -774,10 +778,11 @@ extension ClusterSystem: _ActorTreeTraversable {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Actor Lifecycle
 
-public extension ClusterSystem {
+extension ClusterSystem {
     /// Allows creating a distributed actor with additional configuration applied during its initialization.
     internal func actorWith<Act: DistributedActor>(props: _Props? = nil,
-                                                   _ makeActor: () throws -> Act) rethrows -> Act {
+                                                   _ makeActor: () throws -> Act) rethrows -> Act
+    {
         guard let props = props else {
             return try makeActor()
         }
@@ -789,7 +794,8 @@ public extension ClusterSystem {
 
     /// Allows creating a distributed actor with additional configuration applied during its initialization.
     internal func actorWith<Act: DistributedActor>(_ tags: (any ActorTag)...,
-                                                   makeActor: () throws -> Act) rethrows -> Act {
+                                                   makeActor: () throws -> Act) rethrows -> Act
+    {
         var props = _Props.forSpawn
         props.tags = .init(tags: tags)
 
@@ -799,9 +805,10 @@ public extension ClusterSystem {
     }
 }
 
-public extension ClusterSystem {
-    func resolve<Act>(id address: ActorID, as actorType: Act.Type) throws -> Act?
-        where Act: DistributedActor {
+extension ClusterSystem {
+    public func resolve<Act>(id address: ActorID, as actorType: Act.Type) throws -> Act?
+        where Act: DistributedActor
+    {
         self.log.info("RESOLVE: \(address)")
         guard self.cluster.uniqueNode == address.uniqueNode else {
             self.log.info("Resolved \(address) as remote, on node: \(address.uniqueNode)")
@@ -831,8 +838,9 @@ public extension ClusterSystem {
         }
     }
 
-    func assignID<Act>(_ actorType: Act.Type) -> ClusterSystem.ActorID
-        where Act: DistributedActor {
+    public func assignID<Act>(_ actorType: Act.Type) -> ClusterSystem.ActorID
+        where Act: DistributedActor
+    {
         let props = _Props.forSpawn // task-local read for any properties this actor should have
         let address = try! self._reserveName(type: Act.self, props: props)
 
@@ -848,7 +856,7 @@ public extension ClusterSystem {
         }
     }
 
-    func actorReady<Act>(_ actor: Act) where Act: DistributedActor, Act.ID == ActorID {
+    public func actorReady<Act>(_ actor: Act) where Act: DistributedActor, Act.ID == ActorID {
         self.log.trace("Actor ready", metadata: [
             "actor/id": "\(actor.id)",
             "actor/type": "\(type(of: actor))",
@@ -872,7 +880,7 @@ public extension ClusterSystem {
     }
 
     /// Called during actor deinit/destroy.
-    func resignID(_ id: ActorAddress) {
+    public func resignID(_ id: ActorAddress) {
         self.log.warning("Resign actor id", metadata: ["actor/id": "\(id)"])
         self.namingLock.withLockVoid {
             self._reservedNames.remove(id)
@@ -895,12 +903,12 @@ public extension ClusterSystem {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Remote Calls
 
-public extension ClusterSystem {
-    func makeInvocationEncoder() -> InvocationEncoder {
+extension ClusterSystem {
+    public func makeInvocationEncoder() -> InvocationEncoder {
         InvocationEncoder(system: self)
     }
 
-    func remoteCall<Act, Err, Res>(
+    public func remoteCall<Act, Err, Res>(
         on actor: Act,
         target: RemoteCallTarget,
         invocation: inout InvocationEncoder,
@@ -910,7 +918,8 @@ public extension ClusterSystem {
         where Act: DistributedActor,
         Act.ID == ActorID,
         Err: Error,
-        Res: Codable {
+        Res: Codable
+    {
         guard let clusterShell = _cluster else {
             throw RemoteCallError.clusterAlreadyShutDown
         }
@@ -931,7 +940,7 @@ public extension ClusterSystem {
         return try await ask.value
     }
 
-    func remoteCallVoid<Act, Err>(
+    public func remoteCallVoid<Act, Err>(
         on actor: Act,
         target: RemoteCallTarget,
         invocation: inout InvocationEncoder,
@@ -939,7 +948,8 @@ public extension ClusterSystem {
     ) async throws
         where Act: DistributedActor,
         Act.ID == ActorID,
-        Err: Error {
+        Err: Error
+    {
         guard let shell = self._cluster else {
             throw AskError.systemAlreadyShutDown
         }

--- a/Sources/DistributedActors/ClusterSystemSettings.swift
+++ b/Sources/DistributedActors/ClusterSystemSettings.swift
@@ -244,8 +244,8 @@ public struct ClusterSystemSettings {
     }
 }
 
-public extension Array where Element == _InternalActorTransport {
-    static func += <T: _InternalActorTransport>(transports: inout Self, transport: T) {
+extension Array where Element == _InternalActorTransport {
+    public static func += <T: _InternalActorTransport>(transports: inout Self, transport: T) {
         transports.append(transport)
     }
 }
@@ -316,8 +316,8 @@ public struct LoggingSettings {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Actor Settings
 
-public extension ClusterSystemSettings {
-    struct ActorSettings {
+extension ClusterSystemSettings {
+    public struct ActorSettings {
         public static var `default`: ActorSettings {
             .init()
         }
@@ -330,8 +330,8 @@ public extension ClusterSystemSettings {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Instrumentation Settings
 
-public extension ClusterSystemSettings {
-    struct InstrumentationSettings {
+extension ClusterSystemSettings {
+    public struct InstrumentationSettings {
         /// Default set of enabled instrumentations, based on current operating system.
         ///
         /// On Apple platforms, this includes the `OSSignpostInstrumentationProvider` provided instrumentations,
@@ -393,7 +393,8 @@ public struct ServiceDiscoverySettings {
 
     public init<Discovery, S>(_ implementation: Discovery, service: S)
         where Discovery: ServiceDiscovery, Discovery.Instance == Node,
-        S == Discovery.Service {
+        S == Discovery.Service
+    {
         self.implementation = AnyServiceDiscovery(implementation)
         self._subscribe = { onNext, onComplete in
             implementation.subscribe(to: service, onNext: onNext, onComplete: onComplete)
@@ -402,7 +403,8 @@ public struct ServiceDiscoverySettings {
 
     public init<Discovery, S>(_ implementation: Discovery, service: S, mapInstanceToNode transformer: @escaping (Discovery.Instance) throws -> Node)
         where Discovery: ServiceDiscovery,
-        S == Discovery.Service {
+        S == Discovery.Service
+    {
         let mappedDiscovery: MapInstanceServiceDiscovery<Discovery, Node> = implementation.mapInstance(transformer)
         self.implementation = AnyServiceDiscovery(mappedDiscovery)
         self._subscribe = { onNext, onComplete in

--- a/Sources/DistributedActors/DeadLetters.swift
+++ b/Sources/DistributedActors/DeadLetters.swift
@@ -54,9 +54,9 @@ public struct DeadLetter: NonTransportableActorMessage {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: ClusterSystem.deadLetters
 
-public extension ClusterSystem {
+extension ClusterSystem {
     /// Dead letters reference dedicated to a specific address.
-    func personalDeadLetters<Message: ActorMessage>(type: Message.Type = Message.self, recipient: ActorAddress) -> _ActorRef<Message> {
+    public func personalDeadLetters<Message: ActorMessage>(type: Message.Type = Message.self, recipient: ActorAddress) -> _ActorRef<Message> {
         // TODO: rather could we send messages to self._deadLetters with enough info so it handles properly?
 
         guard recipient.uniqueNode == self.settings.uniqueBindNode else {
@@ -81,7 +81,7 @@ public extension ClusterSystem {
     }
 
     /// Anonymous `/dead/letters` reference, which may be used for messages which have no logical recipient.
-    var deadLetters: _ActorRef<DeadLetter> {
+    public var deadLetters: _ActorRef<DeadLetter> {
         self._deadLetters
     }
 }

--- a/Sources/DistributedActors/DistributedActor+Messages.swift
+++ b/Sources/DistributedActors/DistributedActor+Messages.swift
@@ -52,9 +52,9 @@ extension DistributedActor where ActorSystem == ClusterSystem {
 //    static func _spawn(instance: Self, on system: ClusterSystem) -> _ActorRef<Message>
 // }
 
-public extension DistributedActor where ActorSystem == ClusterSystem {
+extension DistributedActor where ActorSystem == ClusterSystem {
     // FIXME(distributed): this is not enough since we can't get the Message associated type protocol by casting...
-    static func _spawn(instance: Self, on system: ActorSystem) -> _ActorRef<Message> {
+    public static func _spawn(instance: Self, on system: ActorSystem) -> _ActorRef<Message> {
         let behavior: _Behavior<InvocationMessage> = makeBehavior(instance: instance)
         return try! system._spawn(ActorNaming.prefixed(with: "\(Self.self)"), behavior)
     }

--- a/Sources/DistributedActors/EventStream.swift
+++ b/Sources/DistributedActors/EventStream.swift
@@ -81,7 +81,7 @@ public struct EventStream<Event: ActorMessage>: AsyncSequence {
                     _ = self.subscribed.compareExchange(expected: false, desired: true, ordering: .relaxed)
                 })
 
-                continuation.onTermination = { @Sendable(_) in
+                continuation.onTermination = { @Sendable (_) in
                     ref.tell(.asyncUnsubscribe(id) {
                         _ = self.subscribed.compareExchange(expected: true, desired: false, ordering: .relaxed)
                     })

--- a/Sources/DistributedActors/Gossip/GossipLogic.swift
+++ b/Sources/DistributedActors/Gossip/GossipLogic.swift
@@ -158,7 +158,8 @@ struct AnyGossipLogic<Gossip: Codable, Acknowledgement: Codable>: GossipLogic, C
     }
 
     init<Logic>(_ logic: Logic)
-        where Logic: GossipLogic, Logic.Gossip == Gossip, Logic.Acknowledgement == Acknowledgement {
+        where Logic: GossipLogic, Logic.Gossip == Gossip, Logic.Acknowledgement == Acknowledgement
+    {
         var l = logic
         self._selectPeers = { l.selectPeers($0) }
         self._makePayload = { l.makePayload(target: $0) }

--- a/Sources/DistributedActors/Gossip/Gossiper.swift
+++ b/Sources/DistributedActors/Gossip/Gossiper.swift
@@ -37,7 +37,8 @@ enum Gossiper {
         props: _Props = .init(),
         makeLogic: @escaping (Logic.Context) -> Logic
     ) throws -> GossiperControl<Envelope, Acknowledgement>
-        where Logic: GossipLogic, Logic.Gossip == Envelope, Logic.Acknowledgement == Acknowledgement {
+        where Logic: GossipLogic, Logic.Gossip == Envelope, Logic.Acknowledgement == Acknowledgement
+    {
         let ref = try context._spawn(
             naming,
             of: GossipShell<Envelope, Acknowledgement>.Message.self,

--- a/Sources/DistributedActors/Instrumentation/os_signpost/ActorInstrumentation+os_signpost.swift
+++ b/Sources/DistributedActors/Instrumentation/os_signpost/ActorInstrumentation+os_signpost.swift
@@ -52,7 +52,7 @@ public struct OSSignpostActorInstrumentation: ActorInstrumentation {
 @available(iOS 12.0, *)
 @available(tvOS 12.0, *)
 @available(watchOS 3.0, *)
-public extension OSSignpostActorInstrumentation {
+extension OSSignpostActorInstrumentation {
     internal static let actorSpawnedStartFormat: StaticString =
         """
         spawned;\
@@ -65,7 +65,7 @@ public extension OSSignpostActorInstrumentation {
         reason:%{public}s
         """
 
-    func actorSpawned() {
+    public func actorSpawned() {
         guard OSSignpostActorInstrumentation.logLifecycle.signpostsEnabled else {
             return
         }
@@ -95,7 +95,7 @@ public extension OSSignpostActorInstrumentation {
         )
     }
 
-    func actorStopped() {
+    public func actorStopped() {
         guard OSSignpostActorInstrumentation.logLifecycle.signpostsEnabled else {
             return
         }
@@ -116,7 +116,7 @@ public extension OSSignpostActorInstrumentation {
         )
     }
 
-    func actorFailed(failure: _Supervision.Failure) {
+    public func actorFailed(failure: _Supervision.Failure) {
         guard OSSignpostActorInstrumentation.logLifecycle.signpostsEnabled else {
             return
         }
@@ -145,13 +145,13 @@ public extension OSSignpostActorInstrumentation {
 @available(iOS 12.0, *)
 @available(tvOS 12.0, *)
 @available(watchOS 3.0, *)
-public extension OSSignpostActorInstrumentation {
+extension OSSignpostActorInstrumentation {
     // ==== ----------------------------------------------------------------------------------------------------------------
     // MARK: Mailbox
 
-    func actorMailboxRunStarted(mailboxCount: Int) {}
+    public func actorMailboxRunStarted(mailboxCount: Int) {}
 
-    func actorMailboxRunCompleted(processed: Int) {}
+    public func actorMailboxRunCompleted(processed: Int) {}
 
     // ==== ----------------------------------------------------------------------------------------------------------------
     // MARK: Actor Messages: Tell
@@ -168,7 +168,7 @@ public extension OSSignpostActorInstrumentation {
         """
 
     // FIXME: we need the sender() to attach properly
-    func actorTold(message: Any, from: ActorAddress?) {
+    public func actorTold(message: Any, from: ActorAddress?) {
         guard OSSignpostActorInstrumentation.logMessages.signpostsEnabled else {
             return
         }
@@ -211,7 +211,7 @@ public extension OSSignpostActorInstrumentation {
         error-type:%{public}s
         """
 
-    func actorAsked(message: Any, from: ActorAddress?) {
+    public func actorAsked(message: Any, from: ActorAddress?) {
         guard OSSignpostActorInstrumentation.logMessages.signpostsEnabled else {
             return
         }
@@ -228,7 +228,7 @@ public extension OSSignpostActorInstrumentation {
         )
     }
 
-    func actorAskReplied(reply: Any?, error: Error?) {
+    public func actorAskReplied(reply: Any?, error: Error?) {
         guard OSSignpostActorInstrumentation.logMessages.signpostsEnabled else {
             return
         }
@@ -270,7 +270,7 @@ public extension OSSignpostActorInstrumentation {
     // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: Actor Messages: Receive
 
-    static let actorReceivedEventPattern: StaticString =
+    public static let actorReceivedEventPattern: StaticString =
         """
         actor-message-received;\
         recipient-node:%{public}s;\
@@ -281,7 +281,7 @@ public extension OSSignpostActorInstrumentation {
         message-type:%{public}s
         """
 
-    func actorReceivedStart(message: Any, from: ActorAddress?) {
+    public func actorReceivedStart(message: Any, from: ActorAddress?) {
         guard OSSignpostActorInstrumentation.logMessages.signpostsEnabled else {
             return
         }
@@ -301,7 +301,7 @@ public extension OSSignpostActorInstrumentation {
         )
     }
 
-    func actorReceivedEnd(error: Error?) {
+    public func actorReceivedEnd(error: Error?) {
         // TODO: make interval so we know the length of how long an actor processes a message
     }
 
@@ -310,7 +310,7 @@ public extension OSSignpostActorInstrumentation {
     internal static let signpostNameActorWatches: StaticString =
         "System Messages (Watch)"
 
-    static let actorReceivedWatchesPattern: StaticString =
+    public static let actorReceivedWatchesPattern: StaticString =
         """
         watch;\
         action:%{public}s;\
@@ -318,7 +318,7 @@ public extension OSSignpostActorInstrumentation {
         watcher:%{public}s
         """
 
-    func actorWatchReceived(watchee: ActorAddress, watcher: ActorAddress) {
+    public func actorWatchReceived(watchee: ActorAddress, watcher: ActorAddress) {
         guard Self.logSystemMessages.signpostsEnabled else {
             return
         }
@@ -333,7 +333,7 @@ public extension OSSignpostActorInstrumentation {
         )
     }
 
-    func actorUnwatchReceived(watchee: ActorAddress, watcher: ActorAddress) {
+    public func actorUnwatchReceived(watchee: ActorAddress, watcher: ActorAddress) {
         guard Self.logSystemMessages.signpostsEnabled else {
             return
         }

--- a/Sources/DistributedActors/NIO+Extensions.swift
+++ b/Sources/DistributedActors/NIO+Extensions.swift
@@ -17,14 +17,14 @@ import NIO
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: ByteBuffer extensions
 
-internal extension ByteBuffer {
+extension ByteBuffer {
     /// Intended for ad-hoc debugging purposes of network data or serialized payloads.
-    var formatHexDump: String {
+    internal var formatHexDump: String {
         self.formatHexDump()
     }
 
     /// Intended for ad-hoc debugging purposes of network data or serialized payloads.
-    func formatHexDump(maxBytes: Int = 80, bytesPerLine: Int = 16) -> String {
+    internal func formatHexDump(maxBytes: Int = 80, bytesPerLine: Int = 16) -> String {
         let padding = String(repeating: " ", count: 4)
         func asHex(_ byte: UInt8) -> String {
             let s = String(byte, radix: 16, uppercase: true)

--- a/Sources/DistributedActors/Plugins/ActorSystemSettings+Plugins.swift
+++ b/Sources/DistributedActors/Plugins/ActorSystemSettings+Plugins.swift
@@ -73,14 +73,14 @@ public struct PluginsSettings {
 //    }
 }
 
-public extension PluginsSettings {
-    static func += <P: Plugin>(plugins: inout PluginsSettings, plugin: P) {
+extension PluginsSettings {
+    public static func += <P: Plugin>(plugins: inout PluginsSettings, plugin: P) {
         plugins.add(plugin)
     }
 }
 
-public extension ClusterSystemSettings {
-    static func += <P: Plugin>(settings: inout ClusterSystemSettings, plugin: P) {
+extension ClusterSystemSettings {
+    public static func += <P: Plugin>(settings: inout ClusterSystemSettings, plugin: P) {
         settings.plugins.add(plugin)
     }
 }

--- a/Sources/DistributedActors/Props+Metrics.swift
+++ b/Sources/DistributedActors/Props+Metrics.swift
@@ -19,13 +19,13 @@ import NIO
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Metrics _Props
 
-public extension _Props {
+extension _Props {
     /// It is too often too much to report metrics for every single actor, and thus metrics are often better reported in groups.
     /// Since actors may be running various behaviors, it is best to explicitly tag spawned actors with which group they should be reporting metrics to.
     ///
     /// E.g. you may want to report average mailbox size among all worker actors, rather than each and single worker,
     /// to achieve this, one would tag all spawned workers using the same metrics `group`.
-    static func metrics(
+    public static func metrics(
         group: String,
         measure activeMetrics: ActiveMetricsOptionSet,
         _ configure: (inout MetricsProps) -> Void = { _ in () }
@@ -38,7 +38,7 @@ public extension _Props {
     ///
     /// E.g. you may want to report average mailbox size among all worker actors, rather than each and single worker,
     /// to achieve this, one would tag all spawned workers using the same metrics `group`.
-    func metrics(
+    public func metrics(
         group: String,
         measure activeMetrics: ActiveMetricsOptionSet,
         _ configure: (inout MetricsProps) -> Void = { _ in () }

--- a/Sources/DistributedActors/Props.swift
+++ b/Sources/DistributedActors/Props.swift
@@ -82,16 +82,16 @@ public struct _Props: @unchecked Sendable {
 
 // TODO: likely better as class hierarchy, by we'll see...
 
-public extension _Props {
+extension _Props {
     /// Creates a new `_Props` with default values, and overrides the `dispatcher` with the provided one.
-    static func dispatcher(_ dispatcher: _DispatcherProps) -> _Props {
+    public static func dispatcher(_ dispatcher: _DispatcherProps) -> _Props {
         var props = _Props()
         props.dispatcher = dispatcher
         return props
     }
 
     /// Creates copy of this `_Props` changing the dispatcher props, useful for setting a few options in-line when spawning actors.
-    func dispatcher(_ dispatcher: _DispatcherProps) -> _Props {
+    public func dispatcher(_ dispatcher: _DispatcherProps) -> _Props {
         var props = self
         props.dispatcher = dispatcher
         return props
@@ -151,14 +151,14 @@ public enum _DispatcherProps {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Internal _Props settings
 
-public extension _Props {
+extension _Props {
     /// Shorthand for `_Props()._asSellKnown`
     /// - SeeAlso: `_Props._asWellKnown`
-    static let _wellKnown: Self = _Props()._asWellKnown
+    public static let _wellKnown: Self = _Props()._asWellKnown
 
     /// Use with great care, and ONLY if a path is known to only ever be occupied by the one and only actor that is going to be spawned using this well known identity.
     /// Allows spawning actors with "well known" identity (meaning the unique actor incarnation identifier will be set to `ActorIncarnation.wellKnown`).
-    var _asWellKnown: Self {
+    public var _asWellKnown: Self {
         var p = self
         p._wellKnown = true
         return p
@@ -166,7 +166,7 @@ public extension _Props {
 
     /// All "normal" actors are not-so well-known.
     /// Inverse of a well-known actor, i.e. having it's unique identity generated upon spawning.
-    var _asNotSoWellKnown: Self {
+    public var _asNotSoWellKnown: Self {
         var p = self
         p._wellKnown = false
         return p

--- a/Sources/DistributedActors/Receptionist/ActorContext+Receptionist.swift
+++ b/Sources/DistributedActors/Receptionist/ActorContext+Receptionist.swift
@@ -12,22 +12,22 @@
 //
 //===----------------------------------------------------------------------===//
 
-internal extension _ActorContext {
+extension _ActorContext {
     /// Receptionist wrapper, offering convenience functions for registering _this_ actor with the receptionist.
     ///
     /// - SeeAlso: `DistributedActors.Receptionist`, for the system wide receptionist API
-    var receptionist: _ActorContext<Message>.Receptionist {
+    internal var receptionist: _ActorContext<Message>.Receptionist {
         Self.Receptionist(context: self)
     }
 }
 
-internal extension _ActorContext {
+extension _ActorContext {
     /// The receptionist enables type-safe and dynamic (subscription based) actor discovery.
     ///
     /// Actors may register themselves when they start with an `Reception.Key<A>`
     ///
     /// - SeeAlso: `DistributedActors.Receptionist` for the `_ActorRef<Message>` version of this API.
-    struct Receptionist: _MyselfReceptionistOperations {
+    internal struct Receptionist: _MyselfReceptionistOperations {
         public typealias Myself = _ActorRef<Message>
 
         public let _underlyingContext: _ActorContext<Message>

--- a/Sources/DistributedActors/Receptionist/DistributedReception.swift
+++ b/Sources/DistributedActors/Receptionist/DistributedReception.swift
@@ -23,16 +23,17 @@ public enum DistributedReception {}
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: DistributedReception Key
 
-public extension DistributedReception {
+extension DistributedReception {
     /// Used to register and lookup actors in the receptionist.
     /// The key is a combination the Guest's type and an identifier to identify sub-groups of actors of that type.
     ///
     /// The id defaults to "*" which can be used "all actors of that type" (if and only if they registered using this key,
     /// actors which do not opt-into discovery by registering themselves WILL NOT be discovered using this, or any other, key).
     // FIXME(distributed): __DistributedClusterActor must go away, we don't need to be aware of `Message`
-    struct Key<Guest: DistributedActor>: Codable, Sendable,
+    public struct Key<Guest: DistributedActor>: Codable, Sendable,
         ExpressibleByStringLiteral, ExpressibleByStringInterpolation,
-        CustomStringConvertible where Guest.ActorSystem == ClusterSystem {
+        CustomStringConvertible where Guest.ActorSystem == ClusterSystem
+    {
         public let id: String
         public var guestType: Any.Type {
             Guest.self

--- a/Sources/DistributedActors/Receptionist/DistributedReceptionist.swift
+++ b/Sources/DistributedActors/Receptionist/DistributedReceptionist.swift
@@ -50,8 +50,8 @@ public protocol DistributedReceptionist: DistributedActor {
         where Guest: DistributedActor, Guest.ActorSystem == ClusterSystem
 }
 
-public extension DistributedReception {
-    struct GuestListing<Guest: DistributedActor>: AsyncSequence, Sendable where Guest.ActorSystem == ClusterSystem {
+extension DistributedReception {
+    public struct GuestListing<Guest: DistributedActor>: AsyncSequence, Sendable where Guest.ActorSystem == ClusterSystem {
         public typealias Element = Guest
 
         let receptionist: OpLogDistributedReceptionist
@@ -160,7 +160,8 @@ internal final class DistributedReceptionistStorage {
         key: AnyDistributedReceptionKey,
         guest: Guest
     ) -> Bool
-        where Guest: DistributedActor, Guest.ActorSystem == ClusterSystem {
+        where Guest: DistributedActor, Guest.ActorSystem == ClusterSystem
+    {
         guard sequenced.op.isRegister else {
             fatalError("\(#function) can only be called with .register operations, was: \(sequenced)")
         }
@@ -176,7 +177,8 @@ internal final class DistributedReceptionistStorage {
     }
 
     func removeRegistration<Guest>(key: AnyDistributedReceptionKey, guest: Guest) -> Set<VersionedRegistration>?
-        where Guest: DistributedActor, Guest.ActorSystem == ClusterSystem {
+        where Guest: DistributedActor, Guest.ActorSystem == ClusterSystem
+    {
         let address = guest.id
 
         _ = self.removeFromKeyMappings(guest.asAnyDistributedActor)
@@ -325,7 +327,7 @@ internal final class AnyDistributedReceptionListingSubscription: Hashable, @unch
     let key: AnyDistributedReceptionKey
 
     /// Offer a new listing to the subscription stream. // FIXME: implement this by offering single elements (!!!)
-    private let onNext: @Sendable(AnyDistributedActor) -> Void
+    private let onNext: @Sendable (AnyDistributedActor) -> Void
 
     /// We very carefully only modify this from the owning actor (receptionist).
     // TODO: It would be lovely to be able to express this in the type system as "actor owned" or "actor local" to some actor instance.
@@ -334,7 +336,7 @@ internal final class AnyDistributedReceptionListingSubscription: Hashable, @unch
     init(
         subscriptionID: ObjectIdentifier,
         key: AnyDistributedReceptionKey,
-        onNext: @escaping @Sendable(AnyDistributedActor) -> Void
+        onNext: @escaping @Sendable (AnyDistributedActor) -> Void
     ) {
         self.subscriptionID = subscriptionID
         self.key = key

--- a/Sources/DistributedActors/Receptionist/Reception.swift
+++ b/Sources/DistributedActors/Receptionist/Reception.swift
@@ -23,15 +23,16 @@ public enum Reception {}
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Reception Key
 
-public extension Reception {
+extension Reception {
     /// Used to register and lookup actors in the receptionist.
     /// The key is a combination the Guest's type and an identifier to identify sub-groups of actors of that type.
     ///
     /// The id defaults to "*" which can be used "all actors of that type" (if and only if they registered using this key,
     /// actors which do not opt-into discovery by registering themselves WILL NOT be discovered using this, or any other, key).
-    struct Key<Guest: _ReceptionistGuest>: ReceptionKeyProtocol, Codable,
+    public struct Key<Guest: _ReceptionistGuest>: ReceptionKeyProtocol, Codable,
         ExpressibleByStringLiteral, ExpressibleByStringInterpolation,
-        CustomStringConvertible {
+        CustomStringConvertible
+    {
         let id: String
         var guestType: Any.Type {
             Guest.self
@@ -76,10 +77,10 @@ public extension Reception {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Reception Listing
 
-public extension Reception {
+extension Reception {
     /// Response to `Lookup` and `Subscribe` requests.
     /// A listing MAY be empty.
-    struct Listing<Guest: _ReceptionistGuest>: Equatable, CustomStringConvertible {
+    public struct Listing<Guest: _ReceptionistGuest>: Equatable, CustomStringConvertible {
         let underlying: Set<AddressableActorRef>
         let key: Reception.Key<Guest>
 
@@ -109,21 +110,21 @@ public extension Reception {
     }
 }
 
-public extension Reception.Listing where Guest: _ReceivesMessages {
+extension Reception.Listing where Guest: _ReceivesMessages {
     /// Retrieve all listed actor references, mapping them to their appropriate type.
     /// Note that this operation is lazy and has to iterate over all the actors when performing the
     /// iteration.
-    var refs: LazyMapSequence<Set<AddressableActorRef>, _ActorRef<Guest.Message>> {
+    public var refs: LazyMapSequence<Set<AddressableActorRef>, _ActorRef<Guest.Message>> {
         self.underlying.lazy.map { self.key._unsafeAsActorRef($0) }
     }
 
-    var first: _ActorRef<Guest.Message>? {
+    public var first: _ActorRef<Guest.Message>? {
         self.underlying.first.map {
             self.key._unsafeAsActorRef($0)
         }
     }
 
-    func first(where matches: (ActorAddress) -> Bool) -> _ActorRef<Guest.Message>? {
+    public func first(where matches: (ActorAddress) -> Bool) -> _ActorRef<Guest.Message>? {
         self.underlying.first {
             let ref: _ActorRef<Guest.Message> = self.key._unsafeAsActorRef($0)
             return matches(ref.address)
@@ -135,7 +136,7 @@ public extension Reception.Listing where Guest: _ReceivesMessages {
     /// Returns the first actor from the listing whose name matches the passed in `name` parameter.
     ///
     /// Special handling is applied to message adapters (e.g. `/uses/example/two/$messageAdapter` in which case the last segment is ignored).
-    func first(named name: String) -> _ActorRef<Guest.Message>? {
+    public func first(named name: String) -> _ActorRef<Guest.Message>? {
         self.underlying.first {
             $0.path.name == name ||
                 ($0.path.segments.last?.value == "$messageAdapter" && $0.path.segments.dropLast(1).last?.value == name)
@@ -174,9 +175,9 @@ extension ReceptionistListing {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Reception Registered
 
-public extension Reception {
+extension Reception {
     /// Response to a `Register` message
-    final class Registered<Guest: _ReceptionistGuest>: NonTransportableActorMessage, CustomStringConvertible {
+    public final class Registered<Guest: _ReceptionistGuest>: NonTransportableActorMessage, CustomStringConvertible {
         internal let _guest: Guest
         public let key: Reception.Key<Guest>
 
@@ -197,8 +198,8 @@ extension Reception.Registered where Guest: _ReceivesMessages {
     }
 }
 
-public extension Reception.Registered where Guest: DistributedActor, Guest.ActorSystem == ClusterSystem {
-    var actor: Guest {
+extension Reception.Registered where Guest: DistributedActor, Guest.ActorSystem == ClusterSystem {
+    public var actor: Guest {
         let system = self._guest.actorSystem
 
         return try! Guest.resolve(id: self._guest._ref.address, using: system) // FIXME: cleanup these APIs, should never need throws, resolve earlier

--- a/Sources/DistributedActors/Receptionist/Receptionist+Serialization.swift
+++ b/Sources/DistributedActors/Receptionist/Receptionist+Serialization.swift
@@ -36,13 +36,13 @@ extension Reception.Listing: ActorMessage {
     }
 }
 
-public extension Reception.Key {
+extension Reception.Key {
     internal enum CodingKeys: CodingKey {
         case manifest
         case id
     }
 
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         guard let context = decoder.actorSerializationContext else {
             throw SerializationError.missingSerializationContext(decoder, Reception.Listing<Guest>.self)
         }
@@ -60,7 +60,7 @@ public extension Reception.Key {
         self.init(Guest.self, id: id)
     }
 
-    func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Encoder) throws {
         guard let context: Serialization.Context = encoder.actorSerializationContext else {
             throw SerializationError.missingSerializationContext(encoder, Reception.Listing<Guest>.self)
         }

--- a/Sources/DistributedActors/Receptionist/Receptionist.swift
+++ b/Sources/DistributedActors/Receptionist/Receptionist.swift
@@ -53,19 +53,19 @@ public struct Receptionist {
             throw SerializationError.nonTransportableMessage(type: "")
         }
 
-        internal override var _addressableActorRef: AddressableActorRef {
+        override internal var _addressableActorRef: AddressableActorRef {
             AddressableActorRef(self.guest._ref)
         }
 
-        internal override var _key: AnyReceptionKey {
+        override internal var _key: AnyReceptionKey {
             self.key.asAnyKey
         }
 
-        internal override func replyRegistered() {
+        override internal func replyRegistered() {
             self.replyTo?.tell(Reception.Registered(self.guest, key: self.key))
         }
 
-        public override var description: String {
+        override public var description: String {
             "Register(ref: \(self.guest), key: \(self.key), replyTo: \(String(reflecting: self.replyTo))"
         }
     }
@@ -111,15 +111,15 @@ public struct Receptionist {
             throw SerializationError.nonTransportableMessage(type: "\(Self.self)")
         }
 
-        internal override var _key: AnyReceptionKey {
+        override internal var _key: AnyReceptionKey {
             self.key.asAnyKey
         }
 
-        internal override var _boxed: AnySubscribe {
+        override internal var _boxed: AnySubscribe {
             AnySubscribe(subscribe: self)
         }
 
-        internal override var _addressableActorRef: AddressableActorRef {
+        override internal var _addressableActorRef: AddressableActorRef {
             self.subscriber.asAddressable
         }
 
@@ -498,7 +498,7 @@ public class _Subscribe: _ReceptionistMessage, NonTransportableActorMessage {
         fatalErrorBacktrace("failed \(#function)")
     }
 
-    public override init() {
+    override public init() {
         super.init()
     }
 

--- a/Sources/DistributedActors/Receptionist/ReceptionistOperations.swift
+++ b/Sources/DistributedActors/Receptionist/ReceptionistOperations.swift
@@ -66,10 +66,10 @@ internal protocol _ReceptionistOperations: _BaseReceptionistOperations {
     var _system: ClusterSystem { get }
 }
 
-internal extension _ReceptionistOperations {
+extension _ReceptionistOperations {
     @inlinable
     @discardableResult
-    func register<Guest>(
+    internal func register<Guest>(
         _ guest: Guest,
         as id: String,
         replyTo: _ActorRef<Reception.Registered<Guest>>? = nil
@@ -79,7 +79,7 @@ internal extension _ReceptionistOperations {
 
     @inlinable
     @discardableResult
-    func register<Guest>(
+    internal func register<Guest>(
         _ guest: Guest,
         with key: Reception.Key<Guest>,
         replyTo: _ActorRef<Reception.Registered<Guest>>? = nil
@@ -88,7 +88,7 @@ internal extension _ReceptionistOperations {
     }
 
     @inlinable
-    func subscribe<Guest>(
+    internal func subscribe<Guest>(
         _ subscriber: _ActorRef<Reception.Listing<Guest>>,
         to key: Reception.Key<Guest>
     ) where Guest: _ReceptionistGuest {
@@ -96,7 +96,7 @@ internal extension _ReceptionistOperations {
     }
 
     @inlinable
-    func lookup<Guest>(
+    internal func lookup<Guest>(
         _ key: Reception.Key<Guest>,
         replyTo: _ActorRef<Reception.Listing<Guest>>,
         timeout: TimeAmount = .effectivelyInfinite
@@ -151,10 +151,10 @@ internal protocol _MyselfReceptionistOperations: _ReceptionistOperations {
     ) where Guest: _ReceptionistGuest, Myself.Message == Reception.Listing<Guest>
 }
 
-internal extension _MyselfReceptionistOperations {
+extension _MyselfReceptionistOperations {
     @inlinable
     @discardableResult
-    func registerMyself(
+    internal func registerMyself(
         with key: Reception.Key<Myself>,
         replyTo: _ActorRef<Reception.Registered<Myself>>? = nil
     ) -> Reception.Key<Myself> {
@@ -163,7 +163,7 @@ internal extension _MyselfReceptionistOperations {
     }
 
     @inlinable
-    func subscribeMyself<Guest>(
+    internal func subscribeMyself<Guest>(
         to key: Reception.Key<Guest>,
         subReceive callback: @escaping (Reception.Listing<Guest>) -> Void
     ) where Guest: _ReceptionistGuest {
@@ -178,7 +178,7 @@ internal extension _MyselfReceptionistOperations {
     }
 
     @inlinable
-    func subscribeMyself<Guest>(
+    internal func subscribeMyself<Guest>(
         to key: Reception.Key<Guest>
     ) where Guest: _ReceptionistGuest, Myself.Message == Reception.Listing<Guest> {
         self.subscribe(self._myself._ref, to: key)

--- a/Sources/DistributedActors/Refs+any.swift
+++ b/Sources/DistributedActors/Refs+any.swift
@@ -91,12 +91,12 @@ extension AddressableActorRef: CustomStringConvertible {
     }
 }
 
-public extension AddressableActorRef {
-    func hash(into hasher: inout Hasher) {
+extension AddressableActorRef {
+    public func hash(into hasher: inout Hasher) {
         self.address.hash(into: &hasher)
     }
 
-    static func == (lhs: AddressableActorRef, rhs: AddressableActorRef) -> Bool {
+    public static func == (lhs: AddressableActorRef, rhs: AddressableActorRef) -> Bool {
         lhs.address == rhs.address
     }
 }
@@ -126,9 +126,9 @@ extension AddressableActorRef: _ReceivesSystemMessages {
     }
 }
 
-internal extension _RemoteClusterActorPersonality {
+extension _RemoteClusterActorPersonality {
     @usableFromInline
-    func _tellUnsafe(_ message: Any, file: String = #file, line: UInt = #line) {
+    internal func _tellUnsafe(_ message: Any, file: String = #file, line: UInt = #line) {
         guard let _message = message as? Message else {
             traceLog_Remote(self.system.cluster.uniqueNode, "\(self.address)._tellUnsafe [\(message)] failed because of invalid type; self: \(self); Sent at \(file):\(line)")
             return // TODO: drop the message
@@ -138,12 +138,12 @@ internal extension _RemoteClusterActorPersonality {
     }
 }
 
-internal extension _ActorRef {
+extension _ActorRef {
     /// UNSAFE API, DO NOT TOUCH.
     /// This may only be used when certain that a given ref points to a local actor, and thus contains a cell.
     /// May be used by internals when things are to be attached to "myself's cell".
     @usableFromInline
-    var _unsafeUnwrapCell: _ActorCell<Message> {
+    internal var _unsafeUnwrapCell: _ActorCell<Message> {
         switch self.personality {
         case .cell(let cell): return cell
         default: fatalError("Illegal downcast attempt from \(String(reflecting: self)) to _ActorRefWithCell. This is a Swift Distributed Actors bug, please report this on the issue tracker.")
@@ -151,7 +151,7 @@ internal extension _ActorRef {
     }
 
     @usableFromInline
-    var _unwrapActorMetrics: ActiveActorMetrics {
+    internal var _unwrapActorMetrics: ActiveActorMetrics {
         switch self.personality {
         case .cell(let cell):
             return cell.actor?.metrics ?? ActiveActorMetrics.noop
@@ -161,7 +161,7 @@ internal extension _ActorRef {
     }
 
     @usableFromInline
-    var _unsafeUnwrapRemote: _RemoteClusterActorPersonality<Message> {
+    internal var _unsafeUnwrapRemote: _RemoteClusterActorPersonality<Message> {
         switch self.personality {
         case .remote(let remote): return remote
         default: fatalError("Illegal downcast attempt from \(String(reflecting: self)) to _ActorRefWithCell. This is a Swift Distributed Actors bug, please report this on the issue tracker.")

--- a/Sources/DistributedActors/Refs.swift
+++ b/Sources/DistributedActors/Refs.swift
@@ -90,14 +90,14 @@ public protocol AddressableActor {
     var asAddressable: AddressableActorRef { get }
 }
 
-public extension _ActorRef {
+extension _ActorRef {
     /// Exposes given the current actor reference as limited capability representation of itself; an `AddressableActorRef`.
     ///
     /// An `AddressableActorRef` can be used to uniquely identify an actor, however it is not possible to directly send
     /// messages to such identified actor via this reference type.
     ///
     /// - SeeAlso: `AddressableActorRef` for a detailed discussion of its typical use-cases.
-    var asAddressable: AddressableActorRef {
+    public var asAddressable: AddressableActorRef {
         AddressableActorRef(self)
     }
 }
@@ -122,8 +122,8 @@ extension _ActorRef: Hashable {
     }
 }
 
-public extension _ActorRef.Personality {
-    static func == (lhs: _ActorRef.Personality, rhs: _ActorRef.Personality) -> Bool {
+extension _ActorRef.Personality {
+    public static func == (lhs: _ActorRef.Personality, rhs: _ActorRef.Personality) -> Bool {
         switch (lhs, rhs) {
         case (.cell(let l), .cell(let r)):
             return l.address == r.address
@@ -189,8 +189,8 @@ public protocol _ReceivesSystemMessages: Codable {
     func _unsafeGetRemotePersonality<M: ActorMessage>(_ type: M.Type) -> _RemoteClusterActorPersonality<M>
 }
 
-public extension _ReceivesSystemMessages {
-    var path: ActorPath {
+extension _ReceivesSystemMessages {
+    public var path: ActorPath {
         self.address.path
     }
 }
@@ -198,8 +198,8 @@ public extension _ReceivesSystemMessages {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Actor Ref Internals and Internal Capabilities
 
-public extension _ActorRef {
-    func _sendSystemMessage(_ message: _SystemMessage, file: String = #file, line: UInt = #line) {
+extension _ActorRef {
+    public func _sendSystemMessage(_ message: _SystemMessage, file: String = #file, line: UInt = #line) {
         switch self.personality {
         case .cell(let cell):
             cell.sendSystemMessage(message, file: file, line: line)
@@ -235,7 +235,7 @@ public extension _ActorRef {
     }
 
     // FIXME: can this be removed?
-    func _tellOrDeadLetter(_ message: Any, file: String = #file, line: UInt = #line) {
+    public func _tellOrDeadLetter(_ message: Any, file: String = #file, line: UInt = #line) {
         guard let _message = message as? Message else {
             traceLog_Mailbox(self.path, "_tellOrDeadLetter: [\(message)] failed because of invalid message type, to: \(self); Sent at \(file):\(line)")
             self._dropAsDeadLetter(message, file: file, line: line)
@@ -245,11 +245,11 @@ public extension _ActorRef {
         self.tell(_message, file: file, line: line)
     }
 
-    func _dropAsDeadLetter(_ message: Any, file: String = #file, line: UInt = #line) {
+    public func _dropAsDeadLetter(_ message: Any, file: String = #file, line: UInt = #line) {
         self._deadLetters.tell(DeadLetter(message, recipient: self.address, sentAtFile: file, sentAtLine: line), file: file, line: line)
     }
 
-    func _deserializeDeliver(
+    public func _deserializeDeliver(
         _ messageBytes: Serialization.Buffer, using manifest: Serialization.Manifest,
         on pool: _SerializationPool,
         file: String = #file, line: UInt = #line
@@ -301,7 +301,7 @@ public extension _ActorRef {
         )
     }
 
-    func _unsafeGetRemotePersonality<M: ActorMessage>(_ type: M.Type = M.self) -> _RemoteClusterActorPersonality<M> {
+    public func _unsafeGetRemotePersonality<M: ActorMessage>(_ type: M.Type = M.self) -> _RemoteClusterActorPersonality<M> {
         switch self.personality {
         case .remote(let personality):
             return personality._unsafeAssumeCast(to: type)
@@ -408,15 +408,15 @@ extension _ActorCell: CustomDebugStringConvertible {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Convenience extensions for dead letters
 
-public extension _ActorRef where Message == DeadLetter {
+extension _ActorRef where Message == DeadLetter {
     /// Simplified `adapt` method for dead letters, since it is known how the adaptation function looks like.
-    func adapt<IncomingMessage>(from: IncomingMessage.Type) -> _ActorRef<IncomingMessage> {
+    public func adapt<IncomingMessage>(from: IncomingMessage.Type) -> _ActorRef<IncomingMessage> {
         let adapter: _AbstractAdapter = _DeadLetterAdapterPersonality(self._deadLetters, deadRecipient: self.address)
         return .init(.adapter(adapter))
     }
 
     /// Simplified `adapt` method for dead letters, which can be used in contexts where the adapted type can be inferred from context
-    func adapted<IncomingMessage>() -> _ActorRef<IncomingMessage> {
+    public func adapted<IncomingMessage>() -> _ActorRef<IncomingMessage> {
         self.adapt(from: IncomingMessage.self)
     }
 }

--- a/Sources/DistributedActors/Serialization/ActorRef+Serialization.swift
+++ b/Sources/DistributedActors/Serialization/ActorRef+Serialization.swift
@@ -28,13 +28,13 @@ public enum ActorCoding {
     }
 }
 
-public extension _ActorRef {
-    func encode(to encoder: Encoder) throws {
+extension _ActorRef {
+    public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(self.address)
     }
 
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container: SingleValueDecodingContainer = try decoder.singleValueContainer()
         let address = try container.decode(ActorAddress.self)
 
@@ -51,8 +51,8 @@ public extension _ActorRef {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Codable _ReceivesMessages
 
-public extension _ReceivesMessages {
-    func encode(to encoder: Encoder) throws {
+extension _ReceivesMessages {
+    public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
         case let ref as _ActorRef<Message>:
@@ -62,7 +62,7 @@ public extension _ReceivesMessages {
         }
     }
 
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container: SingleValueDecodingContainer = try decoder.singleValueContainer()
         let address: ActorAddress = try container.decode(ActorAddress.self)
 
@@ -83,14 +83,14 @@ public extension _ReceivesMessages {
 /// this type automatically, since users can not access the type at all.
 /// The `ReceivesSystemMessagesDecoder` however does enable this library itself to embed and use this type in Codable
 /// messages, if the need were to arise.
-public extension _ReceivesSystemMessages {
-    func encode(to encoder: Encoder) throws {
+extension _ReceivesSystemMessages {
+    public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         traceLog_Serialization("encode \(self.address) WITH address")
         try container.encode(self.address)
     }
 
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         self = try ReceivesSystemMessagesDecoder.decode(from: decoder) as! Self // as! safe, since we know definitely that Self IS-A ReceivesSystemMessages
     }
 }
@@ -244,8 +244,8 @@ extension UniqueNode: Codable {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Convenience coding functions
 
-internal extension SingleValueDecodingContainer {
-    func decodeNonEmpty(_ type: String.Type, hint: String) throws -> String {
+extension SingleValueDecodingContainer {
+    internal func decodeNonEmpty(_ type: String.Type, hint: String) throws -> String {
         let value = try self.decode(type)
         if value.isEmpty {
             throw DecodingError.dataCorruptedError(in: self, debugDescription: "Cannot initialize [\(hint)] from an empty string!")
@@ -254,8 +254,8 @@ internal extension SingleValueDecodingContainer {
     }
 }
 
-internal extension UnkeyedDecodingContainer {
-    mutating func decodeNonEmpty(_ type: String.Type, hint: String) throws -> String {
+extension UnkeyedDecodingContainer {
+    internal mutating func decodeNonEmpty(_ type: String.Type, hint: String) throws -> String {
         let value = try self.decode(type)
         if value.isEmpty {
             throw DecodingError.dataCorruptedError(in: self, debugDescription: "Cannot initialize [\(hint)] from an empty string!")

--- a/Sources/DistributedActors/Serialization/Serialization+Codable.swift
+++ b/Sources/DistributedActors/Serialization/Serialization+Codable.swift
@@ -28,7 +28,8 @@ extension Decodable {
     }
 
     static func _decode<C>(from container: inout C, forKey key: C.Key, using decoder: Decoder) throws -> Self
-        where C: KeyedDecodingContainerProtocol {
+        where C: KeyedDecodingContainerProtocol
+    {
         try container.decode(Self.self, forKey: key)
     }
 }

--- a/Sources/DistributedActors/Serialization/Serialization+Context.swift
+++ b/Sources/DistributedActors/Serialization/Serialization+Context.swift
@@ -20,11 +20,11 @@ import struct NIO.ByteBufferAllocator
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Serialization.Context
 
-public extension Serialization {
+extension Serialization {
     /// A context object provided to any Encoder/Decoder, in order to allow special `ClusterSystem`-bound types (such as _ActorRef).
     ///
     /// Context MAY be accessed concurrently be encoders/decoders.
-    struct Context {
+    public struct Context {
         public let log: Logger
         public let system: ClusterSystem
 
@@ -86,8 +86,8 @@ public extension Serialization {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Serialization.Context for Encoder & Decoder
 
-public extension CodingUserInfoKey {
-    static let actorSerializationContext: CodingUserInfoKey = .init(rawValue: "sact_ser_context")!
+extension CodingUserInfoKey {
+    public static let actorSerializationContext: CodingUserInfoKey = .init(rawValue: "sact_ser_context")!
 }
 
 public protocol CodableSerializationContext {
@@ -115,8 +115,8 @@ public protocol CodableSerializationContext {
     var actorSerializationContext: Serialization.Context? { get }
 }
 
-public extension Decoder {
-    var actorSerializationContext: Serialization.Context? {
+extension Decoder {
+    public var actorSerializationContext: Serialization.Context? {
         self.userInfo[.actorSerializationContext] as? Serialization.Context
     }
 }
@@ -127,8 +127,8 @@ extension JSONDecoder: CodableSerializationContext {
     }
 }
 
-public extension Encoder {
-    var actorSerializationContext: Serialization.Context? {
+extension Encoder {
+    public var actorSerializationContext: Serialization.Context? {
         self.userInfo[.actorSerializationContext] as? Serialization.Context
     }
 }

--- a/Sources/DistributedActors/Serialization/Serialization+Manifest.swift
+++ b/Sources/DistributedActors/Serialization/Serialization+Manifest.swift
@@ -23,7 +23,7 @@ import Foundation // for Codable
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Serialization Manifest
 
-public extension Serialization {
+extension Serialization {
     /// Serialization manifests are used to carry enough information along a serialized payload,
     /// such that the payload may be safely deserialized into the right type on the recipient system.
     ///
@@ -32,7 +32,7 @@ public extension Serialization {
     /// payload into the "right" type. Some serializers may not need hints, e.g. if the serializer is specialized to a
     /// specific type already -- in those situations not carrying the type `hint` is recommended as it may save precious
     /// bytes from the message envelope size on the wire.
-    struct Manifest: Codable, Hashable {
+    public struct Manifest: Codable, Hashable {
         /// Serializer used to serialize accompanied message.
         public let serializerID: SerializerID
 
@@ -94,14 +94,14 @@ extension Serialization.Manifest: _ProtobufRepresentable {
     }
 }
 
-public extension Serialization {
+extension Serialization {
     /// Creates a manifest, a _recoverable_ representation of a message.
     /// Manifests may be serialized and later used to recover (manifest) type information on another
     /// node which can understand it.
     ///
     /// Manifests only represent names of types, and do not carry versioning information,
     /// as such it may be necessary to carry additional information in order to version APIs more resiliently.
-    func outboundManifest(_ messageType: Any.Type) throws -> Manifest {
+    public func outboundManifest(_ messageType: Any.Type) throws -> Manifest {
         assert(messageType != Any.self, "Any.Type was passed in to outboundManifest, this cannot be right.")
 
         if let manifest = self.settings.typeToManifestRegistry[SerializerTypeKey(any: messageType)] {
@@ -140,7 +140,7 @@ public extension Serialization {
     /// While such `Any.Type` can not be used to invoke Codable's decode() and friends directly,
     /// it does allow us to locate by type identifier the exact right Serializer which knows about the specific type
     /// and can perform the cast safely.
-    func summonType(from manifest: Manifest) throws -> Any.Type {
+    public func summonType(from manifest: Manifest) throws -> Any.Type {
         // TODO: register types until https://github.com/apple/swift/pull/30318 is merged?
         if let custom = self.settings.manifest2TypeRegistry[manifest] {
             return custom
@@ -148,7 +148,8 @@ public extension Serialization {
 
         // TODO: mark as unsafe mode only
         if let hint = manifest.hint,
-            let type = _typeByName(hint) {
+           let type = _typeByName(hint)
+        {
             return type
         }
 

--- a/Sources/DistributedActors/Serialization/Serialization+SerializerID.swift
+++ b/Sources/DistributedActors/Serialization/Serialization+SerializerID.swift
@@ -14,9 +14,9 @@
 
 import SWIM
 
-public extension Serialization {
+extension Serialization {
     /// Used to identify a type (or instance) of a `Serializer`.
-    struct SerializerID: ExpressibleByIntegerLiteral, Hashable, Comparable, CustomStringConvertible {
+    public struct SerializerID: ExpressibleByIntegerLiteral, Hashable, Comparable, CustomStringConvertible {
         public typealias IntegerLiteralType = UInt32
 
         public let value: UInt32
@@ -58,29 +58,29 @@ public extension Serialization {
     }
 }
 
-public extension Optional where Wrapped == Serialization.SerializerID {
+extension Optional where Wrapped == Serialization.SerializerID {
     /// Use the default serializer, as configured in `Serialization.Settings.defaultSerializerID`.
-    static let `default`: Serialization.SerializerID? = nil
+    public static let `default`: Serialization.SerializerID? = nil
 }
 
-public extension Serialization.SerializerID {
-    typealias SerializerID = Serialization.SerializerID
+extension Serialization.SerializerID {
+    public typealias SerializerID = Serialization.SerializerID
 
     // ~~~~~~~~~~~~~~~~ general purpose serializer ids ~~~~~~~~~~~~~~~~
-    static let doNotSerialize: SerializerID = 0
+    public static let doNotSerialize: SerializerID = 0
 
-    static let specializedWithTypeHint: SerializerID = 1
-    static let _ProtobufRepresentable: SerializerID = 2
+    public static let specializedWithTypeHint: SerializerID = 1
+    public static let _ProtobufRepresentable: SerializerID = 2
 
-    static let foundationJSON: SerializerID = 3
-    static let foundationPropertyListBinary: SerializerID = 4
-    static let foundationPropertyListXML: SerializerID = 5
+    public static let foundationJSON: SerializerID = 3
+    public static let foundationPropertyListBinary: SerializerID = 4
+    public static let foundationPropertyListXML: SerializerID = 5
     // ... reserved = 6
     // ... -- || --
     // ... reserved = 16
 
     /// Helper function to never accidentally register a not-Any_ProtobufRepresentable as such.
-    static func check_ProtobufRepresentable<M: Any_ProtobufRepresentable>(_ type: M.Type) -> SerializerID {
+    public static func check_ProtobufRepresentable<M: Any_ProtobufRepresentable>(_ type: M.Type) -> SerializerID {
         ._ProtobufRepresentable
     }
 

--- a/Sources/DistributedActors/Serialization/Serialization+Serializers+Codable.swift
+++ b/Sources/DistributedActors/Serialization/Serialization+Serializers+Codable.swift
@@ -34,17 +34,17 @@ internal class JSONCodableSerializer<Message: Codable>: Serializer<Message> {
         self.decoder = decoder
     }
 
-    public override func serialize(_ message: Message) throws -> Serialization.Buffer {
+    override public func serialize(_ message: Message) throws -> Serialization.Buffer {
         let data = try encoder.encode(message)
         traceLog_Serialization("serialized to: \(data)")
         return .data(data)
     }
 
-    public override func deserialize(from buffer: Serialization.Buffer) throws -> Message {
+    override public func deserialize(from buffer: Serialization.Buffer) throws -> Message {
         try self.decoder.decode(Message.self, from: buffer.readData())
     }
 
-    public override func setSerializationContext(_ context: Serialization.Context) {
+    override public func setSerializationContext(_ context: Serialization.Context) {
         // same context shared for encoding/decoding is safe
         self.decoder.userInfo[.actorSystemKey] = context.system
         self.decoder.userInfo[.actorSerializationContext] = context
@@ -53,7 +53,7 @@ internal class JSONCodableSerializer<Message: Codable>: Serializer<Message> {
         self.encoder.userInfo[.actorSerializationContext] = context
     }
 
-    public override func setUserInfo<Value>(key: CodingUserInfoKey, value: Value?) {
+    override public func setUserInfo<Value>(key: CodingUserInfoKey, value: Value?) {
         self.encoder.userInfo[key] = value
         self.decoder.userInfo[key] = value
     }
@@ -85,19 +85,19 @@ internal class PropertyListCodableSerializer<Message: Codable>: Serializer<Messa
         self.decoder = decoder
     }
 
-    public override func serialize(_ message: Message) throws -> Serialization.Buffer {
+    override public func serialize(_ message: Message) throws -> Serialization.Buffer {
         let data = try encoder.encode(message)
         traceLog_Serialization("serialized to: \(data)")
         return .data(data)
     }
 
-    public override func deserialize(from buffer: Serialization.Buffer) throws -> Message {
+    override public func deserialize(from buffer: Serialization.Buffer) throws -> Message {
         var format = self.format
         // FIXME: validate format = self.format?
         return try self.decoder.decode(Message.self, from: buffer.readData(), format: &format)
     }
 
-    public override func setSerializationContext(_ context: Serialization.Context) {
+    override public func setSerializationContext(_ context: Serialization.Context) {
         // same context shared for encoding/decoding is safe
         self.decoder.userInfo[.actorSystemKey] = context.system
         self.decoder.userInfo[.actorSerializationContext] = context
@@ -106,7 +106,7 @@ internal class PropertyListCodableSerializer<Message: Codable>: Serializer<Messa
         self.encoder.userInfo[.actorSerializationContext] = context
     }
 
-    public override func setUserInfo<Value>(key: CodingUserInfoKey, value: Value?) {
+    override public func setUserInfo<Value>(key: CodingUserInfoKey, value: Value?) {
         self.encoder.userInfo[key] = value
         self.decoder.userInfo[key] = value
     }

--- a/Sources/DistributedActors/Serialization/Serialization+Serializers+Protobuf.swift
+++ b/Sources/DistributedActors/Serialization/Serialization+Serializers+Protobuf.swift
@@ -32,12 +32,12 @@ open class _Base_ProtobufSerializer<Message, ProtobufMessage: SwiftProtobuf.Mess
         return context
     }
 
-    open override func serialize(_ message: Message) throws -> Serialization.Buffer {
+    override open func serialize(_ message: Message) throws -> Serialization.Buffer {
         let proto = try self.toProto(message, context: self.serializationContext)
         return .data(try proto.serializedData())
     }
 
-    open override func deserialize(from buffer: Serialization.Buffer) throws -> Message {
+    override open func deserialize(from buffer: Serialization.Buffer) throws -> Message {
         let proto = try ProtobufMessage(serializedData: buffer.readData())
         return try self.fromProto(proto, context: self.serializationContext)
     }
@@ -52,29 +52,29 @@ open class _Base_ProtobufSerializer<Message, ProtobufMessage: SwiftProtobuf.Mess
         _undefined()
     }
 
-    open override func setSerializationContext(_ context: Serialization.Context) {
+    override open func setSerializationContext(_ context: Serialization.Context) {
         self._serializationContext = context
     }
 }
 
 /// Protobuf serializer for user-defined protobuf messages.
 internal final class _ProtobufSerializer<T: _ProtobufRepresentable>: _Base_ProtobufSerializer<T, T.ProtobufRepresentation> {
-    public override func toProto(_ message: T, context: Serialization.Context) throws -> T.ProtobufRepresentation {
+    override public func toProto(_ message: T, context: Serialization.Context) throws -> T.ProtobufRepresentation {
         try message.toProto(context: self.serializationContext)
     }
 
-    public override func fromProto(_ proto: T.ProtobufRepresentation, context: Serialization.Context) throws -> T {
+    override public func fromProto(_ proto: T.ProtobufRepresentation, context: Serialization.Context) throws -> T {
         try T(fromProto: proto, context: self.serializationContext)
     }
 }
 
 /// Protobuf serializer for internal protobuf messages only.
 internal final class Internal_ProtobufSerializer<T: Internal_ProtobufRepresentable>: _Base_ProtobufSerializer<T, T.ProtobufRepresentation> {
-    public override func toProto(_ message: T, context: Serialization.Context) throws -> T.ProtobufRepresentation {
+    override public func toProto(_ message: T, context: Serialization.Context) throws -> T.ProtobufRepresentation {
         try message.toProto(context: self.serializationContext)
     }
 
-    public override func fromProto(_ proto: T.ProtobufRepresentation, context: Serialization.Context) throws -> T {
+    override public func fromProto(_ proto: T.ProtobufRepresentation, context: Serialization.Context) throws -> T {
         try T(fromProto: proto, context: self.serializationContext)
     }
 }

--- a/Sources/DistributedActors/Serialization/Serialization+Settings.swift
+++ b/Sources/DistributedActors/Serialization/Serialization+Settings.swift
@@ -23,8 +23,8 @@ import Foundation // for Codable
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Serialization Settings
 
-public extension Serialization {
-    struct Settings {
+extension Serialization {
+    public struct Settings {
         // TODO: Workaround for https://bugs.swift.org/browse/SR-12315 "Extension of nested type does not have access to types it is nested in"
         public typealias SerializerID = Serialization.SerializerID
         internal typealias ReservedID = Serialization.ReservedID
@@ -91,7 +91,7 @@ public extension Serialization {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Serialization: Manifest Registration
 
-public extension Serialization.Settings {
+extension Serialization.Settings {
     /// Register a `Serialization.Manifest` for the given `Codable` type and `Serializer`.
     ///
     /// If no `serializer` is selected, it will default to the the `settings.defaultCodableSerializerID`.
@@ -101,7 +101,7 @@ public extension Serialization.Settings {
     /// This can be used to "force" a specific serializer be used for a message type,
     /// regardless if it is codable or not.
     @discardableResult
-    mutating func register<Message: ActorMessage>(
+    public mutating func register<Message: ActorMessage>(
         _ type: Message.Type, hint hintOverride: String? = nil,
         serializerID overrideSerializerID: SerializerID? = nil,
         alsoRegisterActorRef: Bool = true
@@ -146,7 +146,7 @@ public extension Serialization.Settings {
     ///
     /// This manifest will NOT be used when _sending_ messages of the `Message` type.
     @discardableResult
-    mutating func registerInbound<Message: ActorMessage>(
+    public mutating func registerInbound<Message: ActorMessage>(
         _ type: Message.Type, hint hintOverride: String? = nil,
         serializerID overrideSerializerID: SerializerID? = nil
     ) -> Manifest {

--- a/Sources/DistributedActors/Serialization/Serialization.swift
+++ b/Sources/DistributedActors/Serialization/Serialization.swift
@@ -313,11 +313,11 @@ extension Serialization {
 // MARK: Serialization Public API
 
 // TODO: shall we make those return something async-capable, or is our assumption that we invoke these in the serialization pools enough at least until proven wrong?
-public extension Serialization {
+extension Serialization {
     /// Container for serialization output.
     ///
     /// Describing what serializer was used to serialize the value, and its serialized bytes
-    struct Serialized {
+    public struct Serialized {
         public let manifest: Serialization.Manifest
         public let buffer: Serialization.Buffer
     }
@@ -325,7 +325,7 @@ public extension Serialization {
     /// Abstraction of bytes containers.
     ///
     /// Designed to minimize allocation and copies when switching between different byte container types.
-    enum Buffer {
+    public enum Buffer {
         case data(Data)
         case nioByteBuffer(ByteBuffer)
 
@@ -371,7 +371,7 @@ public extension Serialization {
     /// - Returns: `Serialized` describing what serializer was used to serialize the value, and its serialized bytes
     /// - Throws: If no manifest could be created for the value, or a manifest was created however it selected
     ///   a serializer (by ID) that is not registered with the system, or the serializer failing to serialize the message.
-    func serialize<Message>(
+    public func serialize<Message>(
         _ message: Message,
         file: String = #file, line: UInt = #line
     ) throws -> Serialized {
@@ -399,7 +399,8 @@ public extension Serialization {
 
             let result: Serialization.Buffer
             if let predefinedSerializer: AnySerializer =
-                (self._serializersLock.withReaderLock { self._serializers[ObjectIdentifier(messageType)] }) {
+                (self._serializersLock.withReaderLock { self._serializers[ObjectIdentifier(messageType)] })
+            {
                 result = try predefinedSerializer.trySerialize(message)
             } else if let makeSpecializedSerializer = self.settings.specializedSerializerMakers[manifest] {
                 let serializer = makeSpecializedSerializer(self.allocator)
@@ -464,7 +465,7 @@ public extension Serialization {
     /// - Parameters:
     ///   - as: expected type that the deserialized message should be
     ///   - from: `Serialized` containing the manifest used to identify which serializer should be used to deserialize the bytes and the serialized bytes of the message
-    func deserialize<T>(
+    public func deserialize<T>(
         as messageType: T.Type, from serialized: Serialized,
         file: String = #file, line: UInt = #line
     ) throws -> T {
@@ -477,7 +478,7 @@ public extension Serialization {
     ///   - as: expected type that the deserialized message should be
     ///   - from: `Buffer` containing the serialized bytes of the message
     ///   - using: `Manifest` used to identify which serializer should be used to deserialize the bytes (json? protobuf? other?)
-    func deserialize<T>(
+    public func deserialize<T>(
         as messageType: T.Type, from buffer: Serialization.Buffer, using manifest: Serialization.Manifest,
         file: String = #file, line: UInt = #line
     ) throws -> T {
@@ -513,7 +514,7 @@ public extension Serialization {
     /// - Parameters:
     ///   - from: `Buffer` containing the serialized bytes of the message
     ///   - using: `Manifest` used identify the decoder as well as summon the Type of the message. The resulting message is NOT cast to the summoned type.
-    func deserializeAny(
+    public func deserializeAny(
         from buffer: Serialization.Buffer, using manifest: Serialization.Manifest,
         file: String = #file, line: UInt = #line
     ) throws -> Any {
@@ -590,7 +591,7 @@ public extension Serialization {
     /// Validates serialization round-trip is possible for given message.
     ///
     /// Messages marked with `SkipSerializationVerification` are except from this verification.
-    func verifySerializable<Message: ActorMessage>(message: Message) throws {
+    public func verifySerializable<Message: ActorMessage>(message: Message) throws {
         switch message {
         case is NonTransportableActorMessage:
             return // skip
@@ -728,8 +729,8 @@ struct SerializerTypeKey: Hashable, CustomStringConvertible {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Small utility functions
 
-internal extension Foundation.Data {
-    func _copyToByteBuffer(allocator: ByteBufferAllocator) -> ByteBuffer {
+extension Foundation.Data {
+    internal func _copyToByteBuffer(allocator: ByteBufferAllocator) -> ByteBuffer {
         self.withUnsafeBytes { bytes in
             var out: ByteBuffer = allocator.buffer(capacity: self.count)
             out.writeBytes(bytes)
@@ -818,8 +819,8 @@ public protocol SerializationRepresentable {
     static var defaultSerializerID: Serialization.SerializerID? { get }
 }
 
-public extension SerializationRepresentable {
-    static var defaultSerializerID: Serialization.SerializerID? {
+extension SerializationRepresentable {
+    public static var defaultSerializerID: Serialization.SerializerID? {
         nil
     }
 }

--- a/Sources/DistributedActors/Serialization/TopLevelBytesBlobSerializer.swift
+++ b/Sources/DistributedActors/Serialization/TopLevelBytesBlobSerializer.swift
@@ -29,7 +29,7 @@ public class _TopLevelBytesBlobSerializer<Message: Codable>: Serializer<Message>
         self.context = context
     }
 
-    public override func serialize(_ message: Message) throws -> Serialization.Buffer {
+    override public func serialize(_ message: Message) throws -> Serialization.Buffer {
         let encoder = TopLevelBytesBlobEncoder(allocator: self.allocator) // TODO: make it not a class?
         encoder.userInfo[.actorSystemKey] = self.context.system
         encoder.userInfo[.actorSerializationContext] = self.context
@@ -42,7 +42,7 @@ public class _TopLevelBytesBlobSerializer<Message: Codable>: Serializer<Message>
         return bytes
     }
 
-    public override func deserialize(from buffer: Serialization.Buffer) throws -> Message {
+    override public func deserialize(from buffer: Serialization.Buffer) throws -> Message {
         let decoder = TopLevelBytesBlobDecoder()
         decoder.userInfo[.actorSystemKey] = self.context.system
         decoder.userInfo[.actorSerializationContext] = self.context

--- a/Sources/DistributedActors/Serialization/TopLevelProtobufSerializer.swift
+++ b/Sources/DistributedActors/Serialization/TopLevelProtobufSerializer.swift
@@ -26,7 +26,7 @@ internal class _TopLevel_ProtobufSerializer<Message>: Serializer<Message> {
         self.context = context
     }
 
-    public override func serialize(_ message: Message) throws -> Serialization.Buffer {
+    override public func serialize(_ message: Message) throws -> Serialization.Buffer {
         guard let repr = message as? Any_ProtobufRepresentable else {
             throw SerializationError.unableToSerialize(hint: "Can only serialize AnyInternal_ProtobufRepresentable types, was: \(String(reflecting: Message.self))")
         }
@@ -44,7 +44,7 @@ internal class _TopLevel_ProtobufSerializer<Message>: Serializer<Message> {
         return buffer
     }
 
-    public override func deserialize(from buffer: Serialization.Buffer) throws -> Message {
+    override public func deserialize(from buffer: Serialization.Buffer) throws -> Message {
         guard let ProtoType = Message.self as? Any_ProtobufRepresentable.Type else {
             throw SerializationError.unableToDeserialize(hint: "Can only deserialize AnyInternal_ProtobufRepresentable but was \(Message.self)")
         }
@@ -56,9 +56,9 @@ internal class _TopLevel_ProtobufSerializer<Message>: Serializer<Message> {
         return try ProtoType.init(from: decoder) as! Message // explicit .init() is required here (!)
     }
 
-    public override func setSerializationContext(_ context: Serialization.Context) {
+    override public func setSerializationContext(_ context: Serialization.Context) {
         // self.context = context
     }
 
-    public override func setUserInfo<Value>(key: CodingUserInfoKey, value: Value?) {}
+    override public func setUserInfo<Value>(key: CodingUserInfoKey, value: Value?) {}
 }

--- a/Sources/DistributedActors/String+Extensions.swift
+++ b/Sources/DistributedActors/String+Extensions.swift
@@ -23,16 +23,16 @@ public protocol CustomPrettyStringConvertible {
     func prettyDescription(depth: Int) -> String
 }
 
-public extension CustomPrettyStringConvertible {
-    var prettyDescription: String {
+extension CustomPrettyStringConvertible {
+    public var prettyDescription: String {
         self.prettyDescription(depth: 0)
     }
 
-    func prettyDescription(depth: Int) -> String {
+    public func prettyDescription(depth: Int) -> String {
         self.prettyDescription(of: self, depth: depth)
     }
 
-    func prettyDescription(of value: Any, depth: Int) -> String {
+    public func prettyDescription(of value: Any, depth: Int) -> String {
         let mirror = Mirror(reflecting: value)
         let padding0 = String(repeating: " ", count: depth * 2)
         let padding1 = String(repeating: " ", count: (depth + 1) * 2)
@@ -135,8 +135,8 @@ extension Dictionary: CustomPrettyStringConvertible {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: String Interpolation: _:leftPad:
 
-internal extension String.StringInterpolation {
-    mutating func appendInterpolation(_ value: CustomStringConvertible, leftPadTo totalLength: Int) {
+extension String.StringInterpolation {
+    internal mutating func appendInterpolation(_ value: CustomStringConvertible, leftPadTo totalLength: Int) {
         let s = "\(value)"
         let pad = String(repeating: " ", count: max(totalLength - s.count, 0))
         self.appendLiteral("\(pad)\(s)")
@@ -146,8 +146,8 @@ internal extension String.StringInterpolation {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: String Interpolation: Message printing [contents]:type which is useful for enums
 
-internal extension String.StringInterpolation {
-    mutating func appendInterpolation(message: Any) {
+extension String.StringInterpolation {
+    internal mutating func appendInterpolation(message: Any) {
         self.appendLiteral("[\(message)]:\(String(reflecting: type(of: message)))")
     }
 }
@@ -155,8 +155,8 @@ internal extension String.StringInterpolation {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: String Interpolation: reflecting:
 
-internal extension String.StringInterpolation {
-    mutating func appendInterpolation(pretty subject: Any) {
+extension String.StringInterpolation {
+    internal mutating func appendInterpolation(pretty subject: Any) {
         if let prettySubject = subject as? CustomPrettyStringConvertible {
             self.appendLiteral(prettySubject.prettyDescription)
         } else {
@@ -164,17 +164,17 @@ internal extension String.StringInterpolation {
         }
     }
 
-    mutating func appendInterpolation(reflecting subject: Any?) {
+    internal mutating func appendInterpolation(reflecting subject: Any?) {
         self.appendLiteral(String(reflecting: subject))
     }
 
-    mutating func appendInterpolation(reflecting subject: Any) {
+    internal mutating func appendInterpolation(reflecting subject: Any) {
         self.appendLiteral(String(reflecting: subject))
     }
 }
 
-internal extension String.StringInterpolation {
-    mutating func appendInterpolation(lineByLine subject: [Any]) {
+extension String.StringInterpolation {
+    internal mutating func appendInterpolation(lineByLine subject: [Any]) {
         self.appendLiteral("\n    \(subject.map { "\($0)" }.joined(separator: "\n    "))")
     }
 }
@@ -182,12 +182,12 @@ internal extension String.StringInterpolation {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: String Interpolation: _:orElse:
 
-public extension String.StringInterpolation {
-    mutating func appendInterpolation<T>(_ value: T?, orElse defaultValue: String) {
+extension String.StringInterpolation {
+    public mutating func appendInterpolation<T>(_ value: T?, orElse defaultValue: String) {
         self.appendLiteral("\(value.map { "\($0)" } ?? defaultValue)")
     }
 
-    mutating func appendInterpolation<T>(optional value: T?) {
+    public mutating func appendInterpolation<T>(optional value: T?) {
         self.appendLiteral("\(value.map { "\($0)" } ?? "nil")")
     }
 }
@@ -195,16 +195,16 @@ public extension String.StringInterpolation {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Actor Ref custom interpolations
 
-public extension String.StringInterpolation {
-    mutating func appendInterpolation<Message>(name ref: _ActorRef<Message>) {
+extension String.StringInterpolation {
+    public mutating func appendInterpolation<Message>(name ref: _ActorRef<Message>) {
         self.appendLiteral("[\(ref.address.name)]")
     }
 
-    mutating func appendInterpolation<Message>(uniquePath ref: _ActorRef<Message>) {
+    public mutating func appendInterpolation<Message>(uniquePath ref: _ActorRef<Message>) {
         self.appendLiteral("[\(ref.address)]") // TODO: make those address
     }
 
-    mutating func appendInterpolation<Message>(path ref: _ActorRef<Message>) {
+    public mutating func appendInterpolation<Message>(path ref: _ActorRef<Message>) {
         self.appendLiteral("[\(ref.address.path)]")
     }
 }

--- a/Sources/DistributedActors/Supervision.swift
+++ b/Sources/DistributedActors/Supervision.swift
@@ -41,7 +41,7 @@ public struct _SupervisionProps {
     }
 }
 
-public extension _Props {
+extension _Props {
     /// Creates a new `_Props` appending a supervisor for the selected `Error` type, useful for setting a few options in-line when spawning actors.
     ///
     /// Note that order in which overlapping selectors/types are added to the chain matters.
@@ -49,7 +49,7 @@ public extension _Props {
     /// - Parameters:
     ///   - strategy: supervision strategy to apply for the given class of failures
     ///   - forErrorType: error type selector, determining for what type of error the given supervisor should perform its logic.
-    static func supervision(strategy: _SupervisionStrategy, forErrorType errorType: Error.Type) -> _Props {
+    public static func supervision(strategy: _SupervisionStrategy, forErrorType errorType: Error.Type) -> _Props {
         var props = _Props()
         props.supervise(strategy: strategy, forErrorType: errorType)
         return props
@@ -62,7 +62,7 @@ public extension _Props {
     /// - Parameters:
     ///   - strategy: supervision strategy to apply for the given class of failures
     ///   - forAll: failure type selector, working as a "catch all" for the specific types of failures.
-    static func supervision(strategy: _SupervisionStrategy, forAll selector: _Supervise.All = .failures) -> _Props {
+    public static func supervision(strategy: _SupervisionStrategy, forAll selector: _Supervise.All = .failures) -> _Props {
         self.supervision(strategy: strategy, forErrorType: _Supervise.internalErrorTypeFor(selector: selector))
     }
 
@@ -73,7 +73,7 @@ public extension _Props {
     /// - Parameters:
     ///   - strategy: supervision strategy to apply for the given class of failures
     ///   - forErrorType: error type selector, determining for what type of error the given supervisor should perform its logic.
-    func supervision(strategy: _SupervisionStrategy, forErrorType errorType: Error.Type) -> _Props {
+    public func supervision(strategy: _SupervisionStrategy, forErrorType errorType: Error.Type) -> _Props {
         var props = self
         props.supervise(strategy: strategy, forErrorType: errorType)
         return props
@@ -86,7 +86,7 @@ public extension _Props {
     /// - Parameters:
     ///   - strategy: supervision strategy to apply for the given class of failures
     ///   - forAll: failure type selector, working as a "catch all" for the specific types of failures.
-    func supervision(strategy: _SupervisionStrategy, forAll selector: _Supervise.All = .failures) -> _Props {
+    public func supervision(strategy: _SupervisionStrategy, forAll selector: _Supervise.All = .failures) -> _Props {
         self.supervision(strategy: strategy, forErrorType: _Supervise.internalErrorTypeFor(selector: selector))
     }
 
@@ -97,7 +97,7 @@ public extension _Props {
     /// - Parameters:
     ///   - strategy: supervision strategy to apply for the given class of failures
     ///   - forErrorType: failure type selector, working as a "catch all" for the specific types of failures.
-    mutating func supervise(strategy: _SupervisionStrategy, forErrorType errorType: Error.Type) {
+    public mutating func supervise(strategy: _SupervisionStrategy, forErrorType errorType: Error.Type) {
         self.supervision.add(strategy: strategy, forErrorType: errorType)
     }
 
@@ -108,7 +108,7 @@ public extension _Props {
     /// - Parameters:
     ///   - strategy: supervision strategy to apply for the given class of failures
     ///   - forAll: failure type selector, working as a "catch all" for the specific types of failures.
-    mutating func supervise(strategy: _SupervisionStrategy, forAll selector: _Supervise.All = .failures) {
+    public mutating func supervise(strategy: _SupervisionStrategy, forAll selector: _Supervise.All = .failures) {
         self.supervise(strategy: strategy, forErrorType: _Supervise.internalErrorTypeFor(selector: selector))
     }
 }
@@ -209,7 +209,7 @@ public enum _SupervisionStrategy {
     case escalate
 }
 
-public extension _SupervisionStrategy {
+extension _SupervisionStrategy {
     /// Simplified version of `_SupervisionStrategy.restart(atMost:within:backoff:)`.
     ///
     /// - SeeAlso: The top level `_SupervisionStrategy` documentation explores semantics of supervision in more depth.
@@ -234,7 +234,7 @@ public extension _SupervisionStrategy {
     ///   - `within` amount of time within which the `atMost` failures are allowed to happen. This defines the so called "failure period",
     ///     which runs from the first failure encountered for `within` time, and if more than `atMost` failures happen in this time amount then
     ///     no restart is performed and the failure is escalated (and the actor terminates in the process).
-    static func restart(atMost: Int, within: TimeAmount?) -> _SupervisionStrategy {
+    public static func restart(atMost: Int, within: TimeAmount?) -> _SupervisionStrategy {
         .restart(atMost: atMost, within: within, backoff: nil)
     }
 }
@@ -831,7 +831,7 @@ final class RestartingSupervisor<Message: ActorMessage>: Supervisor<Message> {
     }
 
     // TODO: complete impl
-    public override func isSame(as other: Supervisor<Message>) -> Bool {
+    override public func isSame(as other: Supervisor<Message>) -> Bool {
         other is RestartingSupervisor<Message>
     }
 
@@ -873,8 +873,8 @@ extension RestartingSupervisor: CustomStringConvertible {
     }
 }
 
-private extension _Supervision.Failure {
-    func shouldBeHandled(bySupervisorHandling handledType: Error.Type) -> Bool {
+extension _Supervision.Failure {
+    fileprivate func shouldBeHandled(bySupervisorHandling handledType: Error.Type) -> Bool {
         let supervisorHandlesEverything = handledType == _Supervise.AllFailures.self
 
         func matchErrorTypes0() -> Bool {

--- a/Sources/DistributedActors/SystemMessages.swift
+++ b/Sources/DistributedActors/SystemMessages.swift
@@ -106,25 +106,25 @@ public enum TerminationCircumstances {
     case escalating(_Supervision.Failure)
 }
 
-internal extension _SystemMessage {
+extension _SystemMessage {
     @inlinable
-    static func terminated(ref: AddressableActorRef) -> _SystemMessage {
+    internal static func terminated(ref: AddressableActorRef) -> _SystemMessage {
         .terminated(ref: ref, existenceConfirmed: false, addressTerminated: false)
     }
 
     @inlinable
-    static func terminated(ref: AddressableActorRef, existenceConfirmed: Bool) -> _SystemMessage {
+    internal static func terminated(ref: AddressableActorRef, existenceConfirmed: Bool) -> _SystemMessage {
         .terminated(ref: ref, existenceConfirmed: existenceConfirmed, addressTerminated: false)
     }
 
     @inlinable
-    static func terminated(ref: AddressableActorRef, addressTerminated: Bool) -> _SystemMessage {
+    internal static func terminated(ref: AddressableActorRef, addressTerminated: Bool) -> _SystemMessage {
         .terminated(ref: ref, existenceConfirmed: false, addressTerminated: addressTerminated)
     }
 }
 
-public extension _SystemMessage {
-    static func == (lhs: _SystemMessage, rhs: _SystemMessage) -> Bool {
+extension _SystemMessage {
+    public static func == (lhs: _SystemMessage, rhs: _SystemMessage) -> Bool {
         switch (lhs, rhs) {
         case (.start, .start): return true
 

--- a/Sources/DistributedActors/Time.swift
+++ b/Sources/DistributedActors/Time.swift
@@ -229,78 +229,78 @@ extension TimeAmount: CustomStringConvertible, CustomPrettyStringConvertible {
     }
 }
 
-public extension TimeAmount {
+extension TimeAmount {
     /// The microseconds representation of the `TimeAmount`.
-    var microseconds: Int64 {
+    public var microseconds: Int64 {
         self.nanoseconds / TimeAmount.TimeUnit.microseconds.rawValue
     }
 
     /// The milliseconds representation of the `TimeAmount`.
-    var milliseconds: Int64 {
+    public var milliseconds: Int64 {
         self.nanoseconds / TimeAmount.TimeUnit.milliseconds.rawValue
     }
 
     /// The seconds representation of the `TimeAmount`.
-    var seconds: Int64 {
+    public var seconds: Int64 {
         self.nanoseconds / TimeAmount.TimeUnit.seconds.rawValue
     }
 
     /// The minutes representation of the `TimeAmount`.
-    var minutes: Int64 {
+    public var minutes: Int64 {
         self.nanoseconds / TimeAmount.TimeUnit.minutes.rawValue
     }
 
     /// The hours representation of the `TimeAmount`.
-    var hours: Int64 {
+    public var hours: Int64 {
         self.nanoseconds / TimeAmount.TimeUnit.hours.rawValue
     }
 
     /// The days representation of the `TimeAmount`.
-    var days: Int64 {
+    public var days: Int64 {
         self.nanoseconds / TimeAmount.TimeUnit.days.rawValue
     }
 
     /// Returns true if the time amount is "effectively infinite" (equal to `TimeAmount.effectivelyInfinite`)
-    var isEffectivelyInfinite: Bool {
+    public var isEffectivelyInfinite: Bool {
         self == TimeAmount.effectivelyInfinite
     }
 }
 
-public extension TimeAmount {
+extension TimeAmount {
     /// Largest time amount expressible using this type.
     /// Roughly equivalent to 292 years, which for the intents and purposes of this type can serve as "infinite".
-    static var effectivelyInfinite: TimeAmount {
+    public static var effectivelyInfinite: TimeAmount {
         TimeAmount(Value.max)
     }
 
     /// Smallest non-negative time amount.
-    static var zero: TimeAmount {
+    public static var zero: TimeAmount {
         TimeAmount(0)
     }
 }
 
-public extension TimeAmount {
-    static func + (lhs: TimeAmount, rhs: TimeAmount) -> TimeAmount {
+extension TimeAmount {
+    public static func + (lhs: TimeAmount, rhs: TimeAmount) -> TimeAmount {
         .nanoseconds(lhs.nanoseconds + rhs.nanoseconds)
     }
 
-    static func - (lhs: TimeAmount, rhs: TimeAmount) -> TimeAmount {
+    public static func - (lhs: TimeAmount, rhs: TimeAmount) -> TimeAmount {
         .nanoseconds(lhs.nanoseconds - rhs.nanoseconds)
     }
 
-    static func * (lhs: TimeAmount, rhs: Int) -> TimeAmount {
+    public static func * (lhs: TimeAmount, rhs: Int) -> TimeAmount {
         TimeAmount(lhs.nanoseconds * Value(rhs))
     }
 
-    static func * (lhs: TimeAmount, rhs: Double) -> TimeAmount {
+    public static func * (lhs: TimeAmount, rhs: Double) -> TimeAmount {
         TimeAmount(Int64(Double(lhs.nanoseconds) * rhs))
     }
 
-    static func / (lhs: TimeAmount, rhs: Int) -> TimeAmount {
+    public static func / (lhs: TimeAmount, rhs: Int) -> TimeAmount {
         TimeAmount(lhs.nanoseconds / Value(rhs))
     }
 
-    static func / (lhs: TimeAmount, rhs: Double) -> TimeAmount {
+    public static func / (lhs: TimeAmount, rhs: Double) -> TimeAmount {
         TimeAmount(Int64(Double(lhs.nanoseconds) / rhs))
     }
 }
@@ -368,12 +368,12 @@ extension Deadline: CustomStringConvertible {
     }
 }
 
-public extension Deadline {
-    static func - (lhs: Deadline, rhs: Deadline) -> TimeAmount {
+extension Deadline {
+    public static func - (lhs: Deadline, rhs: Deadline) -> TimeAmount {
         .nanoseconds(TimeAmount.Value(lhs.uptimeNanoseconds) - TimeAmount.Value(rhs.uptimeNanoseconds))
     }
 
-    static func + (lhs: Deadline, rhs: TimeAmount) -> Deadline {
+    public static func + (lhs: Deadline, rhs: TimeAmount) -> Deadline {
         if rhs.nanoseconds < 0 {
             return Deadline(lhs.uptimeNanoseconds - Deadline.Value(rhs.nanoseconds.magnitude))
         } else {
@@ -381,7 +381,7 @@ public extension Deadline {
         }
     }
 
-    static func - (lhs: Deadline, rhs: TimeAmount) -> Deadline {
+    public static func - (lhs: Deadline, rhs: TimeAmount) -> Deadline {
         if rhs.nanoseconds < 0 {
             return Deadline(lhs.uptimeNanoseconds + Deadline.Value(rhs.nanoseconds.magnitude))
         } else {
@@ -390,30 +390,30 @@ public extension Deadline {
     }
 }
 
-public extension Deadline {
-    static func fromNow(_ amount: TimeAmount) -> Deadline {
+extension Deadline {
+    public static func fromNow(_ amount: TimeAmount) -> Deadline {
         .now() + amount
     }
 
     /// - Returns: true if the deadline is still pending with respect to the passed in `now` time instant
-    func hasTimeLeft() -> Bool {
+    public func hasTimeLeft() -> Bool {
         self.hasTimeLeft(until: .now())
     }
 
-    func hasTimeLeft(until: Deadline) -> Bool {
+    public func hasTimeLeft(until: Deadline) -> Bool {
         !self.isBefore(until)
     }
 
     /// - Returns: true if the deadline is overdue with respect to the passed in `now` time instant
-    func isOverdue() -> Bool {
+    public func isOverdue() -> Bool {
         self.isBefore(.now())
     }
 
-    func isBefore(_ until: Deadline) -> Bool {
+    public func isBefore(_ until: Deadline) -> Bool {
         self.uptimeNanoseconds < until.uptimeNanoseconds
     }
 
-    var timeLeft: TimeAmount {
+    public var timeLeft: TimeAmount {
         .nanoseconds(self.uptimeNanoseconds - Deadline.now().uptimeNanoseconds)
     }
 }

--- a/Sources/DistributedActors/TimeSpec.swift
+++ b/Sources/DistributedActors/TimeSpec.swift
@@ -31,9 +31,9 @@ internal typealias TimeSpec = timespec
 // TODO: move to Time.swift?
 
 /// Not intended for general use. TOD
-internal extension TimeSpec {
+extension TimeSpec {
     @usableFromInline
-    static func from(timeAmount amount: TimeAmount) -> timespec {
+    internal static func from(timeAmount amount: TimeAmount) -> timespec {
         let seconds = Int(amount.nanoseconds) / NANOS
         let nanos = Int(amount.nanoseconds) % NANOS
         var time = timespec()
@@ -43,7 +43,7 @@ internal extension TimeSpec {
     }
 
     @usableFromInline
-    static func + (a: timespec, b: timespec) -> timespec {
+    internal static func + (a: timespec, b: timespec) -> timespec {
         let totalNanos = a.toNanos() + b.toNanos()
         let seconds = totalNanos / NANOS
         var result = timespec()
@@ -53,7 +53,7 @@ internal extension TimeSpec {
     }
 
     @usableFromInline
-    func toNanos() -> Int {
+    internal func toNanos() -> Int {
         self.tv_nsec + (self.tv_sec * NANOS)
     }
 }

--- a/Sources/DistributedActors/_ActorShell.swift
+++ b/Sources/DistributedActors/_ActorShell.swift
@@ -62,7 +62,7 @@ public final class _ActorShell<Message: ActorMessage>: _ActorContext<Message>, A
     @usableFromInline
     internal var _system: ClusterSystem?
 
-    public override var system: ClusterSystem {
+    override public var system: ClusterSystem {
         if let system = self._system {
             return system
         } else {
@@ -98,7 +98,7 @@ public final class _ActorShell<Message: ActorMessage>: _ActorContext<Message>, A
     // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: _BehaviorTimers
 
-    public override var timers: _BehaviorTimers<Message> {
+    override public var timers: _BehaviorTimers<Message> {
         self._timers
     }
 
@@ -114,7 +114,7 @@ public final class _ActorShell<Message: ActorMessage>: _ActorContext<Message>, A
     // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: Hacky internal trickery to stop an actor from the outside (but same execution context)
 
-    internal override func _forceStop() {
+    override internal func _forceStop() {
         do {
             try self.becomeNext(behavior: .stop(reason: .stopMyself))
         } catch {
@@ -207,7 +207,7 @@ public final class _ActorShell<Message: ActorMessage>: _ActorContext<Message>, A
     private let _childrenLock = ReadWriteLock()
     // All access must be protected with `_childrenLock`, or via `children` helper
     internal var _children: _Children = .init()
-    public override var children: _Children {
+    override public var children: _Children {
         set {
             self._childrenLock.lockWrite()
             defer { self._childrenLock.unlock() }
@@ -227,31 +227,31 @@ public final class _ActorShell<Message: ActorMessage>: _ActorContext<Message>, A
     /// threads, actors, and even nodes (if clustering is used).
     ///
     /// Warning: Do not use after actor has terminated (!)
-    public override var myself: _ActorRef<Message> {
+    override public var myself: _ActorRef<Message> {
         .init(.cell(self._myCell))
     }
 
-    public override var props: _Props {
+    override public var props: _Props {
         self._props
     }
 
-    public override var address: ActorAddress {
+    override public var address: ActorAddress {
         self._address
     }
 
     // Implementation note: Watch out when accessing from outside of an actor run, myself could have been unset (!)
-    public override var path: ActorPath {
+    override public var path: ActorPath {
         self._address.path
     }
 
     // Implementation note: Watch out when accessing from outside of an actor run, myself could have been unset (!)
-    public override var name: String {
+    override public var name: String {
         self._address.name
     }
 
     // access only from within actor
     private var _log: Logger
-    public override var log: Logger {
+    override public var log: Logger {
         get {
             self._log
         }
@@ -630,31 +630,33 @@ public final class _ActorShell<Message: ActorMessage>: _ActorContext<Message>, A
     // MARK: Spawn implementations
 
     @discardableResult
-    public override func _spawn<M>(
+    override public func _spawn<M>(
         _ naming: ActorNaming,
         of type: M.Type = M.self,
         props: _Props = _Props(),
         file: String = #file, line: UInt = #line,
         _ behavior: _Behavior<M>
     ) throws -> _ActorRef<M>
-        where M: ActorMessage {
+        where M: ActorMessage
+    {
         try self.system.serialization._ensureSerializer(type, file: file, line: line)
         return try self._spawn(naming, props: props, behavior)
     }
 
     @discardableResult
-    public override func _spawnWatch<Message>(
+    override public func _spawnWatch<Message>(
         _ naming: ActorNaming,
         of type: Message.Type = Message.self,
         props: _Props = _Props(),
         file: String = #file, line: UInt = #line,
         _ behavior: _Behavior<Message>
     ) throws -> _ActorRef<Message>
-        where Message: ActorMessage {
+        where Message: ActorMessage
+    {
         self.watch(try self._spawn(naming, props: props, behavior))
     }
 
-    public override func stop<Message: ActorMessage>(child ref: _ActorRef<Message>) throws {
+    override public func stop<Message: ActorMessage>(child ref: _ActorRef<Message>) throws {
         try self._stop(child: ref)
     }
 
@@ -662,7 +664,7 @@ public final class _ActorShell<Message: ActorMessage>: _ActorContext<Message>, A
     // MARK: Death Watch
 
     @discardableResult
-    public override func watch<Watchee>(
+    override public func watch<Watchee>(
         _ watchee: Watchee,
         with terminationMessage: Message? = nil,
         file: String = #file, line: UInt = #line
@@ -672,7 +674,7 @@ public final class _ActorShell<Message: ActorMessage>: _ActorContext<Message>, A
     }
 
     @discardableResult
-    public override func unwatch<Watchee>(
+    override public func unwatch<Watchee>(
         _ watchee: Watchee,
         file: String = #file, line: UInt = #line
     ) -> Watchee where Watchee: _DeathWatchable {
@@ -690,8 +692,9 @@ public final class _ActorShell<Message: ActorMessage>: _ActorContext<Message>, A
         self.subReceives[identifier]?.0
     }
 
-    public override func subReceive<SubMessage>(_ id: _SubReceiveId<SubMessage>, _ subType: SubMessage.Type, _ closure: @escaping (SubMessage) throws -> Void) -> _ActorRef<SubMessage>
-        where SubMessage: ActorMessage {
+    override public func subReceive<SubMessage>(_ id: _SubReceiveId<SubMessage>, _ subType: SubMessage.Type, _ closure: @escaping (SubMessage) throws -> Void) -> _ActorRef<SubMessage>
+        where SubMessage: ActorMessage
+    {
         do {
             let wrappedClosure: (SubMessageCarry) throws -> _Behavior<Message> = { carry in
                 guard let message = carry.message as? SubMessage else {
@@ -742,8 +745,9 @@ public final class _ActorShell<Message: ActorMessage>: _ActorContext<Message>, A
         let closure: (Any) -> Message?
     }
 
-    public override func messageAdapter<From>(from fromType: From.Type, adapt: @escaping (From) -> Message?) -> _ActorRef<From>
-        where From: ActorMessage {
+    override public func messageAdapter<From>(from fromType: From.Type, adapt: @escaping (From) -> Message?) -> _ActorRef<From>
+        where From: ActorMessage
+    {
         do {
             let metaType = MetaType(fromType)
             let anyAdapter: (Any) -> Message? = { message in
@@ -981,7 +985,8 @@ extension AbstractShellProtocol {
     }
 
     public func _resolve<Message>(context: ResolveContext<Message>) -> _ActorRef<Message>
-        where Message: ActorMessage {
+        where Message: ActorMessage
+    {
         let myself: _ReceivesSystemMessages = self._myselfReceivesSystemMessages
 
         do {
@@ -1024,10 +1029,10 @@ extension AbstractShellProtocol {
     }
 }
 
-internal extension _ActorContext {
+extension _ActorContext {
     /// INTERNAL API: UNSAFE, DO NOT TOUCH.
     @usableFromInline
-    var _downcastUnsafe: _ActorShell<Message> {
+    internal var _downcastUnsafe: _ActorShell<Message> {
         switch self {
         case let shell as _ActorShell<Message>: return shell
         default: fatalError("Illegal downcast attempt from \(String(reflecting: self)) to ActorCell. This is a bug, please report this on the issue tracker.")

--- a/Sources/DistributedActors/_BehaviorTimers.swift
+++ b/Sources/DistributedActors/_BehaviorTimers.swift
@@ -220,15 +220,15 @@ extension _BehaviorTimers {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Internal System Timer capabilities
 
-internal extension _BehaviorTimers {
+extension _BehaviorTimers {
     @usableFromInline
-    struct ScheduledResume<T> {
+    internal struct ScheduledResume<T> {
         let token: T
     }
 
     /// Dangerous version of `_startTimer` which allows scheduling a `.resume` system message (directly!) with a token `T`, after a time `delay`.
     /// This can be used e.g. to implement restarting an actor after a backoff delay.
-    func _startResumeTimer<T>(key: TimerKey, delay: TimeAmount, resumeWith token: T) {
+    internal func _startResumeTimer<T>(key: TimerKey, delay: TimeAmount, resumeWith token: T) {
         assert(key.isSystemTimer, "_startResumeTimer MUST ONLY be used by system internal tasks, and keys MUST be `_` prefixed. Key was: \(key)")
         self.cancel(for: key)
 

--- a/Sources/DistributedActors/_Mailbox.swift
+++ b/Sources/DistributedActors/_Mailbox.swift
@@ -371,8 +371,9 @@ internal final class _Mailbox<Message: ActorMessage> {
 
         if status.hasSystemMessages {
             while runResult != .shouldStop,
-                runResult != .closed,
-                let message = self.systemMessages.dequeue() {
+                  runResult != .closed,
+                  let message = self.systemMessages.dequeue()
+            {
                 do {
                     try runResult = shell.interpretSystemMessage(message: message)
                 } catch {

--- a/Sources/DistributedActors/_Signals.swift
+++ b/Sources/DistributedActors/_Signals.swift
@@ -152,7 +152,7 @@ public enum _Signals {
             super.init(address: address, existenceConfirmed: true)
         }
 
-        public override var description: String {
+        override public var description: String {
             let reason: String
             if case .some(let r) = self.escalation {
                 reason = ", escalation: \(r)"

--- a/Sources/DistributedActors/utils.swift
+++ b/Sources/DistributedActors/utils.swift
@@ -216,14 +216,14 @@ internal func _left<L, R>(left: L, right: R) -> L {
 
 // MARK: Minor printing/formatting helpers
 
-internal extension BinaryInteger {
-    var hexString: String {
+extension BinaryInteger {
+    internal var hexString: String {
         "0x\(String(self, radix: 16, uppercase: true))"
     }
 }
 
-internal extension Array where Array.Element == UInt8 {
-    var hexString: String {
+extension Array where Array.Element == UInt8 {
+    internal var hexString: String {
         "0x\(self.map(\.hexString).joined(separator: ""))"
     }
 }

--- a/Sources/DistributedActorsConcurrencyHelpers/lock.swift
+++ b/Sources/DistributedActorsConcurrencyHelpers/lock.swift
@@ -61,7 +61,7 @@ public final class Lock {
     }
 }
 
-public extension Lock {
+extension Lock {
     /// Acquire the lock for the duration of the given block.
     ///
     /// This convenience method should be preferred to `lock` and `unlock` in
@@ -71,7 +71,7 @@ public extension Lock {
     /// - Parameter body: The block to execute while holding the lock.
     /// - Returns: The value returned by the block.
     @inlinable
-    func withLock<T>(_ body: () throws -> T) rethrows -> T {
+    public func withLock<T>(_ body: () throws -> T) rethrows -> T {
         self.lock()
         defer {
             self.unlock()
@@ -81,7 +81,7 @@ public extension Lock {
 
     // specialise Void return (for performance)
     @inlinable
-    func withLockVoid(_ body: () throws -> Void) rethrows {
+    public func withLockVoid(_ body: () throws -> Void) rethrows {
         try self.withLock(body)
     }
 }

--- a/Sources/DistributedActorsTestKit/ActorSystemXCTestCase.swift
+++ b/Sources/DistributedActorsTestKit/ActorSystemXCTestCase.swift
@@ -42,12 +42,12 @@ open class ActorSystemXCTestCase: ClusteredActorSystemsXCTestCase {
         return handler
     }
 
-    open override func setUp() async throws {
+    override open func setUp() async throws {
         try await super.setUp()
         _ = await self.setUpNode(String(describing: type(of: self)))
     }
 
-    open override func tearDown() {
+    override open func tearDown() {
         super.tearDown()
     }
 }

--- a/Sources/DistributedActorsTestKit/ActorTestKit.swift
+++ b/Sources/DistributedActorsTestKit/ActorTestKit.swift
@@ -63,9 +63,9 @@ public struct ActorTestKitSettings {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Test Probes
 
-public extension ActorTestKit {
+extension ActorTestKit {
     /// Spawn an `ActorTestProbe` which offers various assertion methods for actor messaging interactions.
-    func makeTestProbe<Message: ActorMessage>(
+    public func makeTestProbe<Message: ActorMessage>(
         _ naming: ActorNaming? = nil,
         expecting type: Message.Type = Message.self,
         file: StaticString = #file, line: UInt = #line
@@ -99,7 +99,7 @@ public extension ActorTestKit {
     /// Spawns an `ActorTestProbe` and immediately subscribes it to the passed in event stream.
     ///
     /// - Hint: Use `fishForMessages` and `fishFor` to filter expectations for specific events.
-    func spawnEventStreamTestProbe<Event: ActorMessage>(
+    public func spawnEventStreamTestProbe<Event: ActorMessage>(
         _ naming: ActorNaming? = nil,
         subscribedTo eventStream: EventStream<Event>,
         file: String = #file, line: UInt = #line, column: UInt = #column
@@ -113,7 +113,7 @@ public extension ActorTestKit {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Eventually
 
-public extension ActorTestKit {
+extension ActorTestKit {
     /// Executes passed in block numerous times, until a the expected value is obtained or the `within` time limit expires,
     /// in which case an `EventuallyError` is thrown, along with the last encountered error thrown by block.
     ///
@@ -124,7 +124,7 @@ public extension ActorTestKit {
     // TODO: does not handle blocking longer than `within` well
     // TODO: should use default `within` from TestKit
     @discardableResult
-    func eventually<T>(
+    public func eventually<T>(
         within timeAmount: TimeAmount, interval: TimeAmount = .milliseconds(100),
         file: StaticString = #file, line: UInt = #line, column: UInt = #column,
         _ block: () throws -> T
@@ -205,10 +205,10 @@ public struct EventuallyError: Error, CustomStringConvertible, CustomDebugString
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: assertHolds
 
-public extension ActorTestKit {
+extension ActorTestKit {
     /// Executes passed in block numerous times, to check the assertion holds over time.
     /// Throws an error when the block fails within the specified time amount.
-    func assertHolds(
+    public func assertHolds(
         for timeAmount: TimeAmount, interval: TimeAmount = .milliseconds(100),
         file: StaticString = #file, line: UInt = #line, column: UInt = #column,
         _ block: () throws -> Void
@@ -241,10 +241,10 @@ public extension ActorTestKit {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: "Power" assertions, should not be used lightly as they are quite heavy and potentially racy
 
-public extension ActorTestKit {
+extension ActorTestKit {
     // TODO: how to better hide such more nasty assertions?
     // TODO: Not optimal since we always do traverseAll rather than follow the Path of the context
-    func _assertActorPathOccupied(_ path: String, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
+    public func _assertActorPathOccupied(_ path: String, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
         precondition(!path.contains("#"), "assertion path MUST NOT contain # id section of an unique path.")
 
         let callSiteInfo = CallSiteInfo(file: file, line: line, column: column, function: #function)
@@ -268,7 +268,7 @@ public extension ActorTestKit {
     /// If unable to resolve a not-dead reference, this function throws, rather than returning the dead reference.
     ///
     /// This is useful when the resolution might be racing against the startup of the actor we are trying to resolve.
-    func _eventuallyResolve<Message>(address: ActorAddress, of: Message.Type = Message.self, within: TimeAmount = .seconds(5)) throws -> _ActorRef<Message> {
+    public func _eventuallyResolve<Message>(address: ActorAddress, of: Message.Type = Message.self, within: TimeAmount = .seconds(5)) throws -> _ActorRef<Message> {
         let context = ResolveContext<Message>(address: address, system: self.system)
 
         return try self.eventually(within: .seconds(3)) {
@@ -286,16 +286,16 @@ public extension ActorTestKit {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Fake and mock contexts
 
-public extension ActorTestKit {
+extension ActorTestKit {
     /// Creates a _fake_ `_ActorContext` which can be used to pass around to fulfil type argument requirements,
     /// however it DOES NOT have the ability to perform any of the typical actor context actions (such as spawning etc).
-    func makeFakeContext<M: ActorMessage>(of: M.Type = M.self) -> _ActorContext<M> {
+    public func makeFakeContext<M: ActorMessage>(of: M.Type = M.self) -> _ActorContext<M> {
         Mock_ActorContext(self.system)
     }
 
     /// Creates a _fake_ `_ActorContext` which can be used to pass around to fulfil type argument requirements,
     /// however it DOES NOT have the ability to perform any of the typical actor context actions (such as spawning etc).
-    func makeFakeContext<M: ActorMessage>(for: _Behavior<M>) -> _ActorContext<M> {
+    public func makeFakeContext<M: ActorMessage>(for: _Behavior<M>) -> _ActorContext<M> {
         self.makeFakeContext(of: M.self)
     }
 }
@@ -316,24 +316,24 @@ public final class Mock_ActorContext<Message: ActorMessage>: _ActorContext<Messa
         self._system = system
     }
 
-    public override var system: ClusterSystem {
+    override public var system: ClusterSystem {
         self._system
     }
 
-    public override var path: ActorPath {
+    override public var path: ActorPath {
         super.path
     }
 
-    public override var name: String {
+    override public var name: String {
         "Mock_ActorContext<\(Message.self)>"
     }
 
-    public override var myself: _ActorRef<Message> {
+    override public var myself: _ActorRef<Message> {
         self.system.deadLetters.adapted()
     }
 
     private lazy var _log: Logger = .init(label: "\(type(of: self))")
-    public override var log: Logger {
+    override public var log: Logger {
         get {
             self._log
         }
@@ -342,12 +342,12 @@ public final class Mock_ActorContext<Message: ActorMessage>: _ActorContext<Messa
         }
     }
 
-    public override var props: _Props {
+    override public var props: _Props {
         .init() // mock impl
     }
 
     @discardableResult
-    public override func watch<Watchee>(
+    override public func watch<Watchee>(
         _ watchee: Watchee,
         with terminationMessage: Message? = nil,
         file: String = #file, line: UInt = #line
@@ -356,7 +356,7 @@ public final class Mock_ActorContext<Message: ActorMessage>: _ActorContext<Messa
     }
 
     @discardableResult
-    public override func unwatch<Watchee>(
+    override public func unwatch<Watchee>(
         _ watchee: Watchee,
         file: String = #file, line: UInt = #line
     ) -> Watchee where Watchee: _DeathWatchable {
@@ -364,26 +364,28 @@ public final class Mock_ActorContext<Message: ActorMessage>: _ActorContext<Messa
     }
 
     @discardableResult
-    public override func _spawn<M>(
+    override public func _spawn<M>(
         _ naming: ActorNaming, of type: M.Type = M.self, props: _Props = _Props(),
         file: String = #file, line: UInt = #line,
         _ behavior: _Behavior<M>
     ) throws -> _ActorRef<M>
-        where M: ActorMessage {
+        where M: ActorMessage
+    {
         fatalError("Failed: \(MockActorContextError())")
     }
 
     @discardableResult
-    public override func _spawnWatch<M>(
+    override public func _spawnWatch<M>(
         _ naming: ActorNaming, of type: M.Type = M.self, props: _Props = _Props(),
         file: String = #file, line: UInt = #line,
         _ behavior: _Behavior<M>
     ) throws -> _ActorRef<M>
-        where M: ActorMessage {
+        where M: ActorMessage
+    {
         fatalError("Failed: \(MockActorContextError())")
     }
 
-    public override var children: _Children {
+    override public var children: _Children {
         get {
             fatalError("Failed: \(MockActorContextError())")
         }
@@ -392,7 +394,7 @@ public final class Mock_ActorContext<Message: ActorMessage>: _ActorContext<Messa
         }
     }
 
-    public override func stop<M>(child ref: _ActorRef<M>) throws {
+    override public func stop<M>(child ref: _ActorRef<M>) throws {
         fatalError("Failed: \(MockActorContextError())")
     }
 }
@@ -400,7 +402,7 @@ public final class Mock_ActorContext<Message: ActorMessage>: _ActorContext<Messa
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Error
 
-public extension ActorTestKit {
+extension ActorTestKit {
     /// Returns an error that can be used when conditions in tests are not met. This is especially useful in
     /// calls to `testKit.eventually`, where a condition is checked multiple times, until it is successful
     /// or times out.
@@ -410,7 +412,7 @@ public extension ActorTestKit {
     ///     testKit.eventually(within: .seconds(3)) {
     ///         guard ... else { throw testKit.error("failed to extract expected information") }
     ///     }
-    func error(_ message: String? = nil, file: StaticString = #file, line: UInt = #line, column: UInt = #column) -> Error {
+    public func error(_ message: String? = nil, file: StaticString = #file, line: UInt = #line, column: UInt = #column) -> Error {
         let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
         let fullMessage: String = message ?? "<no message>"
         return callSite.error(fullMessage, failTest: false)
@@ -421,7 +423,7 @@ public extension ActorTestKit {
     /// Examples:
     ///
     ///     guard ... else { throw testKit.fail("failed to extract expected information") }
-    func fail(_ message: String? = nil, file: StaticString = #file, line: UInt = #line, column: UInt = #column) -> Error {
+    public func fail(_ message: String? = nil, file: StaticString = #file, line: UInt = #line, column: UInt = #column) -> Error {
         let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
         let fullMessage: String = message ?? "<no message>"
         return callSite.error(fullMessage, failTest: true)
@@ -434,20 +436,20 @@ public extension ActorTestKit {
 // Used to mark a repeatable context, in which `ActorTestProbe.expectX` does not
 // immediately fail the test, but instead lets the `ActorTestKit.eventually`
 // block handle it.
-internal extension ActorTestKit {
-    static let threadLocalContextKey: String = "SACT_TESTKIT_REPEATABLE_CONTEXT"
+extension ActorTestKit {
+    internal static let threadLocalContextKey: String = "SACT_TESTKIT_REPEATABLE_CONTEXT"
 
     // Sets a flag that can be checked with `isInRepeatableContext`, to avoid
     // failing a test from within blocks that continuously check conditions,
     // e.g. `ActorTestKit.eventually`. This is safe to use in nested calls.
-    static func enterRepeatableContext() {
+    internal static func enterRepeatableContext() {
         let currentDepth = self.currentRepeatableContextDepth
         Foundation.Thread.current.threadDictionary[self.threadLocalContextKey] = currentDepth + 1
     }
 
     // Unsets the flag and causes `isInRepeatableContext` to return `false`.
     // This is safe to use in nested calls.
-    static func leaveRepeatableContext() {
+    internal static func leaveRepeatableContext() {
         let currentDepth = self.currentRepeatableContextDepth
         precondition(currentDepth > 0, "Imbalanced `leaveRepeatableContext` detected. Depth was \(currentDepth)")
         Foundation.Thread.current.threadDictionary[self.threadLocalContextKey] = currentDepth - 1
@@ -457,12 +459,12 @@ internal extension ActorTestKit {
     // checks conditions. Used in `ActorTestProbe.expectX` and `ActorTestKit.error`
     // to avoid failing the test on the first iteration in e.g. an
     // `ActorTestKit.eventually` block.
-    static func isInRepeatableContext() -> Bool {
+    internal static func isInRepeatableContext() -> Bool {
         self.currentRepeatableContextDepth > 0
     }
 
     // Returns the current depth of nested repeatable context calls.
-    static var currentRepeatableContextDepth: Int {
+    internal static var currentRepeatableContextDepth: Int {
         guard let currentValue = Foundation.Thread.current.threadDictionary[self.threadLocalContextKey] else {
             return 0
         }
@@ -478,11 +480,11 @@ internal extension ActorTestKit {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Receptionist
 
-public extension ActorTestKit {
+extension ActorTestKit {
     /// Ensures that a given number of refs are registered with the Receptionist under `key`.
     /// If `expectedRefs` is specified, also compares it to the listing for `key` and requires an exact match.
     @available(*, deprecated, message: "Will be removed and replaced by API based on DistributedActor. Issue #824")
-    func ensureRegistered<Message>(
+    public func ensureRegistered<Message>(
         key: Reception.Key<_ActorRef<Message>>,
         expectedCount: Int = 1,
         expectedRefs: Set<_ActorRef<Message>>? = nil,

--- a/Sources/DistributedActorsTestKit/ByteBuffer+Testing.swift
+++ b/Sources/DistributedActorsTestKit/ByteBuffer+Testing.swift
@@ -22,9 +22,9 @@ import XCTest
 
 // TODO: probably remove those?
 
-public extension Serialization.Buffer {
+extension Serialization.Buffer {
     // For easier visual inspection of known utf8 data within a Buffer, use with care (!)
-    func stringDebugDescription() -> String {
+    public func stringDebugDescription() -> String {
         switch self {
         case .data(let data):
             return data.stringDebugDescription()
@@ -34,9 +34,9 @@ public extension Serialization.Buffer {
     }
 }
 
-public extension Data {
+extension Data {
     // For easier visual inspection of known utf8 data within a Data, use with care (!)
-    func stringDebugDescription() -> String {
+    public func stringDebugDescription() -> String {
         if let string = String(data: self, encoding: .utf8) {
             return string
         } else {
@@ -45,9 +45,9 @@ public extension Data {
     }
 }
 
-public extension ByteBuffer {
+extension ByteBuffer {
     // For easier visual inspection of known utf8 data within a ByteBuffer, use with care (!)
-    func stringDebugDescription() -> String {
+    public func stringDebugDescription() -> String {
         self.getString(at: 0, length: self.readableBytes)!
     }
 }

--- a/Sources/DistributedActorsTestKit/Cluster/ClusteredActorSystemsXCTestCase.swift
+++ b/Sources/DistributedActorsTestKit/Cluster/ClusteredActorSystemsXCTestCase.swift
@@ -98,7 +98,7 @@ open class ClusteredActorSystemsXCTestCase: XCTestCase {
         return (first, second)
     }
 
-    open override func tearDown() {
+    override open func tearDown() {
         let testsFailed = self.testRun?.totalFailureCount ?? 0 > 0
         if self.captureLogs, self.alwaysPrintCaptureLogs || testsFailed {
             self.printAllCapturedLogs()
@@ -198,8 +198,8 @@ open class ClusteredActorSystemsXCTestCase: XCTestCase {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Printing information
 
-public extension ClusteredActorSystemsXCTestCase {
-    func pinfoMembership(_ system: ClusterSystem, file: StaticString = #file, line: UInt = #line) {
+extension ClusteredActorSystemsXCTestCase {
+    public func pinfoMembership(_ system: ClusterSystem, file: StaticString = #file, line: UInt = #line) {
         let testKit = self.testKit(system)
         let p = testKit.makeTestProbe(expecting: Cluster.Membership.self)
 
@@ -225,8 +225,8 @@ public extension ClusteredActorSystemsXCTestCase {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Captured Logs
 
-public extension ClusteredActorSystemsXCTestCase {
-    func capturedLogs(of node: ClusterSystem) -> LogCapture {
+extension ClusteredActorSystemsXCTestCase {
+    public func capturedLogs(of node: ClusterSystem) -> LogCapture {
         guard let index = self._nodes.firstIndex(of: node) else {
             fatalError("No such node: [\(node)] in [\(self._nodes)]!")
         }
@@ -234,13 +234,13 @@ public extension ClusteredActorSystemsXCTestCase {
         return self._logCaptures[index]
     }
 
-    func printCapturedLogs(of node: ClusterSystem) {
+    public func printCapturedLogs(of node: ClusterSystem) {
         print("------------------------------------- \(node) ------------------------------------------------")
         self.capturedLogs(of: node).printLogs()
         print("========================================================================================================================")
     }
 
-    func printAllCapturedLogs() {
+    public func printAllCapturedLogs() {
         for node in self._nodes {
             self.printCapturedLogs(of: node)
         }
@@ -250,8 +250,8 @@ public extension ClusteredActorSystemsXCTestCase {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Assertions
 
-public extension ClusteredActorSystemsXCTestCase {
-    func assertAssociated(
+extension ClusteredActorSystemsXCTestCase {
+    public func assertAssociated(
         _ system: ClusterSystem, withAtLeast node: UniqueNode,
         timeout: TimeAmount? = nil, interval: TimeAmount? = nil,
         verbose: Bool = false, file: StaticString = #file, line: UInt = #line, column: UInt = #column
@@ -262,7 +262,7 @@ public extension ClusteredActorSystemsXCTestCase {
         )
     }
 
-    func assertAssociated(
+    public func assertAssociated(
         _ system: ClusterSystem, withExactly node: UniqueNode,
         timeout: TimeAmount? = nil, interval: TimeAmount? = nil,
         verbose: Bool = false, file: StaticString = #file, line: UInt = #line, column: UInt = #column
@@ -278,7 +278,7 @@ public extension ClusteredActorSystemsXCTestCase {
     /// - Parameters:
     ///   - withExactly: specific set of nodes that must exactly match the associated nodes on `system`; i.e. no extra associated nodes are allowed
     ///   - withAtLeast: sub-set of nodes that must be associated
-    func assertAssociated(
+    public func assertAssociated(
         _ system: ClusterSystem,
         withExactly exactlyNodes: [UniqueNode] = [],
         withAtLeast atLeastNodes: [UniqueNode] = [],
@@ -329,7 +329,7 @@ public extension ClusteredActorSystemsXCTestCase {
         }
     }
 
-    func assertNotAssociated(
+    public func assertNotAssociated(
         system: ClusterSystem, node: UniqueNode,
         timeout: TimeAmount? = nil, interval: TimeAmount? = nil,
         verbose: Bool = false
@@ -356,7 +356,7 @@ public extension ClusteredActorSystemsXCTestCase {
     /// Asserts the given member node has the expected `status`.
     ///
     /// An error is thrown but NOT failing the test; use in pair with `testKit.eventually` to achieve the expected behavior.
-    func assertMemberStatus(
+    public func assertMemberStatus(
         on system: ClusterSystem, node: UniqueNode,
         is expectedStatus: Cluster.MemberStatus,
         file: StaticString = #file, line: UInt = #line
@@ -379,7 +379,7 @@ public extension ClusteredActorSystemsXCTestCase {
         }
     }
 
-    func assertMemberStatus(
+    public func assertMemberStatus(
         on system: ClusterSystem, node: UniqueNode,
         atLeast expectedAtLeastStatus: Cluster.MemberStatus,
         file: StaticString = #file, line: UInt = #line
@@ -410,7 +410,7 @@ public extension ClusteredActorSystemsXCTestCase {
     }
 
     /// Assert based on the event stream of `Cluster.Event` that the given `node` was downed or removed.
-    func assertMemberDown(_ eventStreamProbe: ActorTestProbe<Cluster.Event>, node: UniqueNode) throws {
+    public func assertMemberDown(_ eventStreamProbe: ActorTestProbe<Cluster.Event>, node: UniqueNode) throws {
         let events = try eventStreamProbe.fishFor(Cluster.Event.self, within: .seconds(5)) {
             switch $0 {
             case .membershipChange(let change)
@@ -429,7 +429,7 @@ public extension ClusteredActorSystemsXCTestCase {
     /// Asserts the given node is the leader.
     ///
     /// An error is thrown but NOT failing the test; use in pair with `testKit.eventually` to achieve the expected behavior.
-    func assertLeaderNode(
+    public func assertLeaderNode(
         on system: ClusterSystem, is expectedNode: UniqueNode?,
         file: StaticString = #file, line: UInt = #line
     ) throws {
@@ -451,8 +451,8 @@ public extension ClusteredActorSystemsXCTestCase {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Resolve utilities, for resolving remote refs "on" a specific system
 
-public extension ClusteredActorSystemsXCTestCase {
-    func resolveRef<M>(_ system: ClusterSystem, type: M.Type, address: ActorAddress, on targetSystem: ClusterSystem) -> _ActorRef<M> {
+extension ClusteredActorSystemsXCTestCase {
+    public func resolveRef<M>(_ system: ClusterSystem, type: M.Type, address: ActorAddress, on targetSystem: ClusterSystem) -> _ActorRef<M> {
         // DO NOT TRY THIS AT HOME; we do this since we have no receptionist which could offer us references
         // first we manually construct the "right remote path", DO NOT ABUSE THIS IN REAL CODE (please) :-)
         let remoteNode = targetSystem.settings.uniqueBindNode

--- a/Sources/DistributedActorsTestKit/Data+Testing.swift
+++ b/Sources/DistributedActorsTestKit/Data+Testing.swift
@@ -20,9 +20,9 @@ import NIOFoundationCompat
 // FIXME: this is obviously not a good idea
 private let testOnlyAllocator = ByteBufferAllocator()
 
-public extension Data {
+extension Data {
     /// For easier testing, as we want all our assertions etc on ByteBuffers
-    func copyToNewByteBuffer() -> ByteBuffer {
+    public func copyToNewByteBuffer() -> ByteBuffer {
         self._copyToByteBuffer(allocator: testOnlyAllocator)
     }
 }

--- a/Sources/DistributedActorsTestKit/LogCapture.swift
+++ b/Sources/DistributedActorsTestKit/LogCapture.swift
@@ -79,8 +79,8 @@ public final class LogCapture {
     }
 }
 
-public extension LogCapture {
-    struct Settings {
+extension LogCapture {
+    public struct Settings {
         public var minimumLogLevel: Logger.Level = .trace
 
         /// Filter and capture logs only from actors with the following path prefix
@@ -103,8 +103,8 @@ public extension LogCapture {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: XCTest integrations and helpers
 
-public extension LogCapture {
-    func printIfFailed(_ testRun: XCTestRun?) {
+extension LogCapture {
+    public func printIfFailed(_ testRun: XCTestRun?) {
         if let failureCount = testRun?.failureCount, failureCount > 0 {
             print("------------------------------------------------------------------------------------------------------------------------")
             self.printLogs()
@@ -112,7 +112,7 @@ public extension LogCapture {
         }
     }
 
-    func printLogs() {
+    public func printLogs() {
         for log in self.logs {
             var metadataString: String = ""
             var actorPath: String = ""
@@ -249,12 +249,12 @@ struct LogCaptureLogHandler: LogHandler {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Should matchers
 
-public extension LogCapture {
+extension LogCapture {
     /// Asserts that a message matching the query requirements was captures *already* (without waiting for it to appear)
     ///
     /// - Parameter message: can be surrounded like `*what*` to query as a "contains" rather than an == on the captured logs.
     @discardableResult
-    func shouldContain(
+    public func shouldContain(
         prefix: String? = nil,
         message: String? = nil,
         grep: String? = nil,
@@ -336,7 +336,7 @@ public extension LogCapture {
         }
     }
 
-    func grep(_ string: String, metadata metadataQuery: [String: String] = [:]) -> [CapturedLogMessage] {
+    public func grep(_ string: String, metadata metadataQuery: [String: String] = [:]) -> [CapturedLogMessage] {
         self.logs.filter {
             guard "\($0)".contains(string) else {
                 // mismatch, exclude it

--- a/Sources/DistributedActorsTestKit/ShouldMatchers.swift
+++ b/Sources/DistributedActorsTestKit/ShouldMatchers.swift
@@ -41,22 +41,22 @@ public struct TestMatchers<T> {
     }
 }
 
-public extension TestMatchers where T: Equatable {
-    func toEqual(_ expected: T) {
+extension TestMatchers where T: Equatable {
+    public func toEqual(_ expected: T) {
         if self.it != expected {
             let error = self.callSite.notEqualError(got: self.it, expected: expected)
             XCTFail("\(error)", file: self.callSite.file, line: self.callSite.line)
         }
     }
 
-    func toNotEqual(_ unexpectedEqual: T) {
+    public func toNotEqual(_ unexpectedEqual: T) {
         if self.it == unexpectedEqual {
             let error = self.callSite.equalError(got: self.it, unexpectedEqual: unexpectedEqual)
             XCTFail("\(error)", file: self.callSite.file, line: self.callSite.line)
         }
     }
 
-    func toBe<Other>(_ expected: Other.Type) {
+    public func toBe<Other>(_ expected: Other.Type) {
         if !(self.it is Other) {
             let error = self.callSite.notEqualError(got: self.it, expected: expected)
             XCTFail("\(error)", file: self.callSite.file, line: self.callSite.line)
@@ -64,12 +64,12 @@ public extension TestMatchers where T: Equatable {
     }
 }
 
-public extension TestMatchers where T: Collection, T.Element: Equatable {
+extension TestMatchers where T: Collection, T.Element: Equatable {
     /// Asserts that `it` starts with the passed in `prefix`.
     ///
     /// If `it` does not completely start with the passed in `prefix`, the error message will also include the a matching
     /// sub-prefix (if any), so one can easier spot at which position the sequences differ.
-    func toStartWith<PossiblePrefix>(prefix: PossiblePrefix) where PossiblePrefix: Collection, T.Element == PossiblePrefix.Element {
+    public func toStartWith<PossiblePrefix>(prefix: PossiblePrefix) where PossiblePrefix: Collection, T.Element == PossiblePrefix.Element {
         if !self.it.starts(with: prefix) {
             let partialMatch = self.it.commonPrefix(with: prefix)
 
@@ -95,7 +95,7 @@ public extension TestMatchers where T: Collection, T.Element: Equatable {
     }
 
     /// Asserts that `it` ends with the passed in `suffix`.
-    func toEndWith<PossibleSuffix>(suffix: PossibleSuffix) where PossibleSuffix: Collection, T.Element == PossibleSuffix.Element {
+    public func toEndWith<PossibleSuffix>(suffix: PossibleSuffix) where PossibleSuffix: Collection, T.Element == PossibleSuffix.Element {
         if !self.it.reversed().starts(with: suffix.reversed()) {
             let prefix = self.it.prefix(self.it.count - suffix.count)
             // fancy printout:
@@ -125,7 +125,7 @@ public extension TestMatchers where T: Collection, T.Element: Equatable {
     }
 
     /// Asserts that `it` contains the `el` element.
-    func toContain(_ el: T.Element) {
+    public func toContain(_ el: T.Element) {
         if !self.it.contains(el) {
             // fancy printout:
             var m = "Expected \(T.self):\n    "
@@ -142,7 +142,7 @@ public extension TestMatchers where T: Collection, T.Element: Equatable {
         }
     }
 
-    func toNotContain(_ el: T.Element) {
+    public func toNotContain(_ el: T.Element) {
         if self.it.contains(el) {
             // fancy printout:
             var m = "Expected \(T.self):\n    "
@@ -160,7 +160,7 @@ public extension TestMatchers where T: Collection, T.Element: Equatable {
     }
 
     /// Asserts that `it` contains at least one element matching the predicate.
-    func toContain(where predicate: (T.Element) -> Bool) {
+    public func toContain(where predicate: (T.Element) -> Bool) {
         if !self.it.contains(where: { el in predicate(el) }) {
             // fancy printout:
             let m = "Expected [\(it)] to contain element matching predicate"
@@ -171,9 +171,9 @@ public extension TestMatchers where T: Collection, T.Element: Equatable {
     }
 }
 
-public extension TestMatchers where T == String {
+extension TestMatchers where T == String {
     /// Asserts that `it` contains the `subString`.
-    func toContain(_ subString: String, negate: Bool = false) {
+    public func toContain(_ subString: String, negate: Bool = false) {
         let contains = self.it.contains(subString)
         if (negate && contains) || (!negate && !contains) {
             // fancy printout:
@@ -190,34 +190,34 @@ public extension TestMatchers where T == String {
     }
 
     /// Asserts that `it` does NOT contain the `subString`.
-    func toNotContain(_ subString: String) {
+    public func toNotContain(_ subString: String) {
         self.toContain(subString, negate: true)
     }
 }
 
-public extension TestMatchers where T: Comparable {
-    func toBeLessThan(_ expected: T) {
+extension TestMatchers where T: Comparable {
+    public func toBeLessThan(_ expected: T) {
         if !(self.it < expected) {
             let error = self.callSite.error("\(self.it) is not less than \(expected)")
             XCTAssertLessThan(self.it, expected, "\(error)", file: self.callSite.file, line: self.callSite.line)
         }
     }
 
-    func toBeLessThanOrEqual(_ expected: T) {
+    public func toBeLessThanOrEqual(_ expected: T) {
         if !(self.it <= expected) {
             let error = self.callSite.error("\(self.it) is not less than or equal \(expected)")
             XCTAssertLessThanOrEqual(self.it, expected, "\(error)", file: self.callSite.file, line: self.callSite.line)
         }
     }
 
-    func toBeGreaterThan(_ expected: T) {
+    public func toBeGreaterThan(_ expected: T) {
         if !(self.it > expected) {
             let error = self.callSite.error("\(self.it) is not greater than \(expected)")
             XCTAssertGreaterThan(self.it, expected, "\(error)", file: self.callSite.file, line: self.callSite.line)
         }
     }
 
-    func toBeGreaterThanOrEqual(_ expected: T) {
+    public func toBeGreaterThanOrEqual(_ expected: T) {
         if !(self.it >= expected) {
             let error = self.callSite.error("\(self.it) is not greater than or equal \(expected)")
             XCTAssertGreaterThanOrEqual(self.it, expected, "\(error)", file: self.callSite.file, line: self.callSite.line)
@@ -225,9 +225,9 @@ public extension TestMatchers where T: Comparable {
     }
 }
 
-public extension TestMatchers where T: Collection {
+extension TestMatchers where T: Collection {
     /// Asserts that `it` is empty
-    func toBeEmpty() {
+    public func toBeEmpty() {
         if !self.it.isEmpty {
             let m = "Expected [\(it)] to be empty"
 
@@ -237,7 +237,7 @@ public extension TestMatchers where T: Collection {
     }
 
     /// Asserts that `it` is not empty
-    func toBeNotEmpty() {
+    public func toBeNotEmpty() {
         if self.it.isEmpty {
             let m = "Expected [\(it)] to to be non-empty"
 
@@ -247,8 +247,8 @@ public extension TestMatchers where T: Collection {
     }
 }
 
-private extension Collection where Element: Equatable {
-    func commonPrefix<OtherSequence>(with other: OtherSequence) -> SubSequence where OtherSequence: Collection, Element == OtherSequence.Element {
+extension Collection where Element: Equatable {
+    fileprivate func commonPrefix<OtherSequence>(with other: OtherSequence) -> SubSequence where OtherSequence: Collection, Element == OtherSequence.Element {
         var otherIterator = other.makeIterator()
         return self.prefix(while: { el in el == otherIterator.next() })
     }
@@ -256,8 +256,8 @@ private extension Collection where Element: Equatable {
 
 // MARK: assertion extensions on specific types
 
-public extension Optional {
-    func shouldBeNil(file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
+extension Optional {
+    public func shouldBeNil(file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
         if self != nil {
             let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
             let error = callSite.error("Expected nil, got [\(String(describing: self))]")
@@ -265,7 +265,7 @@ public extension Optional {
         }
     }
 
-    func shouldNotBeNil(file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
+    public func shouldNotBeNil(file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
         if self == nil {
             let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
             let error = callSite.error("Expected not nil, got [\(String(describing: self))]")
@@ -274,8 +274,8 @@ public extension Optional {
     }
 }
 
-public extension Set {
-    func shouldEqual(_ other: @autoclosure () -> Self, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
+extension Set {
+    public func shouldEqual(_ other: @autoclosure () -> Self, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
         let callSiteInfo = CallSiteInfo(file: file, line: line, column: column, function: #function)
         let rhs = other()
         if self == rhs {
@@ -305,57 +305,57 @@ public extension Set {
     }
 }
 
-public extension Equatable {
+extension Equatable {
     /// Asserts that the value is equal to the `other` value
-    func shouldEqual(_ other: @autoclosure () -> Self, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
+    public func shouldEqual(_ other: @autoclosure () -> Self, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
         let callSiteInfo = CallSiteInfo(file: file, line: line, column: column, function: #function)
         return TestMatchers(it: self, callSite: callSiteInfo).toEqual(other())
     }
 
     /// Asserts that the value is of the expected Type `T`
-    func shouldBe<T>(_ expectedType: T.Type, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
+    public func shouldBe<T>(_ expectedType: T.Type, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
         let callSiteInfo = CallSiteInfo(file: file, line: line, column: column, function: #function)
         return TestMatchers(it: self, callSite: callSiteInfo).toBe(expectedType)
     }
 
-    func shouldNotEqual(_ other: @autoclosure () -> Self, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
+    public func shouldNotEqual(_ other: @autoclosure () -> Self, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
         let callSiteInfo = CallSiteInfo(file: file, line: line, column: column, function: #function)
         return TestMatchers(it: self, callSite: callSiteInfo).toNotEqual(other())
     }
 }
 
-public extension Bool {
-    func shouldBe(_ expected: Bool, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
+extension Bool {
+    public func shouldBe(_ expected: Bool, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
         let csInfo = CallSiteInfo(file: file, line: line, column: column, function: #function)
         return TestMatchers(it: self, callSite: csInfo).toEqual(expected)
     }
 
-    func shouldBeFalse(file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
+    public func shouldBeFalse(file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
         self.shouldBe(false, file: file, line: line, column: column)
     }
 
-    func shouldBeTrue(file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
+    public func shouldBeTrue(file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
         self.shouldBe(true, file: file, line: line, column: column)
     }
 }
 
-public extension Comparable {
-    func shouldBeLessThan(_ expected: Self, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
+extension Comparable {
+    public func shouldBeLessThan(_ expected: Self, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
         let csInfo = CallSiteInfo(file: file, line: line, column: column, function: #function)
         return TestMatchers(it: self, callSite: csInfo).toBeLessThan(expected)
     }
 
-    func shouldBeLessThanOrEqual(_ expected: Self, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
+    public func shouldBeLessThanOrEqual(_ expected: Self, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
         let csInfo = CallSiteInfo(file: file, line: line, column: column, function: #function)
         return TestMatchers(it: self, callSite: csInfo).toBeLessThanOrEqual(expected)
     }
 
-    func shouldBeGreaterThan(_ expected: Self, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
+    public func shouldBeGreaterThan(_ expected: Self, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
         let csInfo = CallSiteInfo(file: file, line: line, column: column, function: #function)
         return TestMatchers(it: self, callSite: csInfo).toBeGreaterThan(expected)
     }
 
-    func shouldBeGreaterThanOrEqual(_ expected: Self, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
+    public func shouldBeGreaterThanOrEqual(_ expected: Self, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
         let csInfo = CallSiteInfo(file: file, line: line, column: column, function: #function)
         return TestMatchers(it: self, callSite: csInfo).toBeGreaterThanOrEqual(expected)
     }
@@ -364,55 +364,57 @@ public extension Comparable {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Collection `should*` matchers
 
-public extension Collection {
-    func shouldBeEmpty(file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
+extension Collection {
+    public func shouldBeEmpty(file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
         let callSiteInfo = CallSiteInfo(file: file, line: line, column: column, function: #function)
         return TestMatchers(it: self, callSite: callSiteInfo).toBeEmpty() // TODO: lazy impl, should get "expected empty" messages etc
     }
 
-    func shouldBeNotEmpty(file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
+    public func shouldBeNotEmpty(file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
         let callSiteInfo = CallSiteInfo(file: file, line: line, column: column, function: #function)
         return TestMatchers(it: self, callSite: callSiteInfo).toBeNotEmpty() // TODO: lazy impl, should get "expected non-empty" messages etc
     }
 }
 
-public extension Collection where Element: Equatable {
-    func shouldStartWith<PossiblePrefix>(prefix: PossiblePrefix, file: StaticString = #file, line: UInt = #line, column: UInt = #column)
-        where PossiblePrefix: Collection, Element == PossiblePrefix.Element {
+extension Collection where Element: Equatable {
+    public func shouldStartWith<PossiblePrefix>(prefix: PossiblePrefix, file: StaticString = #file, line: UInt = #line, column: UInt = #column)
+        where PossiblePrefix: Collection, Element == PossiblePrefix.Element
+    {
         let csInfo = CallSiteInfo(file: file, line: line, column: column, function: #function)
         return TestMatchers(it: self, callSite: csInfo).toStartWith(prefix: prefix)
     }
 
-    func shouldEndWith<PossibleSuffix>(suffix: PossibleSuffix, file: StaticString = #file, line: UInt = #line, column: UInt = #column)
-        where PossibleSuffix: Collection, Element == PossibleSuffix.Element {
+    public func shouldEndWith<PossibleSuffix>(suffix: PossibleSuffix, file: StaticString = #file, line: UInt = #line, column: UInt = #column)
+        where PossibleSuffix: Collection, Element == PossibleSuffix.Element
+    {
         let csInfo = CallSiteInfo(file: file, line: line, column: column, function: #function)
         return TestMatchers(it: self, callSite: csInfo).toEndWith(suffix: suffix)
     }
 
-    func shouldContain(_ el: Element, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
+    public func shouldContain(_ el: Element, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
         let csInfo = CallSiteInfo(file: file, line: line, column: column, function: #function)
         return TestMatchers(it: self, callSite: csInfo).toContain(el)
     }
 
-    func shouldNotContain(_ el: Element, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
+    public func shouldNotContain(_ el: Element, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
         let csInfo = CallSiteInfo(file: file, line: line, column: column, function: #function)
         return TestMatchers(it: self, callSite: csInfo).toNotContain(el)
     }
 
     /// Applies the `where` predicate while trying to locate at least one element in the collection.
-    func shouldContain(where predicate: (Element) -> Bool, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
+    public func shouldContain(where predicate: (Element) -> Bool, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
         let csInfo = CallSiteInfo(file: file, line: line, column: column, function: #function)
         return TestMatchers(it: self, callSite: csInfo).toContain(where: { predicate($0) })
     }
 }
 
-public extension String {
-    func shouldContain(_ el: String, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
+extension String {
+    public func shouldContain(_ el: String, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
         let csInfo = CallSiteInfo(file: file, line: line, column: column, function: #function)
         return TestMatchers(it: self, callSite: csInfo).toContain(el)
     }
 
-    func shouldNotContain(_ el: String, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
+    public func shouldNotContain(_ el: String, file: StaticString = #file, line: UInt = #line, column: UInt = #column) {
         let csInfo = CallSiteInfo(file: file, line: line, column: column, function: #function)
         return TestMatchers(it: self, callSite: csInfo).toNotContain(el)
     }

--- a/Sources/DistributedActorsTestKit/TestProbes+Receptionist.swift
+++ b/Sources/DistributedActorsTestKit/TestProbes+Receptionist.swift
@@ -18,11 +18,11 @@ import XCTest
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: ActorTestProbe: Receptionist expectations
 
-public extension ActorTestProbe where Message == Reception.Listing<_ActorRef<String>> {
+extension ActorTestProbe where Message == Reception.Listing<_ActorRef<String>> {
     /// Expect a listing eventually to contain only the `expected` references.
     ///
     /// Lack of listing emitted during the `within` period also yields a test-case failing error.
-    func eventuallyExpectListing(
+    public func eventuallyExpectListing(
         expected: Set<_ActorRef<String>>, within timeout: TimeAmount,
         verbose: Bool = false,
         file: StaticString = #file, line: UInt = #line, column: UInt = #column

--- a/Sources/DistributedActorsTestKit/TestProbes.swift
+++ b/Sources/DistributedActorsTestKit/TestProbes.swift
@@ -162,14 +162,14 @@ extension ActorTestProbe: CustomStringConvertible {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Expecting messages
 
-public extension ActorTestProbe {
+extension ActorTestProbe {
     /// Expects a message to arrive at the TestProbe and returns it for further assertions.
     /// See also the `expectMessage(_:Message)` overload which provides automatic equality checking.
     ///
     /// - SeeAlso: `maybeExpectMessage(file:line:column:)` which does not fail upon encountering no message within the timeout.
     ///
     /// - Warning: Blocks the current thread until the `expectationTimeout` is exceeded or a message is received by the actor.
-    func expectMessage(file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws -> Message {
+    public func expectMessage(file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws -> Message {
         try self.expectMessage(within: self.expectationTimeout, file: file, line: line, column: column)
     }
 
@@ -178,7 +178,7 @@ public extension ActorTestProbe {
     /// - SeeAlso: `maybeExpectMessage(within:file:line:column:)` which does not fail upon encountering no message within the timeout.
     ///
     /// - Warning: Blocks the current thread until the `timeout` is exceeded or a message is received by the actor.
-    func expectMessage(within timeout: TimeAmount, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws -> Message {
+    public func expectMessage(within timeout: TimeAmount, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws -> Message {
         let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
         do {
             return try self.receiveMessage(within: timeout)
@@ -209,7 +209,7 @@ public extension ActorTestProbe {
     ///
     /// Once `MessageFishingDirective.catchComplete` or `MessageFishingDirective.complete` is returned,
     /// the function returns all so-far accumulated messages.
-    func fishFor<CaughtMessage>(
+    public func fishFor<CaughtMessage>(
         _ type: CaughtMessage.Type, within timeout: TimeAmount,
         file: StaticString = #file, line: UInt = #line, column: UInt = #column,
         _ fisher: (Message) throws -> FishingDirective<CaughtMessage>
@@ -240,14 +240,14 @@ public extension ActorTestProbe {
         return caughtMessages
     }
 
-    enum FishingDirective<CaughtMessage> {
+    public enum FishingDirective<CaughtMessage> {
         case catchContinue(CaughtMessage)
         case catchComplete(CaughtMessage)
         case ignore
         case complete
     }
 
-    enum MessageFishingError: Error {
+    public enum MessageFishingError: Error {
         case noMessagesCaught
     }
 
@@ -259,7 +259,7 @@ public extension ActorTestProbe {
     ///
     /// Once `MessageFishingDirective.catchComplete` or `MessageFishingDirective.complete` is returned,
     /// the function returns all so-far accumulated messages.
-    func fishForMessages(
+    public func fishForMessages(
         within timeout: TimeAmount,
         file: StaticString = #file, line: UInt = #line, column: UInt = #column,
         _ fisher: (Message) throws -> MessageFishingDirective
@@ -278,7 +278,7 @@ public extension ActorTestProbe {
         }
     }
 
-    enum MessageFishingDirective {
+    public enum MessageFishingDirective {
         case catchContinue
         case catchComplete
         case ignore
@@ -286,7 +286,7 @@ public extension ActorTestProbe {
     }
 }
 
-public extension ActorTestProbe {
+extension ActorTestProbe {
     /// Expects a message to "maybe" arrive at the `ActorTestProbe` and returns it for further assertions,
     /// if no message arrives within the timeout (by default `expectationTimeout`) a `nil` value is returned.
     ///
@@ -296,7 +296,7 @@ public extension ActorTestProbe {
     /// - SeeAlso: `expectMessage(file:line:column)` that throws and fails if no message is encountered during the timeout.
     ///
     /// - Warning: Blocks the current thread until the `expectationTimeout` is exceeded or a message is received by the actor.
-    func maybeExpectMessage() throws -> Message? {
+    public func maybeExpectMessage() throws -> Message? {
         try self.maybeExpectMessage(within: self.expectationTimeout)
     }
 
@@ -309,7 +309,7 @@ public extension ActorTestProbe {
     /// - SeeAlso: `expectMessage(within:file:line:column)` that throws and fails if no message is encountered during the timeout.
     ///
     /// - Warning: Blocks the current thread until the `timeout` is exceeded or a message is received by the actor.
-    func maybeExpectMessage(within timeout: TimeAmount) throws -> Message? {
+    public func maybeExpectMessage(within timeout: TimeAmount) throws -> Message? {
         do {
             return try self.maybeReceiveMessage(within: timeout)
         } catch {
@@ -331,7 +331,7 @@ public extension ActorTestProbe {
     }
 }
 
-public extension ActorTestProbe where Message: Equatable {
+extension ActorTestProbe where Message: Equatable {
     /// Fails in nice readable ways:
     ///
     /// - Warning: Blocks the current thread until the `expectationTimeout` is exceeded or an message is received by the actor.
@@ -344,11 +344,11 @@ public extension ActorTestProbe where Message: Equatable {
     ///                ^~~~~~~~~~~~~~
     ///     error: Did not receive expected [awaiting-forever]:String within [1s], error: noMessagesInQueue
     ///
-    func expectMessage(_ message: Message, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
+    public func expectMessage(_ message: Message, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
         try self.expectMessage(message, within: self.expectationTimeout, file: file, line: line, column: column)
     }
 
-    func expectMessage(_ message: Message, within timeout: TimeAmount, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
+    public func expectMessage(_ message: Message, within timeout: TimeAmount, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
         let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
         do {
             let receivedMessage = try self.receiveMessage(within: timeout)
@@ -362,11 +362,11 @@ public extension ActorTestProbe where Message: Equatable {
         }
     }
 
-    func expectMessageType<T>(_ type: T.Type, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
+    public func expectMessageType<T>(_ type: T.Type, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
         try self.expectMessageType(type, within: self.expectationTimeout, file: file, line: line, column: column)
     }
 
-    func expectMessageType<T>(_ type: T.Type, within timeout: TimeAmount, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
+    public func expectMessageType<T>(_ type: T.Type, within timeout: TimeAmount, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
         let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
 
         let receivedMessage = try self.receiveMessage(within: timeout)
@@ -380,12 +380,12 @@ public extension ActorTestProbe where Message: Equatable {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Expecting multiple messages
 
-public extension ActorTestProbe {
+extension ActorTestProbe {
     /// Expects multiple messages to arrive at the TestProbe and returns it for further assertions.
     /// See also the `expectMessagesInAnyOrder([Message])` overload which provides automatic equality checking.
     ///
     /// - Warning: Blocks the current thread until the `expectationTimeout` is exceeded or an message is received by the actor.
-    func expectMessages(count: Int, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws -> [Message] {
+    public func expectMessages(count: Int, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws -> [Message] {
         try self.expectMessages(count: count, within: self.expectationTimeout, file: file, line: line, column: column)
     }
 
@@ -393,7 +393,7 @@ public extension ActorTestProbe {
     /// See also the `expectMessagesInAnyOrder([Message])` overload which provides automatic equality checking.
     ///
     /// - Warning: Blocks the current thread until the `expectationTimeout` is exceeded or an message is received by the actor.
-    func expectMessages(count: Int, within timeout: TimeAmount, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws -> [Message] {
+    public func expectMessages(count: Int, within timeout: TimeAmount, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws -> [Message] {
         let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
 
         let deadline = Deadline.fromNow(timeout)
@@ -427,12 +427,12 @@ public extension ActorTestProbe {
     }
 }
 
-public extension ActorTestProbe where Message: Equatable {
-    func expectMessagesInAnyOrder(_ _messages: [Message], file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
+extension ActorTestProbe where Message: Equatable {
+    public func expectMessagesInAnyOrder(_ _messages: [Message], file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
         try self.expectMessagesInAnyOrder(_messages, within: self.expectationTimeout, file: file, line: line, column: column)
     }
 
-    func expectMessagesInAnyOrder(_ _messages: [Message], within timeout: TimeAmount, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
+    public func expectMessagesInAnyOrder(_ _messages: [Message], within timeout: TimeAmount, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
         var messages = _messages
         let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
         var received: [Message] = []
@@ -457,13 +457,13 @@ public extension ActorTestProbe where Message: Equatable {
 // ==== ------------------------------------------------------------------------------------------------------------
 // MARK: Clearing buffered messages (for expectations)
 
-public extension ActorTestProbe {
+extension ActorTestProbe {
     /// Clear any buffered messages from the probe's queue.
     ///
     /// Blocks until no more message remains to be dropped.
     /// Note that if the probe is concurrently being sent messages as it is clearing them, this may result in spinning forever,
     /// or for in-deterministic amounts of time.
-    func clearMessages() {
+    public func clearMessages() {
         do {
             while try self.maybeExpectMessage() != nil {
                 () // dropping messages
@@ -490,10 +490,10 @@ extension ActorTestProbe: _ReceivesMessages {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: TestProbes can intercept all messages send to a _Behavior
 
-public extension ActorTestProbe {
+extension ActorTestProbe {
     // TODO: would be nice to be able to also intercept system messages hm...
 
-    func interceptAllMessages(sentTo behavior: _Behavior<Message>) -> _Behavior<Message> {
+    public func interceptAllMessages(sentTo behavior: _Behavior<Message>) -> _Behavior<Message> {
         let interceptor: _Interceptor<Message> = ProbeInterceptor(probe: self)
         return .intercept(behavior: behavior, with: interceptor)
     }
@@ -507,13 +507,13 @@ public final class ProbeInterceptor<Message: ActorMessage>: _Interceptor<Message
         self.probe = probe
     }
 
-    public final override func interceptMessage(target: _Behavior<Message>, context: _ActorContext<Message>, message: Message) throws -> _Behavior<Message> {
+    override public final func interceptMessage(target: _Behavior<Message>, context: _ActorContext<Message>, message: Message) throws -> _Behavior<Message> {
         self.probe.tell(message)
         return try target.interpretMessage(context: context, message: message)
     }
 }
 
-public extension ActorTestProbe {
+extension ActorTestProbe {
     @discardableResult
     private func within<T>(_ timeout: TimeAmount, _ block: () throws -> T) throws -> T {
         // FIXME: implement by scheduling checks rather than spinning
@@ -548,7 +548,7 @@ public extension ActorTestProbe {
     ///
     ///     guard ... else { throw p.failure("failed to extract expected information") }
     ///     guard case let .spawned(child) = try p.expectMessage() else { throw p.failure() }
-    func error(_ message: String? = nil, file: StaticString = #file, line: UInt = #line, column: UInt = #column) -> Error {
+    public func error(_ message: String? = nil, file: StaticString = #file, line: UInt = #line, column: UInt = #column) -> Error {
         let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
 
         var fullMessage: String = message ?? "ActorTestProbe failure."
@@ -570,7 +570,7 @@ public extension ActorTestProbe {
     ///
     /// The callback MAY return `nil` in order to signal "this is not the expected message", or throw an error itself.
     // TODO: find a better name; it is not exactly "fish for message" though, that can ignore messages for a while, this one does not
-    func expectMessageMatching<T>(file: StaticString = #file, line: UInt = #line, column: UInt = #column, _ matchExtract: (Message) throws -> T?) throws -> T {
+    public func expectMessageMatching<T>(file: StaticString = #file, line: UInt = #line, column: UInt = #column, _ matchExtract: (Message) throws -> T?) throws -> T {
         let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
         let timeout = self.expectationTimeout
         do {
@@ -591,12 +591,12 @@ public extension ActorTestProbe {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Expecting no message/signal within a timeout
 
-public extension ActorTestProbe {
+extension ActorTestProbe {
     /// Asserts that no message is received by the probe during the specified timeout.
     /// Useful for making sure that after some "terminal" message no other messages are sent.
     ///
     /// Warning: The method will block the current thread for the specified timeout.
-    func expectNoMessage(for timeout: TimeAmount, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
+    public func expectNoMessage(for timeout: TimeAmount, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
         let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
         if let message = self.messagesQueue.poll(timeout) {
             let message = "Received unexpected message [\(message)]:\(type(of: message)). Did not expect to receive any messages for [\(timeout.prettyDescription)]."
@@ -607,7 +607,7 @@ public extension ActorTestProbe {
     /// Asserts that no termination signals (specifically) are received by the probe during the specified timeout.
     ///
     /// Warning: The method will block the current thread for the specified timeout.
-    func expectNoTerminationSignal(for timeout: TimeAmount, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
+    public func expectNoTerminationSignal(for timeout: TimeAmount, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
         let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
         if let termination = self.terminationsQueue.poll(timeout) {
             let message = "Received unexpected termination [\(termination)]. Did not expect to receive any termination for [\(timeout.prettyDescription)]."
@@ -619,9 +619,9 @@ public extension ActorTestProbe {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Expecting signals
 
-public extension ActorTestProbe {
+extension ActorTestProbe {
     /// Expects a signal to be enqueued to this actor within the default `expectationTimeout`.
-    func expectSignal(file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws -> _SystemMessage {
+    public func expectSignal(file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws -> _SystemMessage {
         let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
 
         let maybeGot: _SystemMessage? = self.signalQueue.poll(self.expectationTimeout)
@@ -632,7 +632,7 @@ public extension ActorTestProbe {
     }
 
     /// Expects the `expected` system message
-    func expectSignal(expected: _SystemMessage, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
+    public func expectSignal(expected: _SystemMessage, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
         let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
 
         let got: _SystemMessage = try self.expectSignal(file: file, line: line, column: column)
@@ -644,7 +644,7 @@ public extension ActorTestProbe {
 
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Death watch methods
-public extension ActorTestProbe {
+extension ActorTestProbe {
     /// Instructs this probe to watch the passed in actor.
     /// The `watchee` actor is from now on being watched and we will receive `.terminated` signals about it.
     ///
@@ -656,7 +656,7 @@ public extension ActorTestProbe {
     /// - Returns: reference to the passed in `watchee` actor.
     /// - SeeAlso: `DeathWatch`
     @discardableResult
-    func watch<M>(_ watchee: _ActorRef<M>, file: String = #file, line: UInt = #line) -> _ActorRef<M> {
+    public func watch<M>(_ watchee: _ActorRef<M>, file: String = #file, line: UInt = #line) -> _ActorRef<M> {
         self.internalRef.tell(ProbeCommands.watchCommand(who: watchee.asAddressable, file: file, line: line))
         return watchee
     }
@@ -668,7 +668,7 @@ public extension ActorTestProbe {
     /// Without this it may happen that we asked the probe to watch an actor, and send a message to the actor directly,
     /// and our direct message arrives first, before the watch at the destination, causing potentially confusing behavior
     /// in some very ordering delicate testing scenarios.
-    func forward<Message>(_ message: Message, to target: _ActorRef<Message>, file: String = #file, line: UInt = #line) where Message: Codable {
+    public func forward<Message>(_ message: Message, to target: _ActorRef<Message>, file: String = #file, line: UInt = #line) where Message: Codable {
         self.internalRef.tell(ProbeCommands.forwardCommand(send: { () in target.tell(message, file: file, line: line) }))
     }
 
@@ -682,7 +682,7 @@ public extension ActorTestProbe {
     /// - Returns: reference to the passed in watchee actor.
     /// - SeeAlso: `DeathWatch`
     @discardableResult
-    func unwatch<M>(_ watchee: _ActorRef<M>) -> _ActorRef<M> {
+    public func unwatch<M>(_ watchee: _ActorRef<M>) -> _ActorRef<M> {
         self.internalRef.tell(ProbeCommands.unwatchCommand(who: watchee.asAddressable))
         return watchee
     }
@@ -695,7 +695,7 @@ public extension ActorTestProbe {
     /// - SeeAlso: `DeathWatch`
     @discardableResult
     // TODO: expectTermination(of: ...) maybe nicer wording?
-    func expectTerminated<T>(_ ref: _ActorRef<T>, within timeout: TimeAmount? = nil, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws -> _Signals.Terminated {
+    public func expectTerminated<T>(_ ref: _ActorRef<T>, within timeout: TimeAmount? = nil, file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws -> _Signals.Terminated {
         let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
         let timeout = timeout ?? self.expectationTimeout
 
@@ -715,7 +715,7 @@ public extension ActorTestProbe {
     /// - ***Warning**: Remember to first `watch` the actors you are expecting termination for,
     ///                 otherwise the termination signal will never be received.
     /// - SeeAlso: `DeathWatch`
-    func expectTerminatedInAnyOrder(_ refs: [AddressableActorRef], file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
+    public func expectTerminatedInAnyOrder(_ refs: [AddressableActorRef], file: StaticString = #file, line: UInt = #line, column: UInt = #column) throws {
         let callSite = CallSiteInfo(file: file, line: line, column: column, function: #function)
         var pathSet: Set<ActorAddress> = Set(refs.map(\.address))
 
@@ -736,12 +736,12 @@ public extension ActorTestProbe {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Test probe Lifecycle control
 
-public extension ActorTestProbe {
+extension ActorTestProbe {
     /// Stops the test probe, asynchronously.
     ///
     /// - **Warning**: Since this action is asynchronous, in order to be certain that a probe has terminated before performing another task,
     ///              you may need to watch and expect it to terminate before moving on.
-    func stop() {
+    public func stop() {
         // we send the stop command as normal message in order to not "overtake" other commands that were sent to it
         // not strictly required, but can yield more predictable results when used from tests after all
         self.internalRef.tell(.stopCommand)

--- a/Sources/SwiftBenchmarkTools/ArgParser.swift
+++ b/Sources/SwiftBenchmarkTools/ArgParser.swift
@@ -207,7 +207,7 @@ class ArgumentParser<U> {
     ) {
         self.arguments.append(
             Argument(name: name, help: help)
-            { try self.parseArgument(name, property, defaultValue, parser) }
+                { try self.parseArgument(name, property, defaultValue, parser) }
         )
     }
 

--- a/Sources/SwiftBenchmarkTools/DriverUtils.swift
+++ b/Sources/SwiftBenchmarkTools/DriverUtils.swift
@@ -381,11 +381,11 @@ public final class Timer {
     #endif
 }
 
-public extension UInt64 {
-    var nanoseconds: Int { Int(self) }
-    var microseconds: Int { Int(self / 1000) }
-    var milliseconds: Int { Int(self / 1000 / 1000) }
-    var seconds: Int { Int(self / 1000 / 1000 / 1000) }
+extension UInt64 {
+    public var nanoseconds: Int { Int(self) }
+    public var microseconds: Int { Int(self / 1000) }
+    public var milliseconds: Int { Int(self / 1000 / 1000) }
+    public var seconds: Int { Int(self / 1000 / 1000 / 1000) }
 }
 
 enum TimeUnit: String {

--- a/Tests/DistributedActorsTests/BehaviorMatchers.swift
+++ b/Tests/DistributedActorsTests/BehaviorMatchers.swift
@@ -17,12 +17,12 @@ import DistributedActorsTestKit
 import XCTest
 
 /// Internal testing extensions allowing inspecting behavior internals
-internal extension _Behavior {
+extension _Behavior {
     /// Similar to canonicalize but counts the nesting depth, be it in setup calls or interceptors.
     ///
     // TODO: Implemented recursively and may stack overflow on insanely deep structures.
     // TODO: not all cases are covered, only enough to implement specific tests currently is.
-    func nestingDepth(context: _ActorContext<Message>) throws -> Int {
+    internal func nestingDepth(context: _ActorContext<Message>) throws -> Int {
         func nestingDepth0(_ b: _Behavior<Message>) throws -> Int {
             switch b.underlying {
             case .setup(let onStart):
@@ -55,7 +55,7 @@ internal extension _Behavior {
     //       )
     // TODO: Implemented recursively and may stack overflow on insanely deep structures.
     // TODO: not all cases are covered, only enough to implement specific tests currently is.
-    func prettyFormat(context: _ActorContext<Message>, padWith padding: String = "  ") throws -> String {
+    internal func prettyFormat(context: _ActorContext<Message>, padWith padding: String = "  ") throws -> String {
         func prettyFormat0(_ b: _Behavior<Message>, depth: Int) throws -> String {
             let pad = String(repeating: padding, count: depth)
 

--- a/Tests/DistributedActorsTests/Cluster/MembershipGossipLogicSimulationTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/MembershipGossipLogicSimulationTests.swift
@@ -426,8 +426,8 @@ final class MembershipGossipLogicSimulationTests: ClusteredActorSystemsXCTestCas
     }
 }
 
-private extension MembershipGossipLogic {
-    var nodeName: String {
+extension MembershipGossipLogic {
+    fileprivate var nodeName: String {
         self.localNode.node.systemName
     }
 }

--- a/Tests/DistributedActorsTests/Cluster/Reception/OpLogDistributedReceptionistClusteredTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/Reception/OpLogDistributedReceptionistClusteredTests.swift
@@ -46,8 +46,8 @@ distributed actor StringForwarder: CustomStringConvertible {
     }
 }
 
-private extension DistributedReception.Key {
-    static var stringForwarders: DistributedReception.Key<StringForwarder> {
+extension DistributedReception.Key {
+    fileprivate static var stringForwarders: DistributedReception.Key<StringForwarder> {
         "stringForwarders"
     }
 }

--- a/Tests/DistributedActorsTests/MetricsTestKit/MetricsTestKit.swift
+++ b/Tests/DistributedActorsTests/MetricsTestKit/MetricsTestKit.swift
@@ -121,15 +121,15 @@ extension TestMetrics.FullKey: Hashable {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Assertions
 
-public extension TestMetrics {
+extension TestMetrics {
     // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: Counter
 
-    func expectCounter(_ metric: Counter) throws -> TestCounter {
+    public func expectCounter(_ metric: Counter) throws -> TestCounter {
         metric.handler as! TestCounter
     }
 
-    func expectCounter(_ label: String, _ dimensions: [(String, String)] = []) throws -> TestCounter {
+    public func expectCounter(_ label: String, _ dimensions: [(String, String)] = []) throws -> TestCounter {
         let counter: CounterHandler
         if let c: CounterHandler = self.counters[.init(label: label, dimensions: dimensions)] {
             counter = c
@@ -147,22 +147,22 @@ public extension TestMetrics {
     // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: Gauge
 
-    func expectGauge(_ metric: Gauge) throws -> TestRecorder {
+    public func expectGauge(_ metric: Gauge) throws -> TestRecorder {
         try self.expectRecorder(metric)
     }
 
-    func expectGauge(_ label: String, _ dimensions: [(String, String)] = []) throws -> TestRecorder {
+    public func expectGauge(_ label: String, _ dimensions: [(String, String)] = []) throws -> TestRecorder {
         try self.expectRecorder(label, dimensions)
     }
 
     // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: Recorder
 
-    func expectRecorder(_ metric: Recorder) throws -> TestRecorder {
+    public func expectRecorder(_ metric: Recorder) throws -> TestRecorder {
         metric.handler as! TestRecorder
     }
 
-    func expectRecorder(_ label: String, _ dimensions: [(String, String)] = []) throws -> TestRecorder {
+    public func expectRecorder(_ label: String, _ dimensions: [(String, String)] = []) throws -> TestRecorder {
         guard let counter = self.recorders[.init(label: label, dimensions: dimensions)] else {
             throw TestMetricsError.missingMetric(label: label, dimensions: [])
         }
@@ -176,11 +176,11 @@ public extension TestMetrics {
     // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: Timer
 
-    func expectTimer(_ metric: Timer) throws -> TestTimer {
+    public func expectTimer(_ metric: Timer) throws -> TestTimer {
         metric.handler as! TestTimer
     }
 
-    func expectTimer(_ label: String, _ dimensions: [(String, String)] = []) throws -> TestTimer {
+    public func expectTimer(_ label: String, _ dimensions: [(String, String)] = []) throws -> TestTimer {
         guard let counter = self.timers[.init(label: label, dimensions: dimensions)] else {
             throw TestMetricsError.missingMetric(label: label, dimensions: [])
         }
@@ -406,8 +406,8 @@ public final class TestTimer: TestMetric, TimerHandler, Equatable, CustomStringC
     }
 }
 
-private extension NSLock {
-    func withLock<T>(_ body: () -> T) -> T {
+extension NSLock {
+    fileprivate func withLock<T>(_ body: () -> T) -> T {
         self.lock()
         defer {
             self.unlock()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ RUN echo 'export PATH="$HOME/.tools:$PATH"' >> $HOME/.profile
 
 # swiftformat (until part of the toolchain)
 
-ARG swiftformat_version=0.44.6
+ARG swiftformat_version=0.48.8
 RUN git clone --branch $swiftformat_version --depth 1 https://github.com/nicklockwood/SwiftFormat $HOME/.tools/swift-format
 RUN cd $HOME/.tools/swift-format && swift build -c release
 RUN ln -s $HOME/.tools/swift-format/.build/release/swiftformat $HOME/.tools/swiftformat


### PR DESCRIPTION
Resolves https://github.com/apple/swift-distributed-actors/issues/281 which is important so we don't accidentally introduce public API.

The rules are in line with what HTTPClient also does about such: https://github.com/swift-server/async-http-client/commit/e5022468bb41faf0678c9ce9622edf2c1ddf9e64

Sadly it also caused some churn... but better now than later.