### PR TITLE
[testkit] awaitLogContaining is useful also without inspecting result

### DIFF
--- a/Sources/DistributedActorsTestKit/LogCapture.swift
+++ b/Sources/DistributedActorsTestKit/LogCapture.swift
@@ -62,6 +62,7 @@ public final class LogCapture {
     ///
     /// Returns: first log message that matches text predicate (with naive "contains" check).
     /// Throws: an ``EventuallyError`` when the deadline is exceeded without matching a log message.
+    @discardableResult
     public func awaitLogContaining(
         _ testKit: ActorTestKit, text: String,
         within: TimeAmount = .seconds(3),


### PR DESCRIPTION
### Motivation:

Less warnings in code

### Modifications:

We can use this method to just wait for a log to appear, without inspecting it.

