### PR TITLE
Must not touch EL based APIs after shutting down the ELG

### DIFF
--- a/Sources/DistributedActors/ClusterSystem.swift
+++ b/Sources/DistributedActors/ClusterSystem.swift
@@ -454,7 +454,7 @@ public class ClusterSystem: DistributedActorSystem, @unchecked Sendable {
 
             self._associationTombstoneCleanupTask?.cancel()
             self._associationTombstoneCleanupTask = nil
-            
+
             do {
                 try self._eventLoopGroup.syncShutdownGracefully()
                 // self._receptionistRef = self.deadLetters.adapted()

--- a/Sources/DistributedActors/ClusterSystem.swift
+++ b/Sources/DistributedActors/ClusterSystem.swift
@@ -452,6 +452,9 @@ public class ClusterSystem: DistributedActorSystem, @unchecked Sendable {
             self.systemProvider.stopAll()
             self.dispatcher.shutdown()
 
+            self._associationTombstoneCleanupTask?.cancel()
+            self._associationTombstoneCleanupTask = nil
+            
             do {
                 try self._eventLoopGroup.syncShutdownGracefully()
                 // self._receptionistRef = self.deadLetters.adapted()
@@ -467,8 +470,6 @@ public class ClusterSystem: DistributedActorSystem, @unchecked Sendable {
                  // self._serialization = nil // FIXME: need to release serialization
              }
              */
-            self._associationTombstoneCleanupTask?.cancel()
-            self._associationTombstoneCleanupTask = nil
             _ = self._clusterStore.storeIfNilThenLoad(Box(nil))
 
             self.shutdownReceptacle.offerOnce(nil)


### PR DESCRIPTION
Resolves  #922

The newly added repeated task that does tombstone flushing was cancelled AFTER the ELG shutdown, leading to the  `ERROR: Cannot schedule tasks on an EventLoop that has already shut down. This will be upgraded to a forced crash in future SwiftNIO versions.` error explained in Don't schedule futures on terminated EventLoop #922.

We must not touch ELG related APIs after shutting down; A cancel seems to create a future as well, so it was causing issues.


FYI @drexin 