### PR TITLE
Bring back ClusterSystemSettings.enabled

### DIFF
--- a/Sources/ActorSingletonPlugin/ActorSingletonProxy.swift
+++ b/Sources/ActorSingletonPlugin/ActorSingletonProxy.swift
@@ -67,12 +67,18 @@ internal class ActorSingletonProxy<Message: ActorMessage> {
 
     var behavior: _Behavior<Message> {
         .setup { context in
-            // Subscribe to `Cluster.Event` in order to update `targetNode`
-            context.system.cluster.events.subscribe(
-                context.subReceive(_SubReceiveId(id: "clusterEvent-\(context.name)"), Cluster.Event.self) { event in
-                    try self.receiveClusterEvent(context, event)
-                }
-            )
+            if context.system.settings.enabled {
+                // Subscribe to `Cluster.Event` in order to update `targetNode`
+                context.system.cluster.events.subscribe(
+                    context.subReceive(_SubReceiveId(id: "clusterEvent-\(context.name)"), Cluster.Event.self) { event in
+                        try self.receiveClusterEvent(context, event)
+                    }
+                )
+            } else {
+                // Run singleton on this node if clustering is not enabled
+                context.log.debug("Clustering not enabled. Taking over singleton.")
+                try self.takeOver(context, from: nil)
+            }
 
             return _Behavior<Message>.receiveMessage { message in
                 try self.forwardOrStash(context, message: message)

--- a/Sources/DistributedActors/ActorRefProvider.swift
+++ b/Sources/DistributedActors/ActorRefProvider.swift
@@ -59,6 +59,8 @@ internal struct RemoteActorRefProvider: _ActorRefProvider {
         cluster: ClusterShell,
         localProvider: LocalActorRefProvider
     ) {
+        precondition(settings.enabled, "Remote actor provider should only be used when clustering is enabled")
+
         self.localNode = settings.uniqueBindNode
         self.cluster = cluster
         self.localProvider = localProvider

--- a/Sources/DistributedActors/ClusterSystem.swift
+++ b/Sources/DistributedActors/ClusterSystem.swift
@@ -251,7 +251,11 @@ public class ClusterSystem: DistributedActorSystem, @unchecked Sendable {
             settings.logging._logger.logLevel = settings.logging.logLevel
         }
 
-        settings.logging._logger[metadataKey: "cluster/node"] = "\(settings.uniqueBindNode)"
+        if settings.enabled {
+            settings.logging._logger[metadataKey: "cluster/node"] = "\(settings.uniqueBindNode)"
+        } else {
+            settings.logging._logger[metadataKey: "cluster/node"] = "\(self.name)"
+        }
 
         self.settings = settings
         self.log = settings.logging.baseLogger
@@ -276,47 +280,69 @@ public class ClusterSystem: DistributedActorSystem, @unchecked Sendable {
         // dead letters init
         self._deadLetters = _ActorRef(.deadLetters(.init(self.log, address: ActorAddress._deadLetters(on: settings.uniqueBindNode), system: self)))
 
-        let cluster = ClusterShell(settings: settings)
-        _ = self._clusterStore.storeIfNilThenLoad(Box(cluster))
-
         // actor providers
         let localUserProvider = LocalActorRefProvider(root: _Guardian(parent: theOne, name: "user", localNode: settings.uniqueBindNode, system: self))
         let localSystemProvider = LocalActorRefProvider(root: _Guardian(parent: theOne, name: "system", localNode: settings.uniqueBindNode, system: self))
         // TODO: want to reconcile those into one, and allow /dead as well
-        let effectiveUserProvider = RemoteActorRefProvider(settings: settings, cluster: cluster, localProvider: localUserProvider)
-        let effectiveSystemProvider = RemoteActorRefProvider(settings: settings, cluster: cluster, localProvider: localSystemProvider)
+        var effectiveUserProvider: _ActorRefProvider = localUserProvider
+        var effectiveSystemProvider: _ActorRefProvider = localSystemProvider
+
+        if settings.enabled {
+            let cluster = ClusterShell(settings: settings)
+            _ = self._clusterStore.storeIfNilThenLoad(Box(cluster))
+            effectiveUserProvider = RemoteActorRefProvider(settings: settings, cluster: cluster, localProvider: localUserProvider)
+            effectiveSystemProvider = RemoteActorRefProvider(settings: settings, cluster: cluster, localProvider: localSystemProvider)
+        }
 
         initializationLock.withWriterLockVoid {
             self.systemProvider = effectiveSystemProvider
             self.userProvider = effectiveUserProvider
         }
 
-        // try!-safe, this will spawn under /system/... which we have full control over,
-        // and there /system namespace and it is known there will be no conflict for this name
-        let clusterEvents = try! EventStream<Cluster.Event>(
-            self,
-            name: "clusterEvents",
-            systemStream: true,
-            customBehavior: ClusterEventStream.Shell.behavior
-        )
-        let clusterRef = try! cluster.start(system: self, clusterEvents: clusterEvents) // only spawns when cluster is initialized
-        _ = self._clusterControlStore.storeIfNilThenLoad(Box(ClusterControl(settings, clusterRef: clusterRef, eventStream: clusterEvents)))
+        if !settings.enabled {
+            let clusterEvents = try! EventStream<Cluster.Event>(
+                self,
+                name: "clusterEvents",
+                systemStream: true,
+                customBehavior: ClusterEventStream.Shell.behavior
+            )
 
-        self._associationTombstoneCleanupTask = eventLoopGroup.next().scheduleRepeatedTask(
-            initialDelay: settings.associationTombstoneCleanupInterval.toNIO,
-            delay: settings.associationTombstoneCleanupInterval.toNIO
-        ) { _ in
-            clusterRef.tell(.command(.cleanUpAssociationTombstones))
+            _ = self._clusterStore.storeIfNilThenLoad(Box(nil))
+            _ = self._clusterControlStore.storeIfNilThenLoad(Box(ClusterControl(settings, clusterRef: self.deadLetters.adapted(), eventStream: clusterEvents)))
         }
 
         // node watcher MUST be prepared before receptionist (or any other actor) because it (and all actors) need it if we're running clustered
         // Node watcher MUST be started AFTER cluster and clusterEvents
-        let lazyNodeDeathWatcher = try! self._prepareSystemActor(
-            NodeDeathWatcherShell.naming,
-            NodeDeathWatcherShell.behavior(clusterEvents: clusterEvents),
-            props: ._wellKnown
-        )
-        _ = self._nodeDeathWatcherStore.storeIfNilThenLoad(Box(lazyNodeDeathWatcher.ref))
+        var lazyNodeDeathWatcher: LazyStart<NodeDeathWatcherShell.Message>?
+
+        if let cluster = self._cluster {
+            // try!-safe, this will spawn under /system/... which we have full control over,
+            // and there /system namespace and it is known there will be no conflict for this name
+            let clusterEvents = try! EventStream<Cluster.Event>(
+                self,
+                name: "clusterEvents",
+                systemStream: true,
+                customBehavior: ClusterEventStream.Shell.behavior
+            )
+            let clusterRef = try! cluster.start(system: self, clusterEvents: clusterEvents) // only spawns when cluster is initialized
+            _ = self._clusterControlStore.storeIfNilThenLoad(Box(ClusterControl(settings, clusterRef: clusterRef, eventStream: clusterEvents)))
+
+            self._associationTombstoneCleanupTask = eventLoopGroup.next().scheduleRepeatedTask(
+                initialDelay: settings.associationTombstoneCleanupInterval.toNIO,
+                delay: settings.associationTombstoneCleanupInterval.toNIO
+            ) { _ in
+                clusterRef.tell(.command(.cleanUpAssociationTombstones))
+            }
+
+            lazyNodeDeathWatcher = try! self._prepareSystemActor(
+                NodeDeathWatcherShell.naming,
+                NodeDeathWatcherShell.behavior(clusterEvents: clusterEvents),
+                props: ._wellKnown
+            )
+            _ = self._nodeDeathWatcherStore.storeIfNilThenLoad(Box(lazyNodeDeathWatcher!.ref))
+        } else {
+            _ = self._nodeDeathWatcherStore.storeIfNilThenLoad(Box(nil))
+        }
 
         // OLD receptionist // TODO(distributed): remove when possible
         let receptionistBehavior = self.settings.receptionist.behavior(settings: self.settings)
@@ -344,15 +370,17 @@ public class ClusterSystem: DistributedActorSystem, @unchecked Sendable {
             transport.onActorSystemStart(system: self)
         }
         // lazyCluster?.wakeUp()
-        lazyNodeDeathWatcher.wakeUp()
+        lazyNodeDeathWatcher?.wakeUp()
 
         /// Starts plugins after the system is fully initialized
         self.settings.plugins.startAll(self)
 
         self.log.info("ClusterSystem [\(self.name)] initialized, listening on: \(self.settings.uniqueBindNode)")
-        self.log.info("Setting in effect: .autoLeaderElection: \(self.settings.autoLeaderElection)")
-        self.log.info("Setting in effect: .downingStrategy: \(self.settings.downingStrategy)")
-        self.log.info("Setting in effect: .onDownAction: \(self.settings.onDownAction)")
+        if settings.enabled {
+            self.log.info("Setting in effect: .autoLeaderElection: \(self.settings.autoLeaderElection)")
+            self.log.info("Setting in effect: .downingStrategy: \(self.settings.downingStrategy)")
+            self.log.info("Setting in effect: .onDownAction: \(self.settings.onDownAction)")
+        }
     }
 
     public convenience init() async {
@@ -488,7 +516,13 @@ extension ClusterSystem: Equatable {
 
 extension ClusterSystem: CustomStringConvertible {
     public var description: String {
-        "ClusterSystem(\(self.name), \(self.cluster.uniqueNode))"
+        var res = "ClusterSystem("
+        res.append(self.name)
+        if self.settings.enabled {
+            res.append(", \(self.cluster.uniqueNode)")
+        }
+        res.append(")")
+        return res
     }
 }
 

--- a/Sources/DistributedActors/ClusterSystemSettings.swift
+++ b/Sources/DistributedActors/ClusterSystemSettings.swift
@@ -46,6 +46,20 @@ public struct ClusterSystemSettings {
     // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: Connection establishment, protocol settings
 
+    // Internal for tests only
+    /// If `true` the `ClusterSystem` starts the cluster subsystem upon startup.
+    /// The address bound to will be `bindAddress`.
+    public internal(set) var enabled: Bool = true
+    internal mutating func enable(host: String, port: Int) {
+        self.enabled = true
+        self.bindHost = host
+        self.bindPort = port
+    }
+
+    internal mutating func disable() {
+        self.enabled = false
+    }
+
     /// If configured, the system will receive contact point updates.
     public var discovery: ServiceDiscoverySettings?
 

--- a/Sources/DistributedActorsTestKit/ActorSystemXCTestCase.swift
+++ b/Sources/DistributedActorsTestKit/ActorSystemXCTestCase.swift
@@ -50,4 +50,11 @@ open class ActorSystemXCTestCase: ClusteredActorSystemsXCTestCase {
     override open func tearDown() {
         super.tearDown()
     }
+
+    override open func setUpNode(_ name: String, _ modifySettings: ((inout ClusterSystemSettings) -> Void)? = nil) async -> ClusterSystem {
+        await super.setUpNode(name) { settings in
+            settings.enabled = false
+            modifySettings?(&settings)
+        }
+    }
 }

--- a/Sources/DistributedActorsTestKit/Cluster/ClusteredActorSystemsXCTestCase.swift
+++ b/Sources/DistributedActorsTestKit/Cluster/ClusteredActorSystemsXCTestCase.swift
@@ -61,6 +61,7 @@ open class ClusteredActorSystemsXCTestCase: XCTestCase {
     /// Set up a new node intended to be clustered.
     open func setUpNode(_ name: String, _ modifySettings: ((inout ClusterSystemSettings) -> Void)? = nil) async -> ClusterSystem {
         let node = await ClusterSystem(name) { settings in
+            settings.enabled = true
             settings.node.port = self.nextPort()
 
             if self.captureLogs {

--- a/Tests/ActorSingletonPluginTests/ActorSingletonPluginTests.swift
+++ b/Tests/ActorSingletonPluginTests/ActorSingletonPluginTests.swift
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2019-2022 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import ActorSingletonPlugin
+import DistributedActors
+import DistributedActorsTestKit
+import XCTest
+
+final class ActorSingletonPluginTests: ActorSystemXCTestCase {
+    func test_noCluster_ref() async throws {
+        // Singleton should work just fine without clustering
+        let system = await setUpNode("test") { settings in
+            settings.enabled = false
+            settings += ActorSingletonPlugin()
+        }
+        let replyProbe = ActorTestKit(system).makeTestProbe(expecting: String.self)
+
+        // singleton.host behavior
+        let ref = try system.singleton.host(GreeterSingleton.Message.self, name: GreeterSingleton.name, GreeterSingleton("Hello").behavior)
+        ref.tell(.greet(name: "Charlie", replyTo: replyProbe.ref))
+        try replyProbe.expectMessage("Hello Charlie!")
+
+        // singleton.ref (proxy-only)
+        let proxyRef = try system.singleton.ref(of: GreeterSingleton.Message.self, name: GreeterSingleton.name)
+        proxyRef.tell(.greet(name: "Charlene", replyTo: replyProbe.ref))
+        try replyProbe.expectMessage("Hello Charlene!")
+    }
+}

--- a/Tests/DistributedActorsTests/ActorRefAdapterTests.swift
+++ b/Tests/DistributedActorsTests/ActorRefAdapterTests.swift
@@ -45,6 +45,7 @@ class _ActorRefAdapterTests: ActorSystemXCTestCase {
 
     func test_adaptedRef_overNetwork_shouldConvertMessages() async throws {
         let firstSystem = await setUpNode("One-RemoteActorRefAdapterTests") { settings in
+            settings.enabled = true
             settings.node.host = "127.0.0.1"
             settings.node.port = 1881
         }
@@ -53,6 +54,7 @@ class _ActorRefAdapterTests: ActorSystemXCTestCase {
         let refProbe = firstTestKit.makeTestProbe(expecting: _ActorRef<Int>.self)
 
         let systemTwo = await setUpNode("Two-RemoteActorRefAdapterTests") { settings in
+            settings.enabled = true
             settings.node.host = "127.0.0.1"
             settings.node.port = 1991
         }

--- a/Tests/DistributedActorsTests/Cluster/MembershipGossipLogicSimulationTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/MembershipGossipLogicSimulationTests.swift
@@ -19,6 +19,10 @@ import NIO
 import XCTest
 
 final class MembershipGossipLogicSimulationTests: ClusteredActorSystemsXCTestCase {
+    override func configureActorSystem(settings: inout ClusterSystemSettings) {
+        settings.enabled = false // not actually clustering, just need a few nodes
+    }
+
     override func configureLogCapture(settings: inout LogCapture.Settings) {
         settings.filterActorPaths = [
             "/user/peer",
@@ -71,7 +75,9 @@ final class MembershipGossipLogicSimulationTests: ClusteredActorSystemsXCTestCas
     // MARK: Simulation Tests
 
     func test_avgRounds_untilConvergence() async throws {
-        let systemA = await setUpNode("A")
+        let systemA = await setUpNode("A") { settings in
+            settings.enabled = true
+        }
         let systemB = await setUpNode("B")
         let systemC = await setUpNode("C")
 
@@ -117,7 +123,9 @@ final class MembershipGossipLogicSimulationTests: ClusteredActorSystemsXCTestCas
     }
 
     func test_avgRounds_manyNodes() async throws {
-        let systemA = await setUpNode("A")
+        let systemA = await setUpNode("A") { settings in
+            settings.enabled = true
+        }
         let systemB = await setUpNode("B")
         let systemC = await setUpNode("C")
         let systemD = await setUpNode("D")
@@ -228,7 +236,9 @@ final class MembershipGossipLogicSimulationTests: ClusteredActorSystemsXCTestCas
     }
 
     func test_shouldEventuallySuspendGossiping() async throws {
-        let systemA = await setUpNode("A")
+        let systemA = await setUpNode("A") { settings in
+            settings.enabled = true
+        }
         let systemB = await setUpNode("B")
         let systemC = await setUpNode("C")
 

--- a/Tests/DistributedActorsTests/Cluster/RemoteActorRefProviderTests.swift
+++ b/Tests/DistributedActorsTests/Cluster/RemoteActorRefProviderTests.swift
@@ -18,6 +18,12 @@ import Foundation
 import XCTest
 
 final class RemoteActorRefProviderTests: ActorSystemXCTestCase {
+    override func setUp() async throws {
+        _ = await self.setUpNode(String(reflecting: Self.self)) { settings in
+            settings.enabled = true
+        }
+    }
+
     let localNode = UniqueNode(systemName: "RemoteAssociationTests", host: "127.0.0.1", port: 7111, nid: UniqueNodeID(777_777))
     let remoteNode = UniqueNode(systemName: "RemoteAssociationTests", host: "127.0.0.1", port: 9559, nid: UniqueNodeID(888_888))
     lazy var remoteAddress = ActorAddress(remote: remoteNode, path: try! ActorPath._user.appending("henry").appending("hacker"), incarnation: .random())

--- a/Tests/DistributedActorsTests/ClusterSystemTests.swift
+++ b/Tests/DistributedActorsTests/ClusterSystemTests.swift
@@ -152,10 +152,13 @@ final class ClusterSystemTests: ActorSystemXCTestCase {
     }
 
     func test_cleanUpAssociationTombstones() async throws {
-        let local = await setUpNode("local") {
-            $0.associationTombstoneTTL = .seconds(0)
+        let local = await setUpNode("local") { settings in
+            settings.enabled = true
+            settings.associationTombstoneTTL = .seconds(0)
         }
-        let remote = await setUpNode("remote")
+        let remote = await setUpNode("remote") { settings in
+            settings.enabled = true
+        }
         local.cluster.join(node: remote.cluster.uniqueNode)
 
         let remoteAssociationControlState0 = local._cluster!.getEnsureAssociation(with: remote.cluster.uniqueNode)
@@ -186,9 +189,11 @@ final class ClusterSystemTests: ActorSystemXCTestCase {
 
     func test_remoteCall_success() async throws {
         let local = await setUpNode("local") { settings in
+            settings.enabled = true
             settings.serialization.registerInbound(GreeterCodableError.self)
         }
         let remote = await setUpNode("remote") { settings in
+            settings.enabled = true
             settings.serialization.registerInbound(GreeterCodableError.self)
         }
         local.cluster.join(node: remote.cluster.uniqueNode)
@@ -204,9 +209,11 @@ final class ClusterSystemTests: ActorSystemXCTestCase {
 
     func test_remoteCall_shouldCarryBackThrownError_Codable() async throws {
         let local = await setUpNode("local") { settings in
+            settings.enabled = true
             settings.serialization.registerInbound(GreeterCodableError.self)
         }
         let remote = await setUpNode("remote") { settings in
+            settings.enabled = true
             settings.serialization.registerInbound(GreeterCodableError.self)
         }
         local.cluster.join(node: remote.cluster.uniqueNode)
@@ -224,9 +231,11 @@ final class ClusterSystemTests: ActorSystemXCTestCase {
 
     func test_remoteCall_shouldCarryBackThrownError_nonCodable() async throws {
         let local = await setUpNode("local") { settings in
+            settings.enabled = true
             settings.serialization.registerInbound(GreeterCodableError.self)
         }
         let remote = await setUpNode("remote") { settings in
+            settings.enabled = true
             settings.serialization.registerInbound(GreeterCodableError.self)
         }
         local.cluster.join(node: remote.cluster.uniqueNode)
@@ -244,8 +253,11 @@ final class ClusterSystemTests: ActorSystemXCTestCase {
     }
 
     func test_remoteCallVoid() async throws {
-        let local = await setUpNode("local")
+        let local = await setUpNode("local") { settings in
+            settings.enabled = true
+        }
         let remote = await setUpNode("remote") { settings in
+            settings.enabled = true
             settings.serialization.registerInbound(GreeterCodableError.self)
         }
         local.cluster.join(node: remote.cluster.uniqueNode)
@@ -259,8 +271,11 @@ final class ClusterSystemTests: ActorSystemXCTestCase {
     }
 
     func test_remoteCallVoid_shouldCarryBackThrownError_Codable() async throws {
-        let local = await setUpNode("local")
+        let local = await setUpNode("local") { settings in
+            settings.enabled = true
+        }
         let remote = await setUpNode("remote") { settings in
+            settings.enabled = true
             settings.serialization.registerInbound(GreeterCodableError.self)
         }
         local.cluster.join(node: remote.cluster.uniqueNode)
@@ -277,8 +292,11 @@ final class ClusterSystemTests: ActorSystemXCTestCase {
     }
 
     func test_remoteCallVoid_shouldCarryBackThrownError_nonCodable() async throws {
-        let local = await setUpNode("local")
+        let local = await setUpNode("local") { settings in
+            settings.enabled = true
+        }
         let remote = await setUpNode("remote") { settings in
+            settings.enabled = true
             settings.serialization.registerInbound(GreeterCodableError.self)
         }
         local.cluster.join(node: remote.cluster.uniqueNode)
@@ -296,8 +314,12 @@ final class ClusterSystemTests: ActorSystemXCTestCase {
     }
 
     func test_remoteCall_shouldConfigureTimeout() async throws {
-        let local = await setUpNode("local")
-        let remote = await setUpNode("remote")
+        let local = await setUpNode("local") { settings in
+            settings.enabled = true
+        }
+        let remote = await setUpNode("remote") { settings in
+            settings.enabled = true
+        }
         local.cluster.join(node: remote.cluster.uniqueNode)
 
         let greeter = Greeter(actorSystem: local)
@@ -318,8 +340,12 @@ final class ClusterSystemTests: ActorSystemXCTestCase {
     }
 
     func test_remoteCallVoid_shouldConfigureTimeout() async throws {
-        let local = await setUpNode("local")
-        let remote = await setUpNode("remote")
+        let local = await setUpNode("local") { settings in
+            settings.enabled = true
+        }
+        let remote = await setUpNode("remote") { settings in
+            settings.enabled = true
+        }
         local.cluster.join(node: remote.cluster.uniqueNode)
 
         let greeter = Greeter(actorSystem: local)

--- a/Tests/DistributedActorsTests/SerializationTests.swift
+++ b/Tests/DistributedActorsTests/SerializationTests.swift
@@ -145,6 +145,7 @@ class SerializationTests: ActorSystemXCTestCase {
 
     func test_serialize_actorRef_inMessage_forRemoting() async throws {
         let remoteCapableSystem = await ClusterSystem("remoteCapableSystem") { settings in
+            settings.enabled = true
             settings.serialization.register(HasStringRef.self)
         }
         defer {

--- a/Tests/DistributedActorsTests/TraversalTests.swift
+++ b/Tests/DistributedActorsTests/TraversalTests.swift
@@ -83,7 +83,7 @@ final class TraversalTests: ActorSystemXCTestCase {
                 "receptionist",
                 "receptionist-ref",
                 // cluster actors ---
-                //"downingStrategy", "swim", "nodeDeathWatcher", "gossip", "cluster", "leadership",
+                // "downingStrategy", "swim", "nodeDeathWatcher", "gossip", "cluster", "leadership",
                 // end of cluster actors ---
                 "clusterEvents",
                 "user",

--- a/Tests/DistributedActorsTests/TraversalTests.swift
+++ b/Tests/DistributedActorsTests/TraversalTests.swift
@@ -83,7 +83,7 @@ final class TraversalTests: ActorSystemXCTestCase {
                 "receptionist",
                 "receptionist-ref",
                 // cluster actors ---
-                "downingStrategy", "swim", "nodeDeathWatcher", "gossip", "cluster", "leadership",
+                //"downingStrategy", "swim", "nodeDeathWatcher", "gossip", "cluster", "leadership",
                 // end of cluster actors ---
                 "clusterEvents",
                 "user",


### PR DESCRIPTION
Partially revert https://github.com/apple/swift-distributed-actors/pull/902 but with `enabled` set to `true` by default instead of `false`.
