### PR TITLE
Remove -disable-availability-checking, Swift 5.7 is part of Xcode 14.0 and has right availabilities now

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import class Foundation.ProcessInfo
@@ -228,6 +228,13 @@ let products: [PackageDescription.Product] = [
 
 var package = Package(
     name: "swift-distributed-actors",
+    platforms: [
+        // we require the 'distributed actor' language and runtime feature:
+        .iOS(.v16),
+        .macOS(.v13),
+        .tvOS(.v16),
+        .watchOS(.v9),
+    ],
     products: products,
 
     dependencies: dependencies,

--- a/Package.swift
+++ b/Package.swift
@@ -7,15 +7,7 @@ import PackageDescription
 // Workaround: Since we cannot include the flat just as command line options since then it applies to all targets,
 // and ONE of our dependencies currently produces one warning, we have to use this workaround to enable it in _our_
 // targets when the flag is set. We should remove the dependencies and then enable the flag globally though just by passing it.
-var globalSwiftSettings: [SwiftSetting]
-
-var globalConcurrencyFlags: [String] = [
-    "-Xfrontend", "-disable-availability-checking", // TODO(distributed): remove this flag
-]
-
-globalSwiftSettings = [
-    SwiftSetting.unsafeFlags(globalConcurrencyFlags),
-]
+var globalSwiftSettings: [SwiftSetting] = []
 
 var targets: [PackageDescription.Target] = [
     // ==== ------------------------------------------------------------------------------------------------------------

--- a/Sources/DistributedActors/ActorTags.swift
+++ b/Sources/DistributedActors/ActorTags.swift
@@ -22,11 +22,11 @@ public struct ActorTags {
     // We still might re-think how we represent the storage.
     private var _storage: [String: Sendable & Codable] = [:] // FIXME: fix the key as AnyActorTagKey
 
-    init() {
+    public init() {
         // empty tags
     }
 
-    init(tags: [any ActorTag]) {
+    public init(tags: [any ActorTag]) {
         for tag in tags {
             self._storage[tag.id] = tag.value
         }

--- a/Sources/DistributedActors/Behaviors.swift
+++ b/Sources/DistributedActors/Behaviors.swift
@@ -557,14 +557,12 @@ open class _Interceptor<Message: Codable> {
 }
 
 extension _Interceptor {
-    @inlinable
     static func handleMessage(context: _ActorContext<Message>, behavior: _Behavior<Message>, interceptor: _Interceptor<Message>, message: Message) throws -> _Behavior<Message> {
         let next = try interceptor.interceptMessage(target: behavior, context: context, message: message)
 
         return try _Interceptor.deduplicate(context: context, behavior: next, interceptor: interceptor)
     }
 
-    @inlinable
     static func deduplicate(context: _ActorContext<Message>, behavior: _Behavior<Message>, interceptor: _Interceptor<Message>) throws -> _Behavior<Message> {
         func deduplicate0(_ behavior: _Behavior<Message>) -> _Behavior<Message> {
             let hasDuplicatedIntercept = behavior.existsInStack { b in
@@ -601,7 +599,6 @@ extension _Behavior {
     ///
     /// Note: The returned behavior MUST be `_Behavior.canonicalize`-ed in the vast majority of cases.
     // Implementation note: We don't do so here automatically in order to keep interpretations transparent and testable.
-    @inlinable
     public func interpretMessage(context: _ActorContext<Message>, message: Message, file: StaticString = #file, line: UInt = #line) throws -> _Behavior<Message> {
         switch self.underlying {
         case .receiveMessage(let recv): return try recv(message)
@@ -648,7 +645,6 @@ extension _Behavior {
     }
 
     /// Attempts interpreting signal using the current behavior, or returns `_Behavior.unhandled` if no `_Behavior.signalHandling` was found.
-    @inlinable
     public func interpretSignal(context: _ActorContext<Message>, signal: _Signal) throws -> _Behavior<Message> {
         // This switch does not use a `default:` clause on purpose!
         // This is to enforce having to consider consider how a signal should be interpreted if a new behavior case is added.
@@ -723,7 +719,6 @@ extension _Behavior {
     }
 
     /// Applies `interpretMessage` to an iterator of messages, while canonicalizing the behavior after every reduction.
-    @inlinable
     internal func interpretMessages<Iterator: IteratorProtocol>(context: _ActorContext<Message>, messages: inout Iterator) throws -> _Behavior<Message> where Iterator.Element == Message {
         var currentBehavior: _Behavior<Message> = self
         while currentBehavior.isStillAlive {
@@ -740,7 +735,6 @@ extension _Behavior {
 
     /// Validate if a _Behavior is legal to be used as "initial" behavior (when an Actor is spawned),
     /// since certain behaviors do not make sense as initial behavior.
-    @inlinable
     internal func validateAsInitial() throws {
         switch self.underlying {
         case .same: throw IllegalBehaviorError.notAllowedAsInitial(self)
@@ -750,7 +744,6 @@ extension _Behavior {
     }
 
     /// Same as `validateAsInitial`, however useful in chaining expressions as it returns itself when the validation has passed successfully.
-    @inlinable
     internal func validatedAsInitial() throws -> _Behavior<Message> {
         try self.validateAsInitial()
         return self
@@ -837,7 +830,6 @@ extension _Behavior {
     ///
     /// - Throws: `IllegalBehaviorError.tooDeeplyNestedBehavior` when a too deeply nested behavior is found,
     ///           in order to avoid attempting to start an possibly infinitely deferred behavior.
-    @inlinable
     internal func canonicalize(_ context: _ActorContext<Message>, next: _Behavior<Message>) throws -> _Behavior<Message> {
         guard self.isStillAlive else {
             return self // ignore, we're already dead and cannot become any other behavior
@@ -910,7 +902,6 @@ extension _Behavior {
     /// - Throws: `IllegalBehaviorError.tooDeeplyNestedBehavior` when a too deeply nested behavior is found,
     ///           in order to avoid attempting to start an possibly infinitely deferred behavior.
     // TODO: make not recursive perhaps since could blow up on large chain?
-    @inlinable
     internal func start(context: _ActorContext<Message>) throws -> _Behavior<Message> {
         let failAtDepth = context.system.settings.actor.maxBehaviorNestingDepth
 

--- a/Sources/DistributedActors/StashBuffer.swift
+++ b/Sources/DistributedActors/StashBuffer.swift
@@ -72,7 +72,6 @@ public final class _StashBuffer<Message: Codable> {
     ///              requires the context to be passed in.
     /// - Throws: When any of the behavior reductions throws
     /// - Returns: The last behavior returned from processing the unstashed messages
-    @inlinable
     public func unstashAll(context: _ActorContext<Message>, behavior: _Behavior<Message>) throws -> _Behavior<Message> {
         // TODO: can we make this honor the run length like `Mailbox` does?
         var iterator = self.buffer.iterator

--- a/Sources/DistributedActors/Supervision.swift
+++ b/Sources/DistributedActors/Supervision.swift
@@ -412,31 +412,26 @@ internal class Supervisor<Message: Codable> {
     @usableFromInline
     typealias Directive = SupervisionDirective<Message>
 
-    @inlinable
     internal final func interpretSupervised(target: _Behavior<Message>, context: _ActorContext<Message>, message: Message) throws -> _Behavior<Message> {
         traceLog_Supervision("CALL WITH \(target) @@@@ [\(message)]:\(type(of: message))")
         return try self.interpretSupervised0(target: target, context: context, processingAction: .message(message))
     }
 
-    @inlinable
     internal final func interpretSupervised(target: _Behavior<Message>, context: _ActorContext<Message>, signal: _Signal) throws -> _Behavior<Message> {
         traceLog_Supervision("INTERCEPT SIGNAL APPLY: \(target) @@@@ \(signal)")
         return try self.interpretSupervised0(target: target, context: context, processingAction: .signal(signal))
     }
 
-    @inlinable
     internal final func interpretSupervised(target: _Behavior<Message>, context: _ActorContext<Message>, closure: ActorClosureCarry) throws -> _Behavior<Message> {
         traceLog_Supervision("CALLING CLOSURE: \(target)")
         return try self.interpretSupervised0(target: target, context: context, processingAction: .closure(closure))
     }
 
-    @inlinable
     internal final func interpretSupervised(target: _Behavior<Message>, context: _ActorContext<Message>, subMessage: SubMessageCarry) throws -> _Behavior<Message> {
         traceLog_Supervision("INTERPRETING SUB MESSAGE: \(target)")
         return try self.interpretSupervised0(target: target, context: context, processingAction: .subMessage(subMessage))
     }
 
-    @inlinable
     internal final func interpretSupervised(target: _Behavior<Message>, context: _ActorContext<Message>, closure: @escaping () throws -> _Behavior<Message>) throws -> _Behavior<Message> {
         traceLog_Supervision("CALLING CLOSURE: \(target)")
         return try self.interpretSupervised0(
@@ -444,7 +439,6 @@ internal class Supervisor<Message: Codable> {
         )
     }
 
-    @inlinable
     internal final func startSupervised(target: _Behavior<Message>, context: _ActorContext<Message>) throws -> _Behavior<Message> {
         traceLog_Supervision("CALLING START")
         return try self.interpretSupervised0(
@@ -454,7 +448,6 @@ internal class Supervisor<Message: Codable> {
     }
 
     /// Implements all directives, which supervisor implementations may yield to instruct how we should (if at all) restart an actor.
-    @inlinable
     @inline(__always)
     final func interpretSupervised0(target: _Behavior<Message>, context: _ActorContext<Message>, processingAction: ProcessingAction<Message>) throws -> _Behavior<Message> {
         try self.interpretSupervised0(
@@ -463,7 +456,6 @@ internal class Supervisor<Message: Codable> {
         ) // 1 since we already have "one failure"
     }
 
-    @inlinable
     @inline(__always)
     final func interpretSupervised0(
         target: _Behavior<Message>,

--- a/Sources/DistributedActors/_BehaviorTimers.swift
+++ b/Sources/DistributedActors/_BehaviorTimers.swift
@@ -114,7 +114,6 @@ public final class _BehaviorTimers<Message: Codable> {
     /// Cancels timer associated with the given key.
     ///
     /// - Parameter key: key of the timer to cancel
-    @inlinable
     public func cancel(for key: TimerKey) {
         if let timer = self.installedTimers.removeValue(forKey: key) {
             if context.system.settings.logging.verboseTimers {


### PR DESCRIPTION
Before Swift / Xcode was released, we could not have the right availability markers and needed this flag.

Actually, the availability might still be wrong in nightly builds so I need to investigate a workaround...