### PR TITLE
Make sure to cancel listing when task is cancelled

### DIFF
--- a/Sources/DistributedActors/Timers+Distributed.swift
+++ b/Sources/DistributedActors/Timers+Distributed.swift
@@ -119,8 +119,6 @@ public final class ActorTimers<Act: DistributedActor> where Act.ActorSystem == C
         interval: Duration,
         repeated: Bool
     ) {
-        self.cancel(for: key)
-
         let handle: Cancelable
         if repeated {
             handle = self.dispatchQueue.scheduleAsync(initialDelay: interval, interval: interval) {
@@ -149,6 +147,9 @@ public final class ActorTimers<Act: DistributedActor> where Act.ActorSystem == C
                 }
 
                 await call()
+
+                // The single timer is done. Remove it so it can be installed again if needed.
+                self.cancel(for: key)
             }
         }
 


### PR DESCRIPTION
Resolves https://github.com/apple/swift-distributed-actors/issues/951

Verified that `DistributedReception.GuestListing.continuation.onTermination` closure gets invoked upon task cancellation, so listing subscription gets cancelled accordingly. Adding a test to make sure no further item is received from the listing.
