### PR TITLE
fix wrong cross module usage; seems this was not caught by CI / SwiftPM

### DIFF
--- a/Sources/DistributedActorsConcurrencyHelpers/lock.swift
+++ b/Sources/DistributedActorsConcurrencyHelpers/lock.swift
@@ -18,8 +18,6 @@ import Darwin
 import Glibc
 #endif
 
-import CDistributedActorsMailbox // for backtrace
-
 /// A threading lock based on `libpthread` instead of `libdispatch`.
 ///
 /// This object provides a lock on top of a single `pthread_mutex_t`. This kind
@@ -52,7 +50,6 @@ public final class Lock {
     public func lock() {
         let err = pthread_mutex_lock(self.mutex)
         if (err != 0) {
-            sact_dump_backtrace()
             fatalError("\(#function) failed in pthread_mutex with error \(err)")
         }
     }


### PR DESCRIPTION
Suprisingly this seems to have been building fine on CI, but triggeres errors in Xcode -- where I suppose the module checks are actually enforced...? I'll dig into the actual problems but we can fix this right away anyway.