### PR TITLE
update swift tools version and required apple platforms

### DIFF
--- a/Samples/Package.swift
+++ b/Samples/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -50,9 +50,11 @@ var dependencies: [Package.Dependency] = [
 let package = Package(
     name: "swift-distributed-actors-samples",
     platforms: [
-        .macOS(.v10_15),
-        .iOS(.v8),
-        // ...
+        // we require the 'distributed actor' language and runtime feature:
+        .iOS(.v16),
+        .macOS(.v13),
+        .tvOS(.v16),
+        .watchOS(.v9),
     ],
     products: [
         /* ---  samples --- */


### PR DESCRIPTION
Update the swift tools version and required apple platforms

### Motivation:

Would not build in Xcode on new macOS beta.
