### PR TITLE
Fix #filePath related warnings

### DIFF
--- a/Sources/DistributedActors/Behaviors.swift
+++ b/Sources/DistributedActors/Behaviors.swift
@@ -599,7 +599,7 @@ extension _Behavior {
     ///
     /// Note: The returned behavior MUST be `_Behavior.canonicalize`-ed in the vast majority of cases.
     // Implementation note: We don't do so here automatically in order to keep interpretations transparent and testable.
-    public func interpretMessage(context: _ActorContext<Message>, message: Message, file: StaticString = #filePath, line: UInt = #line) throws -> _Behavior<Message> {
+    public func interpretMessage(context: _ActorContext<Message>, message: Message, file: StaticString = #file, line: UInt = #line) throws -> _Behavior<Message> {
         switch self.underlying {
         case .receiveMessage(let recv): return try recv(message)
         case .receiveMessageAsync(let recv): return self.receiveMessageAsync(recv, message)

--- a/Sources/DistributedActors/Cluster/DistributedNodeDeathWatcher.swift
+++ b/Sources/DistributedActors/Cluster/DistributedNodeDeathWatcher.swift
@@ -48,7 +48,7 @@ internal actor DistributedNodeDeathWatcher {
     private var eventListenerTask: Task<Void, Error>?
 
     init(actorSystem: ActorSystem) async {
-        var log = actorSystem.log
+        let log = actorSystem.log
         self.log = log
         self.selfNode = actorSystem.cluster.uniqueNode
         // initialized

--- a/Sources/DistributedActors/ClusterSystem.swift
+++ b/Sources/DistributedActors/ClusterSystem.swift
@@ -912,7 +912,7 @@ extension ClusterSystem {
         } else {
             lifecycleContainer = nil
         }
-        traceLog_DeathWatch("Make LifecycleWatchContainer for \(id):::: \(lifecycleContainer)")
+        traceLog_DeathWatch("Make LifecycleWatchContainer for \(id):::: \(optional: lifecycleContainer)")
 
         id.context = .init(lifecycle: lifecycleContainer)
 
@@ -1066,7 +1066,7 @@ extension ClusterSystem {
 
         let timeout = RemoteCall.timeout ?? self.settings.defaultRemoteCallTimeout
         let timeoutTask: Task<Void, Error> = Task.detached {
-            await Task.sleep(UInt64(timeout.nanoseconds))
+            try await Task.sleep(nanoseconds: UInt64(timeout.nanoseconds))
             guard !Task.isCancelled else {
                 return
             }

--- a/Sources/DistributedActors/DistributedActorContext.swift
+++ b/Sources/DistributedActors/DistributedActorContext.swift
@@ -24,7 +24,7 @@ public final class DistributedActorContext {
 
     init(lifecycle: LifecycleWatchContainer?) {
         self.lifecycle = lifecycle
-        traceLog_DeathWatch("Create context; Lifecycle: \(lifecycle)")
+        traceLog_DeathWatch("Create context; Lifecycle: \(optional: lifecycle)")
     }
 
     /// Invoked by the actor system when the owning actor is terminating, so we can clean up all stored data

--- a/Sources/DistributedActors/utils.swift
+++ b/Sources/DistributedActors/utils.swift
@@ -41,32 +41,32 @@ import Foundation
  *
  * Originally from: Johannes Weiss (MIT licensed) https://github.com/weissi/swift-undefined
  */
-public func _undefined<T>(hint: String = "", function: StaticString = #function, file: StaticString = #filePath, line: UInt = #line) -> T {
+public func _undefined<T>(hint: String = "", function: StaticString = #function, file: StaticString = #file, line: UInt = #line) -> T {
     let message = hint == "" ? "" : ": \(hint)"
     fatalError("undefined \(function) -> \(T.self)\(message)", file: file, line: line)
 }
 
-public func _undefined(hint: String = "", function: StaticString = #function, file: StaticString = #filePath, line: UInt = #line) -> Never {
+public func _undefined(hint: String = "", function: StaticString = #function, file: StaticString = #file, line: UInt = #line) -> Never {
     let message = hint == "" ? "" : ": \(hint)"
     fatalError("undefined \(function) -> Never \(message)", file: file, line: line)
 }
 
-func TODO<T>(_ hint: String, function: StaticString = #function, file: StaticString = #filePath, line: UInt = #line) -> T {
+func TODO<T>(_ hint: String, function: StaticString = #function, file: StaticString = #file, line: UInt = #line) -> T {
     fatalError("TODO(\(function)): \(hint)", file: file, line: line)
 }
 
-func FIXME<T>(_ hint: String, function: StaticString = #function, file: StaticString = #filePath, line: UInt = #line) -> T {
+func FIXME<T>(_ hint: String, function: StaticString = #function, file: StaticString = #file, line: UInt = #line) -> T {
     fatalError("TODO(\(function)): \(hint)", file: file, line: line)
 }
 
 // TODO: Remove this once we're happy with swift-backtrace always printing backtrace (also on macos)
 @usableFromInline
-internal func fatalErrorBacktrace<T>(_ hint: String, file: StaticString = #filePath, line: UInt = #line) -> T {
+internal func fatalErrorBacktrace<T>(_ hint: String, file: StaticString = #file, line: UInt = #line) -> T {
     sact_dump_backtrace()
     fatalError(hint, file: file, line: line)
 }
 
-internal func assertBacktrace(_ condition: @autoclosure () -> Bool, _ message: @autoclosure () -> String = String(), file: StaticString = #filePath, line: UInt = #line) {
+internal func assertBacktrace(_ condition: @autoclosure () -> Bool, _ message: @autoclosure () -> String = String(), file: StaticString = #file, line: UInt = #line) {
     assert(condition(), { () in sact_dump_backtrace(); return message() }(), file: file, line: line)
 }
 

--- a/Tests/DistributedActorsTests/Cluster/TestExtensions+MembershipDSL.swift
+++ b/Tests/DistributedActorsTests/Cluster/TestExtensions+MembershipDSL.swift
@@ -33,7 +33,7 @@ extension Cluster.MembershipGossip {
 extension Cluster.MembershipGossip.SeenTable {
     /// Express seen tables using a DSL
     /// Syntax: each line: `<owner>: <node>@<version>*`
-    static func parse(_ dslString: String, nodes: [UniqueNode], file: StaticString = #filePath, line: UInt = #line) -> Cluster.MembershipGossip.SeenTable {
+    static func parse(_ dslString: String, nodes: [UniqueNode], file: StaticString = #file, line: UInt = #line) -> Cluster.MembershipGossip.SeenTable {
         let lines = dslString.split(separator: "\n")
         func nodeById(id: String.SubSequence) -> UniqueNode {
             if let found = nodes.first(where: { $0.node.systemName.contains(id) }) {
@@ -71,7 +71,7 @@ extension Cluster.MembershipGossip.SeenTable {
 }
 
 extension VersionVector {
-    static func parse(_ dslString: String, nodes: [UniqueNode], file: StaticString = #filePath, line: UInt = #line) -> VersionVector {
+    static func parse(_ dslString: String, nodes: [UniqueNode], file: StaticString = #file, line: UInt = #line) -> VersionVector {
         func nodeById(id: String.SubSequence) -> UniqueNode {
             if let found = nodes.first(where: { $0.node.systemName.contains(id) }) {
                 return found
@@ -96,7 +96,7 @@ extension Cluster.Membership {
     /// ```
     /// <node identifier>[.:]<node status> || [leader:<node identifier>]
     /// ```
-    static func parse(_ dslString: String, nodes: [UniqueNode], file: StaticString = #filePath, line: UInt = #line) -> Cluster.Membership {
+    static func parse(_ dslString: String, nodes: [UniqueNode], file: StaticString = #file, line: UInt = #line) -> Cluster.Membership {
         func nodeById(id: String.SubSequence) -> UniqueNode {
             if let found = nodes.first(where: { $0.node.systemName.contains(id) }) {
                 return found


### PR DESCRIPTION
https://github.com/apple/swift-distributed-actors/issues/635 caused new warnings:

```
warning: parameter 'file' with default argument '#filePath' passed to parameter 'file', whose default argument is '#file'
```

This is because standard library's assertion and error functions use `#file`.

Also fix a few other trivial warnings.
