### PR TITLE
Silence OpLogDistributedReceptionist.sendAckOps timeout logs

### DIFF
--- a/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
+++ b/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
@@ -629,11 +629,9 @@ extension OpLogDistributedReceptionist {
                 try await peerReceptionistRef.ackOps(until: latestAppliedSeqNrFromPeer, by: self)
             } catch {
                 switch error {
-                case RemoteCallError.clusterAlreadyShutDown:
+                case RemoteCallError.clusterAlreadyShutDown, is TimeoutError:
                     // ignore silently; this often happens during tests when we terminate systems while interacting with them
                     ()
-                case is TimeoutError:
-                    break
                 default:
                     log.error("Error: \(error)")
                 }

--- a/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
+++ b/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
@@ -630,7 +630,8 @@ extension OpLogDistributedReceptionist {
             } catch {
                 switch error {
                 case RemoteCallError.clusterAlreadyShutDown, is TimeoutError:
-                    // ignore silently; this often happens during tests when we terminate systems while interacting with them
+                    // ignore silently; clusterAlreadyShutDown often happens during tests when we terminate systems
+                    // while interacting with them. TimeoutErrors are also expected to happen sometimes.
                     ()
                 default:
                     log.error("Error: \(error)")

--- a/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
+++ b/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
@@ -632,6 +632,8 @@ extension OpLogDistributedReceptionist {
                 case RemoteCallError.clusterAlreadyShutDown:
                     // ignore silently; this often happens during tests when we terminate systems while interacting with them
                     ()
+                case is TimeoutError:
+                    break
                 default:
                     log.error("Error: \(error)")
                 }


### PR DESCRIPTION
I can't really easily reproduce the specific error that caused the logging, but as far as I can tell this is where it came from and I also didn't see this message anymore in my logs.

I was wondering if I should just drop it entirely or maybe still log it under the trace level for instance?

- Resolves #993 
