### PR TITLE
Use correct error type for timeout error silencing

### DIFF
--- a/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
+++ b/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
@@ -631,7 +631,7 @@ extension OpLogDistributedReceptionist {
                 switch error {
                 case RemoteCallError.clusterAlreadyShutDown, RemoteCallError.timedOut:
                     // ignore silently; clusterAlreadyShutDown often happens during tests when we terminate systems
-                    // while interacting with them. TimeoutErrors are also expected to happen sometimes.
+                    // while interacting with them. timedOut are also expected to happen sometimes.
                     ()
                 default:
                     log.error("Error: \(error)")

--- a/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
+++ b/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
@@ -629,7 +629,7 @@ extension OpLogDistributedReceptionist {
                 try await peerReceptionistRef.ackOps(until: latestAppliedSeqNrFromPeer, by: self)
             } catch {
                 switch error {
-                case RemoteCallError.clusterAlreadyShutDown, is TimeoutError:
+                case RemoteCallError.clusterAlreadyShutDown, RemoteCallError.timedOut:
                     // ignore silently; clusterAlreadyShutDown often happens during tests when we terminate systems
                     // while interacting with them. TimeoutErrors are also expected to happen sometimes.
                     ()

--- a/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
+++ b/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
@@ -631,7 +631,7 @@ extension OpLogDistributedReceptionist {
                 switch error {
                 case RemoteCallError.clusterAlreadyShutDown, RemoteCallError.timedOut:
                     // ignore silently; clusterAlreadyShutDown often happens during tests when we terminate systems
-                    // while interacting with them. timedOut are also expected to happen sometimes.
+                    // while interacting with them. timedOut is also expected to happen sometimes.
                     ()
                 default:
                     log.error("Error: \(error)")


### PR DESCRIPTION
Fix silenced error type for OpLogDistributedReceptionist.sendAckOps

### Motivation:

The error type the was silenced by #996 was actually wrong, this fixes it.