### PR TITLE
Fix logging level setting issue

### DIFF
--- a/Sources/DistributedActors/ClusterSystem.swift
+++ b/Sources/DistributedActors/ClusterSystem.swift
@@ -250,8 +250,10 @@ public class ClusterSystem: DistributedActorSystem, @unchecked Sendable {
         self.lazyInitializationLock = initializationLock
 
         if !settings.logging.customizedLogger {
+            // Copy the log level that has been set on the initial logger before we replace it
+            let desiredLogLevel = settings.logging._logger.logLevel
             settings.logging._logger = Logger(label: self.name)
-            settings.logging._logger.logLevel = settings.logging.logLevel
+            settings.logging._logger.logLevel = desiredLogLevel
         }
 
         if settings.enabled {


### PR DESCRIPTION
Avoid the logging level settings from being overridden when replacing the "initialization logger" with a new one.

### Motivation:

The logging settings were overridden at some point and it caused the settings to not be taken into account (see #1002)

### Modifications:

Copy the logging level that had been set on the initial logger to apply it again to the logger that replaces it.

### Result:

- Resolves #1002 
