### PR TITLE
Avoid errors in old toolchains, add to-be-removed convenience keyword

### DIFF
--- a/Sources/DistributedActors/Pattern/WorkerPool.swift
+++ b/Sources/DistributedActors/Pattern/WorkerPool.swift
@@ -83,7 +83,8 @@ public distributed actor WorkerPool<Worker: DistributedWorker>: DistributedWorke
     /// Control for waiting and getting notified for new worker.
     private var newWorkerContinuations: [CheckedContinuation<Void, Never>] = []
 
-    public init(selector: Selector, actorSystem: ActorSystem) async throws {
+    // TODO(distributed): the convenience is no longer required, but because this only got fixed in very recent toolchains; we keep it on for now. We should be able to remove this once 5.7 lands with this fixed (it is the actors and initializers proposal)
+    public convenience init(selector: Selector, actorSystem: ActorSystem) async throws {
         try await self.init(settings: .init(selector: selector), actorSystem: actorSystem)
     }
 


### PR DESCRIPTION
It was reported that beta-2 toolchain errors out on the missing `convenience` in this init. 

This is actually fixed by https://github.com/apple/swift-evolution/blob/main/proposals/0327-actor-initializers.md which @kavon implemented, so as soon as we get a stable Swift which does not need the convenience keyword we can drop it.

Adding for now to make life of early adopters easier.
