### PR TITLE
Improve old betas compatibility

### DIFF
--- a/Sources/DistributedActors/Pattern/WorkerPool.swift
+++ b/Sources/DistributedActors/Pattern/WorkerPool.swift
@@ -83,7 +83,8 @@ public distributed actor WorkerPool<Worker: DistributedWorker>: DistributedWorke
     /// Control for waiting and getting notified for new worker.
     private var newWorkerContinuations: [CheckedContinuation<Void, Never>] = []
 
-    public init(selector: Selector, actorSystem: ActorSystem) async throws {
+    // TODO: remove the convenience marker; since SE-0327 we don't need it anymore: https://github.com/apple/swift-evolution/blob/main/proposals/0327-actor-initializers.md
+    public convenience init(selector: Selector, actorSystem: ActorSystem) async throws {
         try await self.init(settings: .init(selector: selector), actorSystem: actorSystem)
     }
 


### PR DESCRIPTION
Just a convenience change for people hitting the `Designated initializer for 'WorkerPool<Worker>' cannot delegate (with 'self.init'); did you mean this to be a convenience initializer?`  in old Xcode betas.