### PR TITLE
-jazzy remove jazzy; we're only using docc now

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,14 +17,6 @@ ENV LANGUAGE en_US.UTF-8
 RUN apt-get update && apt-get install -y wget
 RUN apt-get update && apt-get install -y lsof dnsutils netcat-openbsd net-tools curl jq # used by integration tests
 
-# ruby and jazzy for docs generation
-RUN apt-get update && apt-get install -y ruby ruby-dev libsqlite3-dev build-essential
-# switch of gem docs building
-
-# jazzy no longer works on xenial as ruby is too old.
-RUN if [ "${ubuntu_version}" = "focal" ] ; then echo "gem: --no-document" > ~/.gemrc; fi
-RUN if [ "${ubuntu_version}" = "focal" ] ; then gem install jazzy; fi
-
 # tools
 RUN mkdir -p $HOME/.tools
 RUN echo 'export PATH="$HOME/.tools:$PATH"' >> $HOME/.profile


### PR DESCRIPTION
Remove jazzy from build; it takes a long time to install ruby native extensions every time, adding up to build time -- and we're not using it anymore.

So long, and thanks for all the fish "Building native extensions. This could take a while..." 🐟 👋 