### PR TITLE
=multi-node improve printouts to always be one-by-one (logs)

### DIFF
--- a/MultiNodeTests/DistributedActorsMultiNodeTests/MultiNode+ReceptionistTests.swift
+++ b/MultiNodeTests/DistributedActorsMultiNodeTests/MultiNode+ReceptionistTests.swift
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import DistributedActors
+import MultiNodeTestKit
+
+public final class MultiNodeReceptionistTests: MultiNodeTestSuite {
+    public init() {}
+
+    public enum Nodes: String, MultiNodeNodes {
+        case first
+        case second
+        case third
+        case fourth
+    }
+
+    public static func configureMultiNodeTest(settings: inout MultiNodeTestSettings) {
+        settings.dumpNodeLogs = .always
+
+        settings.logCapture.excludeGrep = [
+            "SWIMActor.swift", "SWIMInstance.swift",
+            "Gossiper+Shell.swift",
+        ]
+
+        settings.installPrettyLogger = true
+    }
+    public static func configureActorSystem(settings: inout ClusterSystemSettings) {
+        settings.logging.logLevel = .debug
+
+        settings.autoLeaderElection = .lowestReachable(minNumberOfMembers: 3)
+    }
+
+    public let test_receptionist_checkIn = MultiNodeTest(MultiNodeReceptionistTests.self) { multiNode in
+        // *All* nodes spawn an echo actor
+        let localEcho = await DistributedEcho(greeting: "Hi from \(multiNode.system.name), ", actorSystem: multiNode.system)
+
+        try await multiNode.checkPoint("Spawned actors") // ------------------------------------------------------------
+
+        let expectedCount = Nodes.allCases.count
+        var discovered: Set<DistributedEcho> = []
+        for try await actor in await multiNode.system.receptionist.listing(of: .init(DistributedEcho.self)) {
+            multiNode.log.notice("Discovered \(actor.id) from \(actor.id.uniqueNode)")
+            discovered.insert(actor)
+
+            if discovered.count == expectedCount {
+                break
+            }
+        }
+
+        try await multiNode.checkPoint("All members found \(expectedCount) actors") // ---------------------------------
+    }
+
+    distributed actor DistributedEcho {
+        typealias ActorSystem = ClusterSystem
+
+        @ActorID.Metadata(\.receptionID)
+        var receptionID: String
+
+        private let greeting: String
+
+        init(greeting: String, actorSystem: ActorSystem) async {
+            self.actorSystem = actorSystem
+            self.greeting = greeting
+            self.receptionID = "*"
+
+            await actorSystem.receptionist.checkIn(self)
+        }
+
+        distributed func echo(name: String) -> String {
+            "echo: \(greeting)\(name)! (from node: \(self.id.uniqueNode), id: \(self.id.detailedDescription))"
+        }
+    }
+}

--- a/MultiNodeTests/DistributedActorsMultiNodeTests/MultiNode+ReceptionistTests.swift
+++ b/MultiNodeTests/DistributedActorsMultiNodeTests/MultiNode+ReceptionistTests.swift
@@ -35,6 +35,7 @@ public final class MultiNodeReceptionistTests: MultiNodeTestSuite {
 
         settings.installPrettyLogger = true
     }
+
     public static func configureActorSystem(settings: inout ClusterSystemSettings) {
         settings.logging.logLevel = .debug
 
@@ -78,7 +79,7 @@ public final class MultiNodeReceptionistTests: MultiNodeTestSuite {
         }
 
         distributed func echo(name: String) -> String {
-            "echo: \(greeting)\(name)! (from node: \(self.id.uniqueNode), id: \(self.id.detailedDescription))"
+            "echo: \(self.greeting)\(name)! (from node: \(self.id.uniqueNode), id: \(self.id.detailedDescription))"
         }
     }
 }

--- a/Sources/DistributedActors/ActorMetadata.swift
+++ b/Sources/DistributedActors/ActorMetadata.swift
@@ -51,7 +51,7 @@ extension ActorMetadataKeys {
 }
 
 extension ActorID {
-    internal var isWellKnown: Bool {
+    public var isWellKnown: Bool {
         self.metadata.wellKnown != nil
     }
 }

--- a/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
+++ b/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
@@ -295,6 +295,22 @@ extension OpLogDistributedReceptionist: LifecycleWatch {
         }
     }
 
+    public nonisolated func checkIn<Guest>(
+        _ guest: Guest
+    ) async where Guest: DistributedActor, Guest.ActorSystem == ClusterSystem {
+        guard let keyID: String = guest.id.metadata.receptionID else {
+            fatalError("""
+                       Attempted to \(#function) distributed actor without `@ActorID.Metadata(\\.receptionKey)` set on ActorID!
+                       Please set the metadata during actor initialization.
+                       """)
+        }
+        let key = DistributedReception.Key(Guest.self, id: keyID)
+
+        await self.whenLocal { myself in
+            await myself._checkIn(guest, with: key)
+        }
+    }
+
     // 'local' implementation of checkIn
     private func _checkIn<Guest>(
         _ guest: Guest,
@@ -355,7 +371,16 @@ extension OpLogDistributedReceptionist: LifecycleWatch {
     ) async -> DistributedReception.GuestListing<Guest>
         where Guest: DistributedActor, Guest.ActorSystem == ClusterSystem
     {
-        return DistributedReception.GuestListing<Guest>(receptionist: self, key: key, file: file, line: line)
+        DistributedReception.GuestListing<Guest>(receptionist: self, key: key, file: file, line: line)
+    }
+
+    public nonisolated func listing<Guest>(
+        of _: Guest.Type,
+        file: String = #fileID, line: UInt = #line
+    ) async -> DistributedReception.GuestListing<Guest>
+        where Guest: DistributedActor, Guest.ActorSystem == ClusterSystem
+    {
+        DistributedReception.GuestListing<Guest>(receptionist: self, key: Key<Guest>(), file: file, line: line)
     }
 
     // 'local' impl for 'listing'
@@ -374,9 +399,9 @@ extension OpLogDistributedReceptionist: LifecycleWatch {
             // as new ones come in, they will be reported to this subscription later on
             for alreadyRegisteredAtSubscriptionTime in self.storage.registrations(forKey: subscription.key) ?? [] {
                 if subscription.tryOffer(registration: alreadyRegisteredAtSubscriptionTime) {
-                    self.log.notice("OFFERED \(alreadyRegisteredAtSubscriptionTime.actorID) TO \(subscription)")
+                    self.log.debug("Offered \(alreadyRegisteredAtSubscriptionTime.actorID) to subscription \(subscription)")
                 } else {
-                    self.log.notice("DROPPED \(alreadyRegisteredAtSubscriptionTime.actorID) TO \(subscription)")
+                    self.log.warning("Dropped \(alreadyRegisteredAtSubscriptionTime.actorID) on subscription \(subscription)")
                 }
             }
         }

--- a/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
+++ b/Sources/DistributedActors/Cluster/Reception/OperationLogDistributedReceptionist.swift
@@ -300,9 +300,9 @@ extension OpLogDistributedReceptionist: LifecycleWatch {
     ) async where Guest: DistributedActor, Guest.ActorSystem == ClusterSystem {
         guard let keyID: String = guest.id.metadata.receptionID else {
             fatalError("""
-                       Attempted to \(#function) distributed actor without `@ActorID.Metadata(\\.receptionKey)` set on ActorID!
-                       Please set the metadata during actor initialization.
-                       """)
+            Attempted to \(#function) distributed actor without `@ActorID.Metadata(\\.receptionKey)` set on ActorID!
+            Please set the metadata during actor initialization.
+            """)
         }
         let key = DistributedReception.Key(Guest.self, id: keyID)
 

--- a/Sources/DistributedActors/Receptionist/DistributedReception.swift
+++ b/Sources/DistributedActors/Receptionist/DistributedReception.swift
@@ -21,6 +21,19 @@ import Distributed
 public enum DistributedReception {}
 
 // ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: ActorID metadata for easy checking-in
+
+extension ActorMetadataKeys {
+    public var receptionID: Key<String> { "$receptionID" }
+}
+
+extension ActorID {
+    public var hasReceptionID: Bool {
+        self.metadata.receptionID != nil
+    }
+}
+
+// ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: DistributedReception Key
 
 extension DistributedReception {

--- a/Sources/DistributedActors/_OrderedSet+Extensions.swift
+++ b/Sources/DistributedActors/_OrderedSet+Extensions.swift
@@ -20,7 +20,7 @@ extension OrderedSet {
     internal func _filter(
         _ isIncluded: (Element) throws -> Bool
     ) rethrows -> Self {
-        var set = try self.filter(isIncluded)
+        let set = try self.filter(isIncluded)
         return OrderedSet(uncheckedUniqueElements: set)
     }
 }

--- a/Sources/MultiNodeTestKitRunner/MultiNode+TestSuites.swift
+++ b/Sources/MultiNodeTestKitRunner/MultiNode+TestSuites.swift
@@ -18,4 +18,5 @@ import MultiNodeTestKit
 let MultiNodeTestSuites: [any MultiNodeTestSuite.Type] = [
     MultiNodeConductorTests.self,
     MultiNodeClusterSingletonTests.self,
+    MultiNodeReceptionistTests.self,
 ]

--- a/Sources/MultiNodeTestKitRunner/boot+MultiNodeTestKitRunner+Test.swift
+++ b/Sources/MultiNodeTestKitRunner/boot+MultiNodeTestKitRunner+Test.swift
@@ -176,7 +176,7 @@ extension MultiNodeTestKitRunnerBoot {
                         try grepper.result.wait()
                     }
 
-                    let testResult = try interpretNodeTestOutput(
+                    let testResult = try await interpretNodeTestOutput(
                         result,
                         nodeName: nodeName,
                         multiNodeTest: multiNodeTest,

--- a/Sources/MultiNodeTestKitRunner/boot+MultiNodeTestKitRunner.swift
+++ b/Sources/MultiNodeTestKitRunner/boot+MultiNodeTestKitRunner.swift
@@ -141,7 +141,7 @@ struct MultiNodeTestKitRunnerBoot {
 
         let expectedFailure = expectedFailureRegex != nil
         do {
-            var detectedReason: InterpretedRunResult? = nil
+            var detectedReason: InterpretedRunResult?
             if !expectedFailure {
                 switch result {
                 case .failure(let error as MultiNodeProgramError):
@@ -149,7 +149,7 @@ struct MultiNodeTestKitRunnerBoot {
                     for line in error.completeOutput {
                         log("[\(nodeName)](\(multiNodeTest.testName)) \(line)")
 
-                        if line.contains("Fatal error: ") && detectedReason == nil {
+                        if line.contains("Fatal error: "), detectedReason == nil {
                             detectedReason = .outputError(line)
                         } else if case .outputError(let reasonLines) = detectedReason {
                             // keep accumulating lines into the reason, after the "Fatal error:" line.

--- a/Sources/MultiNodeTestKitRunner/boot+MultiNodeTestKitRunner.swift
+++ b/Sources/MultiNodeTestKitRunner/boot+MultiNodeTestKitRunner.swift
@@ -122,6 +122,7 @@ struct MultiNodeTestKitRunnerBoot {
             .1
     }
 
+    @MainActor // Main actor only because we want failures to be printed one after another, and not interleaved.
     func interpretNodeTestOutput(
         _ result: Result<ProgramOutput, Error>,
         nodeName: String,


### PR DESCRIPTION
New receptionist was too aggressive in what it deemed acceptable to be send onNext to the reception stream.

Concurrent messages are fine; specifically if [first:1] then [first:1, second:1] happens, these may have been concurrent in vector clock meaning, but it means that the event has more information so we should be emitting it.