### PR TITLE
Add Swift 5.7 support to legacy release/0.x branch.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -296,8 +296,6 @@ var dependencies: [Package.Dependency] = [
     // ~~~ SSWG APIs ~~~
 
     .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
-    // swift-metrics 1.x and 2.x are almost API compatible, so most clients should use
-    .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0" ..< "3.0.0"),
     .package(url: "https://github.com/apple/swift-service-discovery.git", from: "1.0.0"),
 
     // ~~~ only for GenActors ~~~
@@ -308,8 +306,24 @@ var dependencies: [Package.Dependency] = [
 ]
 
 #if swift(>=5.7)
+// swift-metrics 2.3.2 changed a test API. only pull it in for swift 5.7 to keep backwards compatibility.
 dependencies.append(
-    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .revision("swift-DEVELOPMENT-SNAPSHOT-2022-03-13-a"))
+  .package(url: "https://github.com/apple/swift-metrics.git", .upToNextMajor(from: "2.3.2"))
+)
+#else
+// swift-metrics 1.x and 2.x are almost API compatible, so most clients should use
+dependencies.append(
+    .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0" ..< "2.3.2")
+)
+#endif
+
+#if swift(>=5.8)
+dependencies.append(
+    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .revision("swift-DEVELOPMENT-SNAPSHOT-2022-09-12-a "))
+)
+#elseif swift(>=5.7)
+dependencies.append(
+    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50700.0"))
 )
 #elseif swift(>=5.6)
 dependencies.append(

--- a/Tests/DistributedActorsTests/MetricsTestKit/MetricsTestKit.swift
+++ b/Tests/DistributedActorsTests/MetricsTestKit/MetricsTestKit.swift
@@ -126,7 +126,11 @@ extension TestMetrics {
     // MARK: Counter
 
     public func expectCounter(_ metric: Counter) throws -> TestCounter {
-        metric.handler as! TestCounter
+        #if swift(>=5.7)
+            metric._handler as! TestCounter
+        #else
+            metric.handler as! TestCounter
+        #endif
     }
 
     public func expectCounter(_ label: String, _ dimensions: [(String, String)] = []) throws -> TestCounter {
@@ -159,7 +163,11 @@ extension TestMetrics {
     // MARK: Recorder
 
     public func expectRecorder(_ metric: Recorder) throws -> TestRecorder {
-        metric.handler as! TestRecorder
+        #if swift(>=5.7)
+            metric._handler as! TestRecorder
+        #else
+            metric.handler as! TestRecorder
+        #endif
     }
 
     public func expectRecorder(_ label: String, _ dimensions: [(String, String)] = []) throws -> TestRecorder {
@@ -177,7 +185,11 @@ extension TestMetrics {
     // MARK: Timer
 
     public func expectTimer(_ metric: Timer) throws -> TestTimer {
-        metric.handler as! TestTimer
+        #if swift(>=5.7)
+            metric._handler as! TestTimer
+        #else
+            metric.handler as! TestTimer
+        #endif
     }
 
     public func expectTimer(_ label: String, _ dimensions: [(String, String)] = []) throws -> TestTimer {

--- a/docker/docker-compose.2004.57.yaml
+++ b/docker/docker-compose.2004.57.yaml
@@ -1,0 +1,34 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-distributed-actors:20.04-5.7
+    build:
+      args:
+        ubuntu_version: "focal"
+        swift_version: "5.7"
+
+  unit-tests:
+    image: swift-distributed-actors:20.04-5.7
+
+  unit-tests-until-failure:
+    image: swift-distributed-actors:20.04-5.7
+
+  integration-tests:
+    image: swift-distributed-actors:20.04-5.7
+
+  test:
+    image: swift-distributed-actors:20.04-5.7
+
+  bench:
+    image: swift-distributed-actors:20.04-5.7
+
+  shell:
+    image: swift-distributed-actors:20.04-5.7
+
+  sample-crash:
+    image: swift-distributed-actors:20.04-5.7
+
+  sample-crash-actor:
+    image: swift-distributed-actors:20.04-5.7


### PR DESCRIPTION
This adds support for Swift 5.7, but only to the legacy version.

### Motivation:

Some projects are still using the legacy version but would like to use Swift 5.7. The dependencies of this project require updating for each Swift version.

### Modifications:

* Updated dependencies for Swift 5.7.
* Worked around an issue in swift-metrics, but only did so for Swift 5.7 to keep backwards compatibility.

### Result:

Swift 5.7 is now supported.
