### PR TITLE
=build workaround for SwiftPM not allowing people to consume this lib

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -48,33 +48,6 @@ var targets: [PackageDescription.Target] = [
     ),
 
     // ==== ----------------------------------------------------------------------------------------------------------------
-    // MARK: MultiNodeTestKit
-
-    .target(
-        name: "MultiNodeTestKit",
-        dependencies: [
-            "DistributedActors",
-            // "DistributedActorsTestKit", // can't depend on it because it'll pull in XCTest, and that crashes in executable then
-            .product(name: "Backtrace", package: "swift-backtrace"),
-            .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
-            .product(name: "Atomics", package: "swift-atomics"),
-            .product(name: "OrderedCollections", package: "swift-collections"),
-        ]
-    ),
-
-    .executableTarget(
-        name: "MultiNodeTestKitRunner",
-        dependencies: [
-            // Depend on tests to run:
-            "DistributedActorsMultiNodeTests",
-
-            // Dependencies:
-            "MultiNodeTestKit",
-            .product(name: "ArgumentParser", package: "swift-argument-parser"),
-        ]
-    ),
-
-    // ==== ----------------------------------------------------------------------------------------------------------------
     // MARK: Tests
 
     .testTarget(
@@ -92,14 +65,6 @@ var targets: [PackageDescription.Target] = [
             "DistributedActors",
             "DistributedActorsTestKit",
         ]
-    ),
-
-    .target(
-        name: "DistributedActorsMultiNodeTests",
-        dependencies: [
-            "MultiNodeTestKit",
-        ],
-        path: "MultiNodeTests/DistributedActorsMultiNodeTests"
     ),
 
 //    .testTarget(
@@ -179,7 +144,7 @@ var dependencies: [Package.Dependency] = [
 //    .package(name: "swift-cluster-membership", path: "Packages/swift-cluster-membership"), // FIXME: just work in progress
     .package(url: "https://github.com/apple/swift-cluster-membership", branch: "main"),
 
-    .package(url: "https://github.com/apple/swift-nio", from: "2.40.0"),
+    .package(url: "https://github.com/apple/swift-nio", from: "2.43.1"),
     .package(url: "https://github.com/apple/swift-nio-extras", from: "1.2.0"),
     .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.16.1"),
 
@@ -201,9 +166,6 @@ var dependencies: [Package.Dependency] = [
 
     // ~~~ SwiftPM Plugins ~~~
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-
-    // ~~~ MultiNode Testing ~~~
-    .package(name: "MultiNodeTestPlugin", path: "./InternalPlugins/MultiNodeTest/"),
 
     // ~~~ Command Line ~~~~
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.3"),
@@ -240,6 +202,55 @@ if ProcessInfo.processInfo.environment["VALIDATE_DOCS"] != nil {
             ]
         )
     )
+}
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: MultiNodeTestKit
+
+// TODO: https://github.com/apple/swift-distributed-actors/issues/1064
+//       This is a workaround since when other packages DEPEND ON this package,
+//       they'd fail because we depend on a "local package" and SwiftPM does not understand
+//       that we only use this dependency within the package.
+//       Real solution: Multi node tests must become a real package plugin:
+if ProcessInfo.processInfo.environment["MULTI_NODE_TESTS"] != nil {
+    targets.append(contentsOf: [
+        // MultiNodeTest library
+        .target(
+                name: "MultiNodeTestKit",
+                dependencies: [
+                    "DistributedActors",
+                    // "DistributedActorsTestKit", // can't depend on it because it'll pull in XCTest, and that crashes in executable then
+                    .product(name: "Backtrace", package: "swift-backtrace"),
+                    .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
+                    .product(name: "Atomics", package: "swift-atomics"),
+                    .product(name: "OrderedCollections", package: "swift-collections"),
+                ]
+        ),
+        .executableTarget(
+                name: "MultiNodeTestKitRunner",
+                dependencies: [
+                    // Depend on tests to run:
+                    "DistributedActorsMultiNodeTests",
+
+                    // Dependencies:
+                    "MultiNodeTestKit",
+                    .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                ]
+        ),
+
+        // MultiNodeTests declared within this project
+        .target(
+                name: "DistributedActorsMultiNodeTests",
+                dependencies: [
+                    "MultiNodeTestKit",
+                ],
+                path: "MultiNodeTests/DistributedActorsMultiNodeTests"
+        ),
+    ])
+
+    dependencies.append(contentsOf: [// ~~~ MultiNode Testing ~~~
+        .package(name: "MultiNodeTestPlugin", path: "./InternalPlugins/MultiNodeTest/"),
+    ])
 }
 
 // This is a workaround since current published nightly docker images don't have the latest Swift availabilities yet

--- a/Sources/DistributedActors/ClusterSystem.swift
+++ b/Sources/DistributedActors/ClusterSystem.swift
@@ -1327,7 +1327,7 @@ extension ClusterSystem {
         ])
 
         let anyReturn = try await withCheckedThrowingContinuation { cc in
-            Task { [invocation] in
+            Task { [invocation] in // FIXME: make an async stream here since we lost ordering guarantees here
                 var directDecoder = ClusterInvocationDecoder(system: self, invocation: invocation)
                 let directReturnHandler = ClusterInvocationResultHandler(directReturnContinuation: cc)
 

--- a/docker/docker-compose.2004.57.yaml
+++ b/docker/docker-compose.2004.57.yaml
@@ -16,7 +16,7 @@ services:
 
   integration-tests:
     image: swift-distributed-actors:20.04-57
-    command: /bin/bash -cl "swift package --disable-sandbox multi-node test"
+    command: /bin/bash -cl "MULTI_NODE_TESTS=yes swift package --disable-sandbox multi-node test"
 
   test:
     image: swift-distributed-actors:20.04-57

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -18,7 +18,7 @@ services:
 
   integration-tests:
     image: swift-distributed-actors:20.04-main
-    command: /bin/bash -cl "swift package --disable-sandbox multi-node test"
+    command: /bin/bash -cl "MULTI_NODE_TESTS=yes swift package --disable-sandbox multi-node test"
 
   test:
     image: swift-distributed-actors:20.04-main

--- a/docker/docker-compose.custom.yaml
+++ b/docker/docker-compose.custom.yaml
@@ -40,7 +40,7 @@ services:
 
   integration-tests:
     <<: *common
-    command: /bin/bash -cl "swift package --disable-sandbox multi-node test"
+    command: /bin/bash -cl "MULTI_NODE_TESTS=yes swift package --disable-sandbox multi-node test"
 
   test:
     <<: *common

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
 
   integration-tests:
     <<: *common
-    command: /bin/bash -cl "swift package --disable-sandbox multi-node test"
+    command: /bin/bash -cl "MULTI_NODE_TESTS=yes swift package --disable-sandbox multi-node test"
 
   test:
     <<: *common


### PR DESCRIPTION
while we started using MultiNodeTestKit -- it has to do with the fact that we're using a "local plugin" and SwiftPM thinks that's not usable for other libraries -- but yeah, they are NOT using it since it is not a public plugin so it is not an issue.

The real solution will be either making SwiftPM smarter about it, or making MultiNode a real plugin with its own package.

Workaround for https://github.com/apple/swift-distributed-actors/issues/1064