### PR TITLE
Fix typo: Lifecycle example

### DIFF
--- a/Sources/DistributedActors/Docs.docc/Lifecycle.md
+++ b/Sources/DistributedActors/Docs.docc/Lifecycle.md
@@ -23,8 +23,8 @@ distributed actor Romeo: LifecycleWatch {
         print("\(Self.self) terminated!")
     }
 
-    distributed func watch(_ romeo: Romeo) {
-        watchTermination(of: romeo)
+    distributed func watch(_ juliet: Juliet) {
+        watchTermination(of: juliet)
     }
     
     func terminated(actor id: ActorID) async {


### PR DESCRIPTION
A typo in a documentation

### Modifications:

changes the `watch(_ romeo: Romeo)` in Romeo actor

