### PR TITLE
Fix overflow in TimeSpec addition on 32-bit architectures

### DIFF
--- a/Sources/DistributedCluster/TimeSpec.swift
+++ b/Sources/DistributedCluster/TimeSpec.swift
@@ -45,15 +45,14 @@ extension TimeSpec {
     @usableFromInline
     internal static func + (a: timespec, b: timespec) -> timespec {
         let totalNanos = a.toNanos() + b.toNanos()
-        let seconds = totalNanos / NANOS
         var result = timespec()
-        result.tv_sec = seconds
-        result.tv_nsec = totalNanos % NANOS
+        result.tv_sec = Int(totalNanos / Int64(NANOS))
+        result.tv_nsec = Int(totalNanos % Int64(NANOS))
         return result
     }
 
     @usableFromInline
-    internal func toNanos() -> Int {
-        self.tv_nsec + (self.tv_sec * NANOS)
+    internal func toNanos() -> Int64 {
+        Int64(self.tv_nsec) + (Int64(self.tv_sec) * Int64(NANOS))
     }
 }

--- a/Tests/DistributedClusterTests/TimeSpecTests.swift
+++ b/Tests/DistributedClusterTests/TimeSpecTests.swift
@@ -38,7 +38,7 @@ class TimeSpecTests: XCTestCase {
     }
 
     func test_timeSpecShouldBeCreatedProperlyFromDuration() {
-        self.total.toNanos().shouldEqual(Int(self.totalDuration.nanoseconds))
+        self.total.toNanos().shouldEqual(Int64(self.totalDuration.nanoseconds))
         self.total.tv_sec.shouldEqual(Int(self.totalDuration.nanoseconds) / NANOS)
         self.total.tv_nsec.shouldEqual(Int(self.totalDuration.nanoseconds) % NANOS)
     }


### PR DESCRIPTION
When Int is 32 bits, converting seconds to nanoseconds overflows. This change uses Int64 explicitly.

The change has been verified on a custom Linux armv7 system. Cross-compilation was used for the armv7 build, so I wasn't able to run the tests for that, but all tests pass on x86_64.