### PR TITLE
Create .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,3 @@
+version: 1
+external_links:
+  documentation: "https://apple.github.io/swift-distributed-actors"


### PR DESCRIPTION
This adds support for a documentation link on the Swift Package Index.

[![CleanShot 2022-10-28 at 16 59 35@2x](https://user-images.githubusercontent.com/65520/198664466-f5fca91b-e711-466c-a522-e5a0dc76aa69.png)](https://swiftpackageindex.com/SwiftPackageIndex/SemanticVersion)


### Motivation:

This will make the existing documentation easily accessible in usual place on the Swift Package Index.
