### PR TITLE
Use Serialization instead of JSONEncoder in recordArgument()

### DIFF
--- a/Sources/DistributedCluster/Serialization/Serialization+Invocation.swift
+++ b/Sources/DistributedCluster/Serialization/Serialization+Invocation.swift
@@ -44,12 +44,8 @@ public struct ClusterInvocationEncoder: DistributedTargetInvocationEncoder {
     }
 
     public mutating func recordArgument<Value: Codable>(_ argument: RemoteCallArgument<Value>) throws {
-//        let serialized = try self.system.serialization.serialize(argument.value)
-//        let data = serialized.buffer.readData()
-        let encoder = JSONEncoder()
-        encoder.userInfo[.actorSystemKey] = self.system
-        encoder.userInfo[.actorSerializationContext] = self.system.serialization.context
-        let data = try encoder.encode(argument.value)
+        let serialized = try self.system.serialization.serialize(argument.value)
+        let data = serialized.buffer.readData()
         self.arguments.append(data)
     }
 


### PR DESCRIPTION
Int arguments were serialized as Strings, but the deserializer expected bytes. I found these commented lines of code that seemed to be the correct way of serializing instead of using JSONEncoder, but I'm not sure if that is true. If it is, I guess the reason these were comments might still apply, but it does work in my simple application and all tests are successful.