### PR TITLE
+sample DistributedBuilds a fun example pretending to be a "jenkins"-like thing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 *.orig
 *.app
+.history
 
 Instruments/ActorInstruments/ActorInstruments.xcodeproj/xcuserdata
 Instruments/ActorInstruments/build/

--- a/Package.swift
+++ b/Package.swift
@@ -39,11 +39,13 @@ var targets: [PackageDescription.Target] = [
             .product(name: "NIOSSL", package: "swift-nio-ssl"),
             .product(name: "NIOExtras", package: "swift-nio-extras"),
             .product(name: "SwiftProtobuf", package: "swift-protobuf"),
-            .product(name: "Logging", package: "swift-log"),
-            .product(name: "Metrics", package: "swift-metrics"),
             .product(name: "ServiceDiscovery", package: "swift-service-discovery"),
             .product(name: "Backtrace", package: "swift-backtrace"),
             .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
+            // Observability
+            .product(name: "Logging", package: "swift-log"),
+            .product(name: "Metrics", package: "swift-metrics"),
+            .product(name: "Tracing", package: "swift-distributed-tracing"),
         ]
     ),
 
@@ -182,7 +184,8 @@ var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-collections", from: "1.0.1"),
 
     // ~~~ Observability ~~~
-    .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),
+    .package(url: "https://github.com/apple/swift-log", from: "1.4.0"),
+    .package(url: "https://github.com/apple/swift-distributed-tracing", branch: "main"),
     // swift-metrics 1.x and 2.x are almost API compatible, so most clients should use
     .package(url: "https://github.com/apple/swift-metrics", "1.0.0" ..< "3.0.0"),
     .package(url: "https://github.com/apple/swift-service-discovery", from: "1.0.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -185,7 +185,7 @@ var dependencies: [Package.Dependency] = [
 
     // ~~~ Observability ~~~
     .package(url: "https://github.com/apple/swift-log", from: "1.4.0"),
-    .package(url: "https://github.com/apple/swift-distributed-tracing", branch: "main"),
+    .package(url: "https://github.com/apple/swift-distributed-tracing", from: "0.3.0"),
     // swift-metrics 1.x and 2.x are almost API compatible, so most clients should use
     .package(url: "https://github.com/apple/swift-metrics", "1.0.0" ..< "3.0.0"),
     .package(url: "https://github.com/apple/swift-service-discovery", from: "1.0.0"),

--- a/Samples/Package.swift
+++ b/Samples/Package.swift
@@ -37,8 +37,17 @@ var targets: [PackageDescription.Target] = [
             .product(name: "OpenTelemetry", package: "opentelemetry-swift"),
             .product(name: "OtlpGRPCSpanExporting", package: "opentelemetry-swift"),
             "_PrettyLogHandler",
-        ],
-        path: "Sources/SampleClusterTracing"
+        ]
+    ),
+
+    .executableTarget(
+        name: "SampleClusterBuilds",
+        dependencies: [
+            .product(name: "DistributedCluster", package: "swift-distributed-actors"),
+            .product(name: "OpenTelemetry", package: "opentelemetry-swift"),
+            .product(name: "OtlpGRPCSpanExporting", package: "opentelemetry-swift"),
+            "_PrettyLogHandler",
+        ]
     ),
 
     .target(

--- a/Samples/Package.swift
+++ b/Samples/Package.swift
@@ -21,11 +21,30 @@ var targets: [PackageDescription.Target] = [
         name: "SampleDiningPhilosophers",
         dependencies: [
             .product(name: "DistributedCluster", package: "swift-distributed-actors"),
+            "_PrettyLogHandler",
         ],
         path: "Sources/SampleDiningPhilosophers",
         exclude: [
             "dining-philosopher-fsm.graffle",
             "dining-philosopher-fsm.svg",
+        ]
+    ),
+
+    .executableTarget(
+        name: "SampleClusterTracing",
+        dependencies: [
+            .product(name: "DistributedCluster", package: "swift-distributed-actors"),
+            .product(name: "OpenTelemetry", package: "opentelemetry-swift"),
+            .product(name: "OtlpGRPCSpanExporting", package: "opentelemetry-swift"),
+            "_PrettyLogHandler",
+        ],
+        path: "Sources/SampleClusterTracing"
+    ),
+
+    .target(
+        name: "_PrettyLogHandler",
+        dependencies: [
+            .product(name: "DistributedCluster", package: "swift-distributed-actors"),
         ]
     ),
 
@@ -45,6 +64,7 @@ var dependencies: [Package.Dependency] = [
     .package(name: "swift-distributed-actors", path: "../"),
 
     // ~~~~~~~ only for samples ~~~~~~~
+    .package(url: "https://github.com/slashmo/opentelemetry-swift", branch: "main"),
 ]
 
 let package = Package(
@@ -58,10 +78,13 @@ let package = Package(
     ],
     products: [
         /* ---  samples --- */
-
         .executable(
             name: "SampleDiningPhilosophers",
             targets: ["SampleDiningPhilosophers"]
+        ),
+        .executable(
+            name: "SampleClusterTracing",
+            targets: ["SampleClusterTracing"]
         ),
     ],
 

--- a/Samples/Package.swift
+++ b/Samples/Package.swift
@@ -64,7 +64,7 @@ var dependencies: [Package.Dependency] = [
     .package(name: "swift-distributed-actors", path: "../"),
 
     // ~~~~~~~ only for samples ~~~~~~~
-    .package(url: "https://github.com/slashmo/opentelemetry-swift", branch: "main"),
+    .package(url: "https://github.com/slashmo/opentelemetry-swift", from: "0.3.0"),
 ]
 
 let package = Package(

--- a/Samples/Sources/SampleClusterBuilds/ClusterBuilds.swift
+++ b/Samples/Sources/SampleClusterBuilds/ClusterBuilds.swift
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2018-2022 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import _PrettyLogHandler
+import Distributed
+import DistributedCluster
+import Logging
+import NIO
+import OpenTelemetry
+import OtlpGRPCSpanExporting
+import Tracing
+
+struct ClusterBuilds {
+    let system: ClusterSystem
+    var workers: [ActorID: BuildWorker] = [:]
+
+    init(name: String, port: Int) async {
+        self.system = await ClusterSystem(name) { settings in
+            settings.bindPort = port
+
+            settings.plugins.install(plugin: ClusterSingletonPlugin())
+
+            // We are purposefully making allowing long calls:
+            settings.remoteCall.defaultTimeout = .seconds(20)
+
+            // Try joining this seed node automatically; once we have joined at least once node, we'll learn about others.
+            settings.discovery = ServiceDiscoverySettings(static: [
+                Main.Config.seedEndpoint
+            ])
+        }
+        self.system.cluster.join(endpoint: Main.Config.seedEndpoint)
+    }
+
+    mutating func run(tasks: Int) async throws {
+        var singletonSettings = ClusterSingletonSettings()
+        singletonSettings.allocationStrategy = .byLeadership
+
+        let buildTasks: [BuildTask] = (0..<tasks).map { _ in BuildTask() }
+
+        // anyone can host the singleton, but by default, it'll be on the build leader (7330) various strategies are possible.
+        let ref = try await system.singleton.host(name: BuildLeader.singletonName) { actorSystem in
+            return await BuildLeader(buildTasks: buildTasks, actorSystem: actorSystem)
+        }
+
+        // all nodes, except the build-leader node contain a few workers:
+        if system.isBuildWorker {
+            func makeWorker() async {
+                let worker = await BuildWorker(actorSystem: self.system)
+                workers[worker.id] = worker
+            }
+
+            for _ in 0..<Main.Config.workersPerNode {
+                await makeWorker()
+            }
+        }
+    }
+}

--- a/Samples/Sources/SampleClusterBuilds/Convenience/Clock+Extensions.swift
+++ b/Samples/Sources/SampleClusterBuilds/Convenience/Clock+Extensions.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2018-2022 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import _PrettyLogHandler
+import Distributed
+import DistributedCluster
+import Logging
+import NIO
+import OpenTelemetry
+import OtlpGRPCSpanExporting
+import Tracing
+
+// Sleep, with adding a little bit of noise (additional delay) to the duration.
+func noisySleep(for duration: ContinuousClock.Duration) async {
+    var duration = duration + .milliseconds(Int.random(in: 200 ..< 500))
+    try? await Task.sleep(until: ContinuousClock.now + duration, clock: .continuous)
+}

--- a/Samples/Sources/SampleClusterBuilds/Convenience/Roles.swift
+++ b/Samples/Sources/SampleClusterBuilds/Convenience/Roles.swift
@@ -26,8 +26,8 @@ extension ClusterSystem {
     var isBuildLeader: Bool {
         self.cluster.endpoint.port == 7330
     }
+
     var isBuildWorker: Bool {
         self.cluster.endpoint.port > 7330
-
     }
 }

--- a/Samples/Sources/SampleClusterBuilds/Convenience/Roles.swift
+++ b/Samples/Sources/SampleClusterBuilds/Convenience/Roles.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2018-2022 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import _PrettyLogHandler
+import Distributed
+import DistributedCluster
+import Logging
+import NIO
+import OpenTelemetry
+import OtlpGRPCSpanExporting
+import Tracing
+
+// TODO: we want to support "member roles" in membership, this would be then a built in query, and not hardcoded by port either.
+extension ClusterSystem {
+    var isBuildLeader: Bool {
+        self.cluster.endpoint.port == 7330
+    }
+    var isBuildWorker: Bool {
+        self.cluster.endpoint.port > 7330
+
+    }
+}

--- a/Samples/Sources/SampleClusterBuilds/Convenience/Weak.swift
+++ b/Samples/Sources/SampleClusterBuilds/Convenience/Weak.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2018-2022 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Distributed
+import DistributedCluster
+
+final class Weak<Act: DistributedActor> {
+    weak var actor: Act?
+
+    init(_ actor: Act) {
+        self.actor = actor
+    }
+
+    init(idForRemoval id: ClusterSystem.ActorID) {
+        self.actor = nil
+    }
+}

--- a/Samples/Sources/SampleClusterBuilds/DefaultActorSystem.swift
+++ b/Samples/Sources/SampleClusterBuilds/DefaultActorSystem.swift
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2018-2022 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Distributed
+import DistributedCluster
+
+typealias DefaultDistributedActorSystem = ClusterSystem

--- a/Samples/Sources/SampleClusterBuilds/Model.swift
+++ b/Samples/Sources/SampleClusterBuilds/Model.swift
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2018-2022 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import _PrettyLogHandler
+import Distributed
+import DistributedCluster
+import Logging
+import NIO
+import struct Foundation.UUID
+import OpenTelemetry
+import OtlpGRPCSpanExporting
+import Tracing
+
+struct BuildTask: Sendable, Codable, Hashable {
+    let id: BuildTaskID
+
+    // this would have some state about "what to build"
+
+    init() {
+        self.id = .init()
+    }
+    init(id: BuildTaskID) {
+        self.id = id
+    }
+}
+
+/// A trivial "build result" representation, not carrying additional information, just for demonstration purposes.
+enum BuildResult: Sendable, Codable, Equatable {
+    case successful
+    case failed
+    case rejected
+}
+
+struct BuildTaskID: Sendable, Codable, Hashable, CustomStringConvertible {
+    let id: UUID
+    init() {
+        self.id = UUID()
+    }
+
+    var description: String {
+        "\(id)"
+    }
+}

--- a/Samples/Sources/SampleClusterBuilds/Model.swift
+++ b/Samples/Sources/SampleClusterBuilds/Model.swift
@@ -15,9 +15,9 @@
 import _PrettyLogHandler
 import Distributed
 import DistributedCluster
+import struct Foundation.UUID
 import Logging
 import NIO
-import struct Foundation.UUID
 import OpenTelemetry
 import OtlpGRPCSpanExporting
 import Tracing
@@ -30,6 +30,7 @@ struct BuildTask: Sendable, Codable, Hashable {
     init() {
         self.id = .init()
     }
+
     init(id: BuildTaskID) {
         self.id = id
     }

--- a/Samples/Sources/SampleClusterBuilds/Roles/BuildLeader.swift
+++ b/Samples/Sources/SampleClusterBuilds/Roles/BuildLeader.swift
@@ -1,0 +1,182 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2018-2022 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import DistributedCluster
+import Logging
+import DequeModule
+
+distributed actor BuildLeader: ClusterSingleton, LifecycleWatch {
+    static let singletonName = "BuildLeader"
+
+    lazy var log: Logger = Logger(actor: self)
+
+    var initialTasks: Int
+    var remainingTasks: Deque<BuildTask>
+
+    var totalWorkers: [ActorID: Weak<BuildWorker>] = [:]
+    var workerAssignment: [ActorID: BuildTask] = [:]
+
+    var availableWorkers: AsyncStream<BuildWorker>!
+    var availableWorkersCC: AsyncStream<BuildWorker>.Continuation!
+
+    var membership: Cluster.Membership = .empty
+
+    init(buildTasks: [BuildTask], actorSystem: ActorSystem) async {
+        self.actorSystem = actorSystem
+        self.initialTasks = buildTasks.count
+        self.remainingTasks = Deque(buildTasks)
+
+        self.availableWorkers = AsyncStream(BuildWorker.self) { cc in
+            self.availableWorkersCC = cc
+        }
+
+        log.notice("\(Self.self) initialized on [\(actorSystem.cluster.node)]")
+        Task {
+            await self.discoverBuildWorkers()
+        }
+        Task {
+            await self.subscribeMembership()
+        }
+        Task {
+            try await self.processAllBuildTasks()
+        }
+    }
+
+    func processAllBuildTasks() async throws -> BuildStats {
+        log.notice("Process all build tasks \(self.remainingTasks.count)", metadata: [
+            "tasks/remaining": "\(self.remainingTasks.count)",
+            "workers/count": "\(totalWorkers.count)",
+        ])
+        /// Keep searching for available workers until we have processed all BuildTasks.
+        for try await availableWorker in availableWorkers {
+            guard let buildTask = self.remainingTasks.popFirst() else {
+                break // no more tasks!
+            }
+            
+            self.workerAssignment[availableWorker.id] = buildTask
+            log.notice("Schedule work [\(buildTask.id)] on [\(availableWorker)]!", metadata: [
+                "tasks/remaining": "\(self.remainingTasks.count)",
+                "workers/total": "\(self.totalWorkers.count)",
+                "workers/available": "\(self.totalWorkers.count - self.workerAssignment.count)",
+                "workers/assigned": "\(self.workerAssignment.count)",
+                "workers/nodes": "\(self.membership.count(atLeast: .up))",
+            ])
+
+            Task {
+                do {
+                    let result = try await availableWorker.work(on: buildTask, reportLogs: nil)
+                    self.builtTaskCompleted(result, by: availableWorker)
+                } catch {
+                    self.builtTaskCompleted(.failed, by: availableWorker)
+                }
+            }
+        }
+
+        return self.stats()
+    }
+
+    private func builtTaskCompleted(_ result: BuildResult, by worker: BuildWorker) {
+        guard let assignedTask = self.workerAssignment.removeValue(forKey: worker.id) else {
+            log.warning("Worker [\(worker)] completed task but wasn't assigned any!")
+            return
+        }
+
+        log.notice("Task [\(assignedTask.id)] was completed [\(result)] by [\(worker)]!")
+        switch result {
+        case.successful:
+            break
+        case .rejected, .failed:
+            log.notice("Task [\(assignedTask.id)] was [\(result)], so we must schedule it again...")
+            self.remainingTasks.append(assignedTask)
+        }
+
+        if self.totalWorkers[worker.id] != nil {
+            log.notice("Worker \(worker.id) is available for other work again!")
+            // the worker is not terminated, good.
+            self.availableWorkersCC.yield(worker)
+        } else {
+            log.notice("Worker \(worker.id) seems to have failed, not available for new work...")
+        }
+    }
+
+    func workerAvailable(_ worker: BuildWorker) {
+        self.totalWorkers[worker.id] = .init(worker)
+    }
+
+    func stats() -> BuildStats {
+        .init(total: self.initialTasks, processed: self.initialTasks - remainingTasks.count)
+    }
+
+}
+
+struct BuildStats: Sendable, Codable, CustomStringConvertible {
+    let total: Int
+    let processed: Int
+
+    var complete: Bool {
+        self.total == self.processed
+    }
+
+    init(total: Int, processed: Int) {
+        self.total = total
+        self.processed = processed
+    }
+
+    var description: String {
+        "BuildStats(total: \(total), processed: \(processed), complete: \(complete))"
+    }
+}
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: Maintaining worker statuses
+
+extension BuildLeader {
+
+    func discoverBuildWorkers() async {
+        log.notice("Discovering \(BuildWorker.self) actors...")
+        for await worker in await self.actorSystem.receptionist.listing(of: BuildWorker.self) {
+            self.totalWorkers[worker.id] = .init(worker)
+            log.notice("Discovered new \(BuildWorker.self)", metadata: [
+                "discovered/id": "\(worker.id)",
+                "workers/count": "\(self.totalWorkers.count)",
+            ])
+
+            self.availableWorkersCC.yield(watchTermination(of: worker))
+        }
+    }
+
+    func subscribeMembership() async {
+        for await event in self.actorSystem.cluster.events {
+            try? self.membership.apply(event: event)
+        }
+    }
+
+    func terminated(actor id: ClusterSystem.ActorID) async {
+        log.warning("Worker actor \(id) terminated, removed from available workers", metadata: [
+            "terminated/id": "\(id)",
+            "workers/total": "\(self.totalWorkers.count)",
+            "workers/available": "\(self.totalWorkers.count - self.workerAssignment.count)",
+            "workers/assigned": "\(self.workerAssignment.count)",
+            "workers/nodes": "\(self.membership.count(atLeast: .up))",
+        ])
+
+        _ = self.totalWorkers.removeValue(forKey: id)
+
+        if let interruptedTask = self.workerAssignment.removeValue(forKey: id) {
+            self.log.warning("Worker [\(id)] was working on [\(interruptedTask)], re-scheduling this task...")
+            self.remainingTasks.append(interruptedTask)
+        }
+
+    }
+}

--- a/Samples/Sources/SampleClusterBuilds/Roles/BuildWorker.swift
+++ b/Samples/Sources/SampleClusterBuilds/Roles/BuildWorker.swift
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2018-2022 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import DistributedCluster
+import Logging
+
+distributed actor BuildWorker: CustomStringConvertible {
+    lazy var log = Logger(actor: self)
+    var activeBuildTask: BuildTask?
+
+    @ActorID.Metadata(\.receptionID)
+    var receptionID: String
+
+    init(actorSystem: ActorSystem) async {
+        self.actorSystem = actorSystem
+
+        self.receptionID = "*" // default key for "all of this type"
+        await actorSystem.receptionist.checkIn(self)
+        log.notice("Build worker initialized on \(actorSystem.cluster.node)")
+    }
+
+    distributed func work(on task: BuildTask, reportLogs log: LogCollector? = nil) async -> BuildResult {
+        if let activeBuildTask = self.activeBuildTask {
+            self.log.warning("Reject task [\(task)], already working on [\(activeBuildTask)]")
+            return .rejected
+        }
+
+        self.activeBuildTask = task
+        defer { self.activeBuildTask = nil }
+
+        log?.log(line: "Starting build \(task)...")
+        await noisySleep(for: .seconds(1))
+
+        for i in 1...5 {
+            log?.log(line: "Building file \(i)/5")
+            await noisySleep(for: .seconds(1))
+        }
+
+        for i in 1...5 {
+            log?.log(line: "Testing \(i)/5")
+            await noisySleep(for: .seconds(1))
+        }
+
+        return .successful
+    }
+
+    public nonisolated var description: String {
+        "\(Self.self)(\(self.id))"
+    }
+}

--- a/Samples/Sources/SampleClusterBuilds/Roles/LogCollector.swift
+++ b/Samples/Sources/SampleClusterBuilds/Roles/LogCollector.swift
@@ -15,8 +15,5 @@
 import DistributedCluster
 
 distributed actor LogCollector {
-
-    nonisolated func log(line: String) {
-
-    }
+    nonisolated func log(line: String) {}
 }

--- a/Samples/Sources/SampleClusterBuilds/Roles/LogCollector.swift
+++ b/Samples/Sources/SampleClusterBuilds/Roles/LogCollector.swift
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2018-2022 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import DistributedCluster
+
+distributed actor LogCollector {
+
+    nonisolated func log(line: String) {
+
+    }
+}

--- a/Samples/Sources/SampleClusterBuilds/boot.swift
+++ b/Samples/Sources/SampleClusterBuilds/boot.swift
@@ -23,7 +23,6 @@ import Tracing
 
 @main
 enum Main {
-
     enum Config {
         // "seed" node that all others will join (and learn about other nodes in the cluster automatically)
         static let seedEndpoint = Cluster.Endpoint(host: "127.0.0.1", port: 7330) // just a convention, leader can be decided in various ways
@@ -65,7 +64,6 @@ enum Main {
 
         let otel = OTel(serviceName: nodeName, eventLoopGroup: group, processor: processor)
         InstrumentationSystem.bootstrap(otel.tracer())
-
 
         var app = await ClusterBuilds(name: nodeName, port: port)
         try! await app.run(tasks: Main.Config.totalBuildTasks)

--- a/Samples/Sources/SampleClusterBuilds/boot.swift
+++ b/Samples/Sources/SampleClusterBuilds/boot.swift
@@ -1,0 +1,80 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2018-2022 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import _PrettyLogHandler
+import Distributed
+import DistributedCluster
+import Logging
+import NIO
+import OpenTelemetry
+import OtlpGRPCSpanExporting
+import Tracing
+
+@main
+enum Main {
+
+    enum Config {
+        // "seed" node that all others will join (and learn about other nodes in the cluster automatically)
+        static let seedEndpoint = Cluster.Endpoint(host: "127.0.0.1", port: 7330) // just a convention, leader can be decided in various ways
+
+        // How many workers per node
+        static let workersPerNode = 2
+        // How many tasks should the leader try to process, scaling out computation to workers.
+        static let totalBuildTasks = 100
+    }
+
+    static func main() async throws {
+        print("===---------------------------------------------------------===")
+        print("|            Sample Cluster Builds                            |")
+        print("|                                                             |")
+        print("| USAGE:                                                      |")
+        print("|        swift run SampleClusterBuilds 7330 (becomes leader)  |")
+        print("|        swift run SampleClusterBuilds 7331 worker            |")
+        print("|        swift run SampleClusterBuilds ...  worker            |")
+        print("===---------------------------------------------------------===")
+
+        let port = Int(CommandLine.arguments.dropFirst().first ?? "7330")!
+        let role: ClusterNodeRole
+        if port == 7330 {
+            role = .leader
+        } else if CommandLine.arguments.dropFirst(2).first == "worker" {
+            role = .worker
+        } else {
+            fatalError("Undefined role for node: \(port)! Available roles: \(ClusterNodeRole.allCases)")
+        }
+        let nodeName = "ClusterBuilds-\(port)-\(role)"
+
+        // Bootstrap logging:
+        LoggingSystem.bootstrap(SamplePrettyLogHandler.init)
+
+        // Bootstrap OpenTelemetry tracing:
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let exporter = OtlpGRPCSpanExporter(config: OtlpGRPCSpanExporter.Config(eventLoopGroup: group))
+        let processor = OTel.SimpleSpanProcessor(exportingTo: exporter)
+
+        let otel = OTel(serviceName: nodeName, eventLoopGroup: group, processor: processor)
+        InstrumentationSystem.bootstrap(otel.tracer())
+
+
+        var app = await ClusterBuilds(name: nodeName, port: port)
+        try! await app.run(tasks: Main.Config.totalBuildTasks)
+
+        try await app.system.terminated
+    }
+}
+
+enum ClusterNodeRole: CaseIterable, Hashable {
+    case leader
+    case worker
+}

--- a/Samples/Sources/SampleClusterTracing/Clock+Extensions.swift
+++ b/Samples/Sources/SampleClusterTracing/Clock+Extensions.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2018-2022 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import _PrettyLogHandler
+import Distributed
+import DistributedCluster
+import Logging
+import NIO
+import OpenTelemetry
+import OtlpGRPCSpanExporting
+import Tracing
+
+// Sleep, with adding a little bit of noise (additional delay) to the duration.
+func noisySleep(for duration: ContinuousClock.Duration) async {
+    var duration = duration + .milliseconds(Int.random(in: 100 ..< 300))
+    try? await Task.sleep(until: ContinuousClock.now + duration, clock: .continuous)
+}

--- a/Samples/Sources/SampleClusterTracing/Cooking/Chopping.swift
+++ b/Samples/Sources/SampleClusterTracing/Cooking/Chopping.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2018-2022 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import _PrettyLogHandler
+import Distributed
+import DistributedCluster
+import Logging
+import NIO
+import Tracing
+
+protocol Chopping {
+    func chop(_ vegetable: Vegetable) async throws -> Vegetable
+}
+
+distributed actor VegetableChopper: Chopping {
+    @ActorID.Metadata(\.receptionID)
+    var receptionID: String
+
+    init(actorSystem: ActorSystem) async {
+        self.actorSystem = actorSystem
+
+        self.receptionID = "*" // default key for "all of this type"
+        await actorSystem.receptionist.checkIn(self)
+    }
+
+    distributed func chop(_ vegetable: Vegetable) async throws -> Vegetable {
+        await InstrumentationSystem.tracer.withSpan(#function) { _ in
+            await noisySleep(for: .seconds(5))
+
+            return vegetable.asChopped
+        }
+    }
+}

--- a/Samples/Sources/SampleClusterTracing/Cooking/PrimaryCook.swift
+++ b/Samples/Sources/SampleClusterTracing/Cooking/PrimaryCook.swift
@@ -1,0 +1,143 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2018-2022 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import _PrettyLogHandler
+import Distributed
+import DistributedCluster
+import Logging
+import NIO
+import Tracing
+
+distributed actor PrimaryCook: LifecycleWatch {
+    lazy var log = Logger(actor: self)
+
+    var choppers: [ClusterSystem.ActorID: VegetableChopper] = [:]
+    var waitingForChoppers: (Int, CheckedContinuation<Void, Never>)?
+
+    init(actorSystem: ActorSystem) async {
+        self.actorSystem = actorSystem
+
+        _ = self.startChopperListingTask()
+    }
+
+    func startChopperListingTask() -> Task<Void, Never> {
+        Task {
+            for await chopper in await actorSystem.receptionist.listing(of: VegetableChopper.self) {
+                log.notice("Discovered vegetable chopper: \(chopper.id)")
+                self.choppers[chopper.id] = chopper
+
+                /// We implement a simple "if we're waiting for N choppers... let's notify the continuation once that is reached"
+                /// This would be nice to provide as a fun "active" collection type that can be `.waitFor(...)`-ed.
+                if let waitingForChoppersCount = self.waitingForChoppers?.0,
+                   choppers.count >= waitingForChoppersCount
+                {
+                    self.waitingForChoppers?.1.resume()
+                }
+            }
+        }
+    }
+
+    distributed func makeDinner() async throws -> Meal {
+        try await InstrumentationSystem.tracer.withSpan(#function) { _ in
+            await noisySleep(for: .milliseconds(200))
+
+            log.notice("Cooking dinner, but we need [2] vegetable choppers...! Suspend waiting for nodes to join.")
+            let (first, second) = try await getChoppers()
+            async let veggies = try chopVegetables(firstChopper: first, secondChopper: second)
+            async let meat = marinateMeat()
+            async let oven = preheatOven(temperature: 350)
+            // ...
+            return try await cook(veggies, meat, oven)
+        }
+    }
+
+    private func getChoppers() async throws -> (some Chopping, some Chopping) {
+        await withCheckedContinuation { cc in
+            self.waitingForChoppers = (2, cc)
+        }
+
+        var chopperIDs = self.choppers.keys.makeIterator()
+        guard let id1 = chopperIDs.next(),
+              let first = choppers[id1]
+        else {
+            throw NotEnoughChoppersError()
+        }
+        guard let id2 = chopperIDs.next(),
+              let second = choppers[id2]
+        else {
+            throw NotEnoughChoppersError()
+        }
+
+        return (first, second)
+    }
+
+    // Called by lifecycle watch when a watched actor terminates.
+    func terminated(actor id: DistributedCluster.ActorID) async {
+        self.choppers.removeValue(forKey: id)
+    }
+}
+
+func chopVegetables(firstChopper: some Chopping,
+                    secondChopper: some Chopping) async throws -> [Vegetable]
+{
+    try await InstrumentationSystem.tracer.withSpan("chopVegetables") { _ in
+        // Chop the vegetables...!
+        //
+        // However, since chopping is a very difficult operation,
+        // one chopping task can be performed at the same time on a single service!
+        // (Imagine that... we cannot parallelize these two tasks, and need to involve another service).
+        async let carrot = try firstChopper.chop(.carrot(chopped: false))
+        async let potato = try secondChopper.chop(.potato(chopped: false))
+        return try await [carrot, potato]
+    }
+}
+
+// func chop(_ vegetable: Vegetable, tracer: any Tracer) async throws -> Vegetable {
+//  await tracer.withSpan("chop-\(vegetable)") { _ in
+//    await sleep(for: .seconds(5))
+//   //  ...
+//    return vegetable // "chopped"
+//  }
+// }
+
+func marinateMeat() async -> Meat {
+    await noisySleep(for: .milliseconds(620))
+
+    return await InstrumentationSystem.tracer.withSpan("marinateMeat") { _ in
+        await noisySleep(for: .seconds(3))
+        // ...
+        return Meat()
+    }
+}
+
+func preheatOven(temperature: Int) async -> Oven {
+    await InstrumentationSystem.tracer.withSpan("preheatOven") { _ in
+        // ...
+        await noisySleep(for: .seconds(6))
+        return Oven()
+    }
+}
+
+func cook(_: Any, _: Any, _: Any) async -> Meal {
+    await InstrumentationSystem.tracer.withSpan("cook") { span in
+        span.addEvent("children-asking-if-done-already")
+        await noisySleep(for: .seconds(3))
+        span.addEvent("children-asking-if-done-already-again")
+        await noisySleep(for: .seconds(2))
+        // ...
+        return Meal()
+    }
+}
+
+struct NotEnoughChoppersError: Error {}

--- a/Samples/Sources/SampleClusterTracing/DefaultActorSystem.swift
+++ b/Samples/Sources/SampleClusterTracing/DefaultActorSystem.swift
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2018-2022 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Distributed
+import DistributedCluster
+
+typealias DefaultDistributedActorSystem = ClusterSystem

--- a/Samples/Sources/SampleClusterTracing/Model.swift
+++ b/Samples/Sources/SampleClusterTracing/Model.swift
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2018-2022 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import _PrettyLogHandler
+import Distributed
+import DistributedCluster
+import Logging
+import NIO
+import OpenTelemetry
+import OtlpGRPCSpanExporting
+import Tracing
+
+struct Meal: Sendable, Codable {}
+
+struct Meat: Sendable, Codable {}
+
+struct Oven: Sendable, Codable {}
+
+enum Vegetable: Sendable, Codable {
+    case potato(chopped: Bool)
+    case carrot(chopped: Bool)
+
+    var asChopped: Self {
+        switch self {
+        case .carrot: return .carrot(chopped: true)
+        case .potato: return .potato(chopped: true)
+        }
+    }
+}

--- a/Samples/Sources/SampleClusterTracing/Roles/ChoppingNode.swift
+++ b/Samples/Sources/SampleClusterTracing/Roles/ChoppingNode.swift
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2018-2022 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import _PrettyLogHandler
+import Distributed
+import DistributedCluster
+import Logging
+import NIO
+import Tracing
+
+struct ChoppingNode {
+    let system: ClusterSystem
+
+    var chopper: VegetableChopper?
+
+    init(name: String, port: Int) async {
+        self.system = await ClusterSystem(name) { settings in
+            settings.bindPort = port
+
+            // We are purposefully making very slow calls, so they show up nicely in tracing:
+            settings.remoteCall.defaultTimeout = .seconds(20)
+        }
+    }
+
+    mutating func run() async throws {
+        monitorMembership(on: self.system)
+
+        let leaderEndpoint = Cluster.Endpoint(host: self.system.cluster.endpoint.host, port: 7330)
+        self.system.log.notice("Joining: \(leaderEndpoint)")
+        self.system.cluster.join(endpoint: leaderEndpoint)
+
+        try await self.system.cluster.up(within: .seconds(30))
+        self.system.log.notice("Joined!")
+
+        let chopper = await VegetableChopper(actorSystem: system)
+        self.chopper = chopper
+        self.system.log.notice("Vegetable chopper \(chopper) started!")
+
+        for await chopper in await self.system.receptionist.listing(of: VegetableChopper.self) {
+            self.system.log.warning("GOT: \(chopper.id)")
+        }
+    }
+}

--- a/Samples/Sources/SampleClusterTracing/Roles/LeaderNode.swift
+++ b/Samples/Sources/SampleClusterTracing/Roles/LeaderNode.swift
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2018-2022 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import _PrettyLogHandler
+import Distributed
+import DistributedCluster
+import Logging
+import NIO
+import Tracing
+
+struct LeaderNode {
+    let system: ClusterSystem
+
+    init(name: String, port: Int) async {
+        self.system = await ClusterSystem(name) { settings in
+            settings.bindPort = port
+
+            // We are purposefully making very slow calls, so they show up nicely in tracing:
+            settings.remoteCall.defaultTimeout = .seconds(20)
+        }
+    }
+
+    func run() async throws {
+        monitorMembership(on: self.system)
+
+        let cook = await PrimaryCook(actorSystem: system)
+        let meal = try await cook.makeDinner()
+
+        self.system.log.notice("Made dinner successfully!")
+    }
+}

--- a/Samples/Sources/SampleClusterTracing/boot.swift
+++ b/Samples/Sources/SampleClusterTracing/boot.swift
@@ -24,9 +24,6 @@ import Tracing
 /*
  * Sample showcasing a long traced interaction.
  */
-
-typealias DefaultDistributedActorSystem = ClusterSystem
-
 @main enum Main {
     static func main() async throws {
         print("===-----------------------------------------------------===")

--- a/Samples/Sources/SampleClusterTracing/boot.swift
+++ b/Samples/Sources/SampleClusterTracing/boot.swift
@@ -1,0 +1,101 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2018-2022 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import _PrettyLogHandler
+import Distributed
+import DistributedCluster
+import Logging
+import NIO
+import OpenTelemetry
+import OtlpGRPCSpanExporting
+import Tracing
+
+/*
+ * Sample showcasing a long traced interaction.
+ */
+
+typealias DefaultDistributedActorSystem = ClusterSystem
+
+@main enum Main {
+    static func main() async throws {
+        print("===-----------------------------------------------------===")
+        print("|            Cluster Tracing Sample App                   |")
+        print("|                                                         |")
+        print("| USAGE:                                                  |")
+        print("|        swift run SampleClusterTracing # leader          |")
+        print("|        swift run SampleClusterTracing 7331 chopping     |")
+        print("|        swift run SampleClusterTracing 7332 chopping     |")
+        print("===-----------------------------------------------------===")
+
+        let port = Int(CommandLine.arguments.dropFirst().first ?? "7330")!
+        let role: ClusterNodeRole
+        if port == 7330 {
+            role = .leader
+        } else if CommandLine.arguments.dropFirst(2).first == "chopping" {
+            role = .chopping
+        } else {
+            fatalError("Undefined role for node: \(port)! Available roles: \(ClusterNodeRole.allCases)")
+        }
+        let nodeName = "SampleNode-\(port)-\(role)"
+
+        // Bootstrap logging:
+        LoggingSystem.bootstrap(SamplePrettyLogHandler.init)
+
+        // Bootstrap OpenTelemetry tracing:
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let exporter = OtlpGRPCSpanExporter(config: OtlpGRPCSpanExporter.Config(eventLoopGroup: group))
+        let processor = OTel.SimpleSpanProcessor(exportingTo: exporter)
+
+        let otel = OTel(serviceName: nodeName, eventLoopGroup: group, processor: processor)
+        InstrumentationSystem.bootstrap(otel.tracer())
+
+        // Start the sample app node.
+        // (All nodes attempt to join the leader at 7330, forming a cluster with it).
+        let system: ClusterSystem
+
+        if role == .leader {
+            let node = await LeaderNode(name: nodeName, port: port)
+            system = node.system
+            try! await node.run()
+        } else {
+            var node = await ChoppingNode(name: nodeName, port: port)
+            system = node.system
+            try! await node.run()
+        }
+
+        try await system.terminated
+    }
+}
+
+func monitorMembership(on system: ClusterSystem) {
+    Task {
+        for await event in system.cluster.events {
+            system.log.debug("Membership change: \(event)")
+
+            let membership = await system.cluster.membershipSnapshot
+            if membership.members(withStatus: .down).count == membership.count {
+                system.log.notice("Membership: \(membership.count)", metadata: [
+                    "cluster/membership": Logger.MetadataValue.array(membership.members(atMost: .down).map {
+                        "\($0)"
+                    }),
+                ])
+            }
+        }
+    }
+}
+
+enum ClusterNodeRole: CaseIterable, Hashable {
+    case leader
+    case chopping
+}

--- a/Samples/Sources/SampleDiningPhilosophers/boot.swift
+++ b/Samples/Sources/SampleDiningPhilosophers/boot.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import _PrettyLogHandler
 import Distributed
 import DistributedCluster
 import Logging

--- a/Samples/Sources/_PrettyLogHandler/SamplePrettyLogHandler.swift
+++ b/Samples/Sources/_PrettyLogHandler/SamplePrettyLogHandler.swift
@@ -76,7 +76,7 @@ public struct SamplePrettyLogHandler: LogHandler {
         let label: String
         if let id = effectiveMetadata.removeValue(forKey: "actor/id")?.description {
             if id.contains("[$wellKnown") {
-                label = String(id[id.firstIndex(of: "[")!..<id.endIndex])
+                label = String(id[id.firstIndex(of: "[")! ..< id.endIndex])
             } else {
                 label = id
             }

--- a/Samples/Sources/_PrettyLogHandler/SamplePrettyLogHandler.swift
+++ b/Samples/Sources/_PrettyLogHandler/SamplePrettyLogHandler.swift
@@ -74,7 +74,14 @@ public struct SamplePrettyLogHandler: LogHandler {
             nodeInfo += "\(node)"
         }
         let label: String
-        if let path = effectiveMetadata.removeValue(forKey: "actor/path")?.description {
+        if let id = effectiveMetadata.removeValue(forKey: "actor/id")?.description {
+            if id.contains("[$wellKnown") {
+                label = String(id[id.firstIndex(of: "[")!..<id.endIndex])
+            } else {
+                label = id
+            }
+            effectiveMetadata.removeValue(forKey: "actor/path")
+        } else if let path = effectiveMetadata.removeValue(forKey: "actor/path")?.description {
             label = path
         } else {
             label = ""

--- a/Samples/Sources/_PrettyLogHandler/SamplePrettyLogHandler.swift
+++ b/Samples/Sources/_PrettyLogHandler/SamplePrettyLogHandler.swift
@@ -29,7 +29,7 @@ import WASILibc
 #endif
 
 /// Logger that prints "pretty" for showcasing the cluster nicely in sample applications.
-struct SamplePrettyLogHandler: LogHandler {
+public struct SamplePrettyLogHandler: LogHandler {
     static let CONSOLE_RESET = "\u{001B}[0;0m"
     static let CONSOLE_BOLD = "\u{001B}[1m"
 
@@ -52,8 +52,7 @@ struct SamplePrettyLogHandler: LogHandler {
         }
     }
 
-    // internal for testing only
-    internal init(label: String) {
+    public init(label: String) {
         self.label = label
     }
 

--- a/Samples/docker/collector-config.yaml
+++ b/Samples/docker/collector-config.yaml
@@ -1,0 +1,24 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: otel-collector:4317
+
+exporters:
+  logging:
+    logLevel: debug
+
+  jaeger:
+    endpoint: "jaeger:14250"
+    tls:
+      insecure: true
+
+  zipkin:
+    endpoint: "http://zipkin:9411/api/v2/spans"
+
+
+service:
+  pipelines:
+    traces:
+      receivers: otlp
+      exporters: [logging, jaeger, zipkin]

--- a/Samples/docker/docker-compose.yaml
+++ b/Samples/docker/docker-compose.yaml
@@ -1,0 +1,26 @@
+version: '3'
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    command: ["--config=/etc/config.yaml"]
+    volumes:
+      - ./collector-config.yaml:/etc/config.yaml
+    ports:
+      - "4317:4317"
+    networks: [exporter]
+    depends_on: [zipkin, jaeger]
+
+  zipkin:
+    image: openzipkin/zipkin:latest
+    ports:
+      - "9411:9411"
+    networks: [exporter]
+
+  jaeger:
+    image: jaegertracing/all-in-one
+    ports:
+      - "16686:16686"
+    networks: [exporter]
+
+networks:
+  exporter:

--- a/Sources/DistributedActorsTestKit/Cluster/ClusteredActorSystemsXCTestCase.swift
+++ b/Sources/DistributedActorsTestKit/Cluster/ClusteredActorSystemsXCTestCase.swift
@@ -300,7 +300,11 @@ extension ClusteredActorSystemsXCTestCase {
         }
 
         return self.lock.withLock {
-            self._logCaptures[index]
+            if _logCaptures.count > index {
+                return self._logCaptures[index]
+            } else {
+                fatalError("Attempt to get logs but no logs captured for index \(index)!")
+            }
         }
     }
 

--- a/Sources/DistributedCluster/Cluster/Cluster+Membership.swift
+++ b/Sources/DistributedCluster/Cluster/Cluster+Membership.swift
@@ -703,6 +703,7 @@ extension Cluster {
             case notFoundAny(Cluster.Endpoint, in: Cluster.Membership)
             case atLeastStatusRequirementNotMet(expectedAtLeast: Cluster.MemberStatus, found: Cluster.Member)
             case statusRequirementNotMet(expected: Cluster.MemberStatus, found: Cluster.Member)
+            case countRequirementNotMet(expected: Int, expectedStatus: Cluster.MemberStatus)
             case awaitStatusTimedOut(Duration, Error?)
 
             var prettyDescription: String {
@@ -721,6 +722,8 @@ extension Cluster {
                     return "Expected \(reflecting: foundMember.node) to be seen as at-least [\(expectedAtLeastStatus)] but was [\(foundMember.status)]"
                 case .statusRequirementNotMet(let expectedStatus, let foundMember):
                     return "Expected \(reflecting: foundMember.node) to be seen as [\(expectedStatus)] but was [\(foundMember.status)]"
+                case .countRequirementNotMet(let count, let expectedStatus):
+                    return "Expected \(count) nodes to be seen as [\(expectedStatus)], but did not find enough"
                 case .awaitStatusTimedOut(let duration, let lastError):
                     let lastErrorMessage: String
                     if let error = lastError {

--- a/Sources/DistributedCluster/Cluster/ClusterShell.swift
+++ b/Sources/DistributedCluster/Cluster/ClusterShell.swift
@@ -148,12 +148,12 @@ internal class ClusterShell {
             return
         }
 
-        system.log.warning("Terminate existing association [\(reflecting: remoteNode)].")
+        system.log.info("Terminate existing association [\(reflecting: remoteNode)].")
 
         // notify the failure detector, that we shall assume this node as dead from here on.
         // it's gossip will also propagate the information through the cluster
         traceLog_Remote(system.cluster.node, "Finish terminate association [\(remoteNode)]: Notifying SWIM, .confirmDead")
-        system.log.warning("Confirm .dead to underlying SWIM, node: \(reflecting: remoteNode)")
+        system.log.debug("Confirm .dead to underlying SWIM, node: \(reflecting: remoteNode)")
         self._swimShell.confirmDead(node: remoteNode)
 
         // it is important that we first check the contains; as otherwise we'd re-add a .down member for what was already removed (!)
@@ -1059,7 +1059,7 @@ extension ClusterShell {
             // the change was a replacement and thus we need to down the old member (same host:port as the new one),
             // and terminate its association.
 
-            state.log.info("Accepted handshake from [\(reflecting: directive.handshake.remoteNode)] which replaces the previously known: [\(reflecting: replacedMember)].")
+            state.log.debug("Accepted handshake from [\(reflecting: directive.handshake.remoteNode)] which replaces the previously known: [\(reflecting: replacedMember)].")
 
             // We MUST be careful to first terminate the association and then store the new one in 2)
             self.terminateAssociation(context.system, state: &state, replacedMember.node)

--- a/Sources/DistributedCluster/Cluster/Leadership.swift
+++ b/Sources/DistributedCluster/Cluster/Leadership.swift
@@ -243,7 +243,7 @@ extension Leadership {
             if enoughMembers {
                 return self.selectByLowestAddress(context: context, membership: &membership, membersToSelectAmong: membersToSelectAmong)
             } else {
-                context.log.info("Not enough members [\(membersToSelectAmong.count)/\(self.minimumNumberOfMembersToDecide)] to run election, members: \(membersToSelectAmong)")
+                context.log.debug("Not enough members [\(membersToSelectAmong.count)/\(self.minimumNumberOfMembersToDecide)] to run election, members: \(membersToSelectAmong)")
                 if self.loseLeadershipIfBelowMinNrOfMembers {
                     return self.notEnoughMembers(context: context, membership: &membership, membersToSelectAmong: membersToSelectAmong)
                 } else {
@@ -300,7 +300,7 @@ extension Leadership {
                 .first
 
             if let change = try! membership.applyLeadershipChange(to: leader) { // try! safe, as we KNOW this member is part of membership
-                context.log.debug(
+                context.log.info(
                     "Selected new leader: [\(oldLeader, orElse: "nil") -> \(leader, orElse: "nil")]",
                     metadata: [
                         "membership": "\(membership)",

--- a/Sources/DistributedCluster/Cluster/Reception/OperationLogDistributedReceptionist.swift
+++ b/Sources/DistributedCluster/Cluster/Reception/OperationLogDistributedReceptionist.swift
@@ -525,9 +525,9 @@ extension OpLogDistributedReceptionist {
 
             for registration in registrations {
                 if subscription.tryOffer(registration: registration) {
-                    self.log.notice("OFFERED \(registration.actorID) TO \(subscription)")
+                    self.log.trace("Offered \(registration.actorID) to \(subscription)")
                 } else {
-                    self.log.notice("DROPPED \(registration.actorID) TO \(subscription)")
+                    self.log.trace("Dropped \(registration.actorID) to \(subscription)")
                 }
             }
         }

--- a/Sources/DistributedCluster/Cluster/Reception/OperationLogDistributedReceptionist.swift
+++ b/Sources/DistributedCluster/Cluster/Reception/OperationLogDistributedReceptionist.swift
@@ -744,11 +744,7 @@ extension OpLogDistributedReceptionist {
 
         for subscription in subscriptions {
             for registration in registrations {
-                if subscription.tryOffer(registration: registration) {
-                    self.log.notice("OFFERED \(registration.actorID) TO \(subscription)")
-                } else {
-                    self.log.notice("DROPPED \(registration.actorID) TO \(subscription)")
-                }
+                subscription.tryOffer(registration: registration)
             }
         }
     }

--- a/Sources/DistributedCluster/Cluster/SWIM/SWIMActor.swift
+++ b/Sources/DistributedCluster/Cluster/SWIM/SWIMActor.swift
@@ -338,7 +338,7 @@ internal distributed actor SWIMActor: SWIMPeer, SWIMAddressablePeer, CustomStrin
         // Log the transition
         switch change.status {
         case .unreachable:
-            self.log.info(
+            self.log.debug(
                 """
                 Node \(change.member.node) determined [.unreachable]! \
                 The node is not yet marked [.down], a downing strategy or other Cluster.Event subscriber may act upon this information.
@@ -347,7 +347,7 @@ internal distributed actor SWIMActor: SWIMPeer, SWIMAddressablePeer, CustomStrin
                 ]
             )
         default:
-            self.log.info(
+            self.log.debug(
                 "Node \(change.member.node) determined [.\(change.status)] (was \(optional: change.previousStatus)).",
                 metadata: [
                     "swim/member": "\(change.member)",

--- a/Sources/DistributedCluster/ClusterSystem.swift
+++ b/Sources/DistributedCluster/ClusterSystem.swift
@@ -1162,9 +1162,7 @@ extension ClusterSystem {
                     arguments: arguments
                 )
 
-                if let baggage {
-                    InstrumentationSystem.instrument.inject(baggage, into: &invocation, using: .invocationMessage)
-                }
+                InstrumentationSystem.instrument.inject(baggage, into: &invocation, using: .invocationMessage)
 
                 recipient.sendInvocation(invocation)
             }
@@ -1235,9 +1233,7 @@ extension ClusterSystem {
                     arguments: arguments
                 )
 
-                if let baggage {
-                    InstrumentationSystem.instrument.inject(baggage, into: &invocation, using: .invocationMessage)
-                }
+                InstrumentationSystem.instrument.inject(baggage, into: &invocation, using: .invocationMessage)
 
                 recipient.sendInvocation(invocation)
             }

--- a/Sources/DistributedCluster/DeadLetters.swift
+++ b/Sources/DistributedCluster/DeadLetters.swift
@@ -204,7 +204,7 @@ public final class DeadLetterOffice {
         }
 
         // in all other cases, we want to log the dead letter:
-        self.log.notice(
+        self.log.debug(
             "Dead letter was not delivered \(recipientString)",
             metadata: { () -> Logger.Metadata in
                 // TODO: more metadata (from Envelope) (e.g. sender)

--- a/Sources/DistributedCluster/DistributedProgress/DistributedProgress.swift
+++ b/Sources/DistributedCluster/DistributedProgress/DistributedProgress.swift
@@ -29,10 +29,10 @@ public distributed actor DistributedProgress<Steps: DistributedProgressSteps> {
 
     func to(step: Steps) async throws {
         // TODO: checks that we don't move backwards...
-        log.notice("Move to step: \(step)")
+        self.log.notice("Move to step: \(step)")
         self.step = step
 
-        for sub in subscribers {
+        for sub in self.subscribers {
             try await sub.currentStep(step)
         }
 
@@ -108,7 +108,7 @@ public distributed actor DistributedProgress<Steps: DistributedProgressSteps> {
                 return
             }
 
-            try await ensureSubscription()
+            try await self.ensureSubscription()
 
             await withCheckedContinuation { (cc: CheckedContinuation<Void, Never>) in
                 self._completedCC = cc
@@ -121,7 +121,7 @@ public distributed actor DistributedProgress<Steps: DistributedProgressSteps> {
                 return nil // last step was already emitted
             }
 
-            try await ensureSubscription()
+            try await self.ensureSubscription()
 
             return await withCheckedContinuation { (cc: CheckedContinuation<Steps, Never>) in
                 self._nextCC = cc
@@ -168,7 +168,6 @@ public distributed actor DistributedProgress<Steps: DistributedProgressSteps> {
 // MARK: Progress AsyncSequence
 
 extension DistributedProgress.Box {
-
     public func steps(file: String = #file, line: UInt = #line) async throws -> DistributedProgressAsyncSequence<Steps> {
         try await self.ensureSubscription()
 
@@ -198,7 +197,7 @@ public struct DistributedProgressAsyncSequence<Steps: DistributedProgressSteps>:
         }
 
         public func next() async throws -> Steps? {
-            try await box.nextStep()
+            try await self.box.nextStep()
         }
     }
 }
@@ -210,6 +209,7 @@ public protocol DistributedProgressSteps: Codable, Sendable, Equatable, CaseIter
     static var count: Int { get }
     static var last: Self { get }
 }
+
 extension DistributedProgressSteps {
     public static var count: Int {
         precondition(count > 0, "\(Self.self) cannot have zero steps (cases)!")

--- a/Sources/DistributedCluster/DistributedProgress/DistributedProgress.swift
+++ b/Sources/DistributedCluster/DistributedProgress/DistributedProgress.swift
@@ -16,6 +16,30 @@ import Distributed
 import DistributedActorsConcurrencyHelpers
 import Logging
 
+
+class TEST {
+    class Thing {
+        func change() {}
+    }
+
+    class State {
+        let mutable: Thing
+        init(mutable: Thing) {
+            self.mutable = mutable
+        }
+    }
+
+    func test(state: State) {
+        Task {
+            state.mutable.change() // data-rade (!)
+        }
+        Task {
+            state.mutable.change() // data-rade (!)
+        }
+    }
+}
+
+
 public distributed actor DistributedProgress<Steps: DistributedProgressSteps> {
     public typealias ActorSystem = ClusterSystem
     lazy var log = Logger(actor: self)

--- a/Sources/DistributedCluster/DistributedProgress/DistributedProgress.swift
+++ b/Sources/DistributedCluster/DistributedProgress/DistributedProgress.swift
@@ -1,0 +1,225 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2018-2022 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Distributed
+import DistributedActorsConcurrencyHelpers
+import Logging
+
+public distributed actor DistributedProgress<Steps: DistributedProgressSteps> {
+    public typealias ActorSystem = ClusterSystem
+    lazy var log = Logger(actor: self)
+
+    var step: Steps?
+    var subscribers: Set<ProgressSubscriber> = []
+
+    public init(actorSystem: ActorSystem, steps: Steps.Type = Steps.self) {
+        self.actorSystem = actorSystem
+    }
+
+    func to(step: Steps) async throws {
+        // TODO: checks that we don't move backwards...
+        log.notice("Move to step: \(step)")
+        self.step = step
+
+        for sub in subscribers {
+            try await sub.currentStep(step)
+        }
+
+        if step == Steps.allCases.reversed().first {
+            self.log.notice("Progress completed, clear subscribers.")
+            self.subscribers = []
+            return
+        }
+    }
+
+    distributed func subscribe<Subscriber: ProgressSubscriber>(subscriber: Subscriber) async throws {
+        self.log.notice("Subscribed \(subscriber.id)...")
+        self.subscribers.insert(subscriber)
+
+        if let step {
+            try await subscriber.currentStep(step)
+        }
+    }
+
+    distributed actor ProgressSubscriber {
+        typealias ActorSystem = ClusterSystem
+
+        /// Mutable box that we update as the progress proceeds remotely...
+        let box: Box
+
+        init(box: Box, actorSystem: ActorSystem) {
+            self.actorSystem = actorSystem
+            self.box = box
+        }
+
+        distributed func currentStep(_ step: Steps) {
+            self.box.updateStep(step)
+        }
+    }
+
+    public final class Box: Codable {
+        public typealias Element = Steps
+
+        let lock: Lock
+        private var currentStep: Steps?
+
+        let source: DistributedProgress<Steps>
+        let actorSystem: ClusterSystem
+        private var _sub: ProgressSubscriber?
+
+        private var _nextCC: CheckedContinuation<Steps, Never>?
+        private var _completedCC: CheckedContinuation<Void, Never>?
+
+        public // FIXME: not public
+        init(source: DistributedProgress<Steps>) {
+            self.source = source
+            self.actorSystem = source.actorSystem
+            self.lock = Lock()
+            self.currentStep = nil
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            self.lock = Lock()
+            self.currentStep = nil
+            self.actorSystem = decoder.userInfo[.actorSystemKey] as! ClusterSystem
+            self.source = try container.decode(DistributedProgress<Steps>.self)
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(self.source)
+        }
+
+        /// Suspend until this ``DistributedProgress`` has reached its last, and final, "step".
+        public func completed() async throws {
+            if self.currentStep == Steps.last {
+                return
+            }
+
+            try await ensureSubscription()
+
+            await withCheckedContinuation { (cc: CheckedContinuation<Void, Never>) in
+                self._completedCC = cc
+            }
+        }
+
+        /// Suspend until this ``DistributedProgress`` receives a next "step".
+        public func nextStep() async throws -> Steps? {
+            if self.currentStep == Steps.last {
+                return nil // last step was already emitted
+            }
+
+            try await ensureSubscription()
+
+            return await withCheckedContinuation { (cc: CheckedContinuation<Steps, Never>) in
+                self._nextCC = cc
+            }
+        }
+
+        func updateStep(_ step: Steps) {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+
+            self.currentStep = step
+
+            if let onNext = _nextCC {
+                onNext.resume(returning: step)
+            }
+
+            if step == Steps.last {
+                if let completed = _completedCC {
+                    completed.resume()
+                }
+            }
+        }
+
+        @discardableResult
+        private func ensureSubscription() async throws -> ProgressSubscriber {
+            self.lock.lock()
+
+            if let sub = self._sub {
+                self.lock.unlock()
+                return sub
+            } else {
+                let sub = ProgressSubscriber(box: self, actorSystem: self.actorSystem)
+                self._sub = sub
+                self.lock.unlock()
+
+                try await self.source.subscribe(subscriber: sub)
+                return sub
+            }
+        }
+    }
+}
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: Progress AsyncSequence
+
+extension DistributedProgress.Box {
+
+    public func steps(file: String = #file, line: UInt = #line) async throws -> DistributedProgressAsyncSequence<Steps> {
+        try await self.ensureSubscription()
+
+        return DistributedProgressAsyncSequence(box: self)
+    }
+}
+
+public struct DistributedProgressAsyncSequence<Steps: DistributedProgressSteps>: AsyncSequence {
+    public typealias Element = Steps
+
+    private let box: DistributedProgress<Steps>.Box
+
+    public init(box: DistributedProgress<Steps>.Box) {
+        self.box = box
+    }
+
+    public func makeAsyncIterator() -> AsyncIterator {
+        return AsyncIterator(box: self.box)
+    }
+
+    public struct AsyncIterator: AsyncIteratorProtocol {
+        public typealias Element = Steps
+        let box: DistributedProgress<Steps>.Box
+
+        init(box: DistributedProgress<Steps>.Box) {
+            self.box = box
+        }
+
+        public func next() async throws -> Steps? {
+            try await box.nextStep()
+        }
+    }
+}
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: Progress Steps protocol
+
+public protocol DistributedProgressSteps: Codable, Sendable, Equatable, CaseIterable {
+    static var count: Int { get }
+    static var last: Self { get }
+}
+extension DistributedProgressSteps {
+    public static var count: Int {
+        precondition(count > 0, "\(Self.self) cannot have zero steps (cases)!")
+        return Self.allCases.count
+    }
+
+    public static var last: Self {
+        guard let last = Self.allCases.reversed().first else {
+            fatalError("\(Self.self) cannot have zero steps (cases)!")
+        }
+        return last
+    }
+}

--- a/Sources/DistributedCluster/DistributedProgress/DistributedProgress.swift
+++ b/Sources/DistributedCluster/DistributedProgress/DistributedProgress.swift
@@ -16,7 +16,6 @@ import Distributed
 import DistributedActorsConcurrencyHelpers
 import Logging
 
-
 class TEST {
     class Thing {
         func change() {}
@@ -38,7 +37,6 @@ class TEST {
         }
     }
 }
-
 
 public distributed actor DistributedProgress<Steps: DistributedProgressSteps> {
     public typealias ActorSystem = ClusterSystem

--- a/Sources/DistributedCluster/InvocationBehavior.swift
+++ b/Sources/DistributedCluster/InvocationBehavior.swift
@@ -13,8 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 import Distributed
-import InstrumentationBaggage
 import struct Foundation.Data
+import InstrumentationBaggage
 
 /// Representation of the distributed invocation in the Behavior APIs.
 /// This needs to be removed eventually as we remove behaviors.

--- a/Sources/DistributedCluster/InvocationBehavior.swift
+++ b/Sources/DistributedCluster/InvocationBehavior.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Distributed
+import InstrumentationBaggage
 import struct Foundation.Data
 
 /// Representation of the distributed invocation in the Behavior APIs.
@@ -23,12 +24,19 @@ public struct InvocationMessage: Sendable, Codable, CustomStringConvertible {
     let genericSubstitutions: [String]
     let arguments: [Data]
 
+    /// Tracing metadata, injected/extracted by distributed-tracing.
+    var metadata: [String: String] = [:]
+
+    var hasMetadata: Bool {
+        !self.metadata.isEmpty
+    }
+
     var target: RemoteCallTarget {
         RemoteCallTarget(targetIdentifier)
     }
 
     public var description: String {
-        "InvocationMessage(callID: \(callID), target: \(target), genericSubstitutions: \(genericSubstitutions), arguments: \(arguments.count))"
+        "InvocationMessage(callID: \(callID), target: \(target), genericSubstitutions: \(genericSubstitutions), arguments: \(arguments.count), metadata: \(metadata))"
     }
 }
 

--- a/Sources/DistributedCluster/TracingSupport.swift
+++ b/Sources/DistributedCluster/TracingSupport.swift
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2018-2022 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Tracing
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: Injector
+
+struct InvocationMessageInjector: Tracing.Injector {
+    typealias Carrier = InvocationMessage
+
+    func inject(_ value: String, forKey key: String, into carrier: inout Carrier) {
+        carrier.metadata[key] = value
+    }
+}
+
+extension Tracing.Injector where Self == InvocationMessageInjector {
+    static var invocationMessage: InvocationMessageInjector {
+        InvocationMessageInjector()
+    }
+}
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: Extractor
+
+struct InvocationMessageExtractor: Tracing.Extractor {
+    typealias Carrier = InvocationMessage
+
+    func extract(key: String, from carrier: Carrier) -> String? {
+        carrier.metadata[key]
+    }
+}
+
+extension Tracing.Extractor where Self == InvocationMessageExtractor {
+    static var invocationMessage: InvocationMessageExtractor {
+        InvocationMessageExtractor()
+    }
+}

--- a/Tests/DistributedClusterTests/DistributedProgressTests.swift
+++ b/Tests/DistributedClusterTests/DistributedProgressTests.swift
@@ -1,0 +1,165 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Actors open source project
+//
+// Copyright (c) 2018-2022 Apple Inc. and the Swift Distributed Actors project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Distributed Actors project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Distributed
+import DistributedActorsTestKit
+@testable import DistributedCluster
+import Foundation
+import Logging
+import XCTest
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: Builder
+
+distributed actor Builder: CustomStringConvertible {
+    let probe: ActorTestProbe<String>
+    lazy var log = Logger(actor: self)
+
+    init(probe: ActorTestProbe<String>, actorSystem: ActorSystem) {
+        self.actorSystem = actorSystem
+        self.probe = probe
+        probe.tell("Romeo init")
+    }
+
+    public distributed func build() -> DistributedProgress<BuildSteps>.Box {
+        let progress = DistributedProgress(actorSystem: actorSystem, steps: BuildSteps.self)
+
+        Task {
+            try await progress.whenLocal { progress in
+                try await progress.to(step: .prepare)
+                try await Task.sleep(until: .now + .milliseconds(100), clock: .continuous)
+                try await progress.to(step: .compile)
+                try await Task.sleep(until: .now + .milliseconds(200), clock: .continuous)
+                try await progress.to(step: .test)
+                try await Task.sleep(until: .now + .milliseconds(200), clock: .continuous)
+                try await progress.to(step: .complete)
+            }
+        }
+
+        return DistributedProgress<BuildSteps>.Box(source: progress)
+    }
+
+    nonisolated var description: String {
+        "\(Self.self)(\(id))"
+    }
+}
+
+enum BuildSteps: String, DistributedProgressSteps {
+    case prepare
+    case compile
+    case test
+    case complete
+}
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: Juliet
+
+distributed actor BuildWatcher: CustomStringConvertible {
+    lazy var log = Logger(actor: self)
+
+    let probe: ActorTestProbe<String>
+    let builder: Builder
+
+    init(probe: ActorTestProbe<String>, builder: Builder, actorSystem: ActorSystem) {
+        self.actorSystem = actorSystem
+        self.probe = probe
+        self.builder = builder
+    }
+
+    distributed func runBuild_waitCompleted() async throws {
+        let progress = try await self.builder.build()
+
+        try await progress.completed()
+        probe.tell("completed")
+    }
+
+    distributed func runBuild_streamSteps() async throws {
+        let progress = try await self.builder.build()
+
+        for try await step in try await progress.steps() {
+            probe.tell("received-step:\(step)")
+        }
+    }
+
+    nonisolated var description: String {
+        "\(Self.self)(\(id))"
+    }
+}
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: Tests
+
+final class DistributedProgressTests: ClusteredActorSystemsXCTestCase, @unchecked Sendable {
+    override var captureLogs: Bool {
+        false
+    }
+
+    override func configureLogCapture(settings: inout LogCapture.Settings) {
+        settings.excludeActorPaths = [
+            "/system/cluster",
+            "/system/gossip",
+            "/system/cluster/gossip",
+            "/system/receptionist",
+            "/system/receptionist-ref",
+            "/system/cluster/swim",
+            "/system/clusterEvents",
+        ]
+    }
+
+    func test_progress_happyPath() async throws {
+        let system = await self.setUpNode("single")
+
+        let pb = self.testKit(system).makeTestProbe(expecting: String.self)
+        let pw = self.testKit(system).makeTestProbe(expecting: String.self)
+        let p = self.testKit(system).makeTestProbe(expecting: String.self)
+
+        let builder = Builder(probe: pb, actorSystem: system)
+        let watcher = BuildWatcher(probe: pw, builder: builder, actorSystem: system)
+
+        Task {
+            try await watcher.runBuild_waitCompleted()
+            p.tell("done")
+        }
+
+        try pw.expectMessage("completed")
+        try p.expectMessage("done")
+    }
+
+    func test_progress_stream() async throws {
+        let system = await self.setUpNode("single")
+
+        let pb = self.testKit(system).makeTestProbe(expecting: String.self)
+        let pw = self.testKit(system).makeTestProbe(expecting: String.self)
+        let p = self.testKit(system).makeTestProbe(expecting: String.self)
+
+        let builder = Builder(probe: pb, actorSystem: system)
+        let watcher = BuildWatcher(probe: pw, builder: builder, actorSystem: system)
+
+        Task {
+            try await watcher.runBuild_streamSteps()
+            p.tell("done")
+        }
+
+        let messages = try pw.fishForMessages(within: .seconds(5)) { message in
+            if message == "received-step:\(BuildSteps.last)" {
+                return .catchComplete
+            } else {
+                return .catchContinue
+            }
+        }
+        pinfo("Received \(messages.count) progress updates: \(messages)")
+        messages.shouldEqual(BuildSteps.allCases.suffix(messages.count).map { "received-step:\($0)" })
+        try p.expectMessage("done")
+    }
+}

--- a/Tests/DistributedClusterTests/DistributedProgressTests.swift
+++ b/Tests/DistributedClusterTests/DistributedProgressTests.swift
@@ -138,13 +138,14 @@ final class DistributedProgressTests: ClusteredActorSystemsXCTestCase, @unchecke
 
     func test_progress_stream_local() async throws {
         let system = await self.setUpNode("single")
-        try await impl_progress_stream_cluster(first: system, second: system)
+        try await self.impl_progress_stream_cluster(first: system, second: system)
     }
+
     func test_progress_stream_cluster() async throws {
         let (first, second) = await self.setUpPair()
         try await joinNodes(node: first, with: second)
 
-        try await impl_progress_stream_cluster(first: first, second: second)
+        try await self.impl_progress_stream_cluster(first: first, second: second)
     }
 
     func impl_progress_stream_cluster(first: ClusterSystem, second: ClusterSystem) async throws {

--- a/Tests/DistributedClusterTests/DistributedProgressTests.swift
+++ b/Tests/DistributedClusterTests/DistributedProgressTests.swift
@@ -81,14 +81,14 @@ distributed actor BuildWatcher: CustomStringConvertible {
         let progress = try await self.builder.build()
 
         try await progress.completed()
-        probe.tell("completed")
+        self.probe.tell("completed")
     }
 
     distributed func runBuild_streamSteps() async throws {
         let progress = try await self.builder.build()
 
         for try await step in try await progress.steps() {
-            probe.tell("received-step:\(step)")
+            self.probe.tell("received-step:\(step)")
         }
     }
 


### PR DESCRIPTION
A new example that's very fun to visualize using tracing.

It uses singletons and receptionist to implement a "jenkins"-like system.
By adding more nodes to the system, you can see it linearly decrease the time it needs to finish the "builds"! 

With 2 nodes it takes 12 minutes... and is a pyramid of doom:
![Screenshot 2022-11-15 at 21 55 37](https://user-images.githubusercontent.com/120979/201952250-96ce85ae-7a39-4e06-a427-0b28f633a25c.png)

This depends on the Tracing adoption PR.

And with 5 worker nodes it's this lovely execution:
![Screenshot 2022-11-15 at 22 00 19](https://user-images.githubusercontent.com/120979/201952369-bde10605-e975-4535-b008-27ad29711e8d.png)
