### PR TITLE
DocC doc on Swift Package Index

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,5 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [DistributedCluster]
+


### PR DESCRIPTION
Setting up DocC doc on [Swift Package Index](https://blog.swiftpackageindex.com/posts/auto-generating-auto-hosting-and-auto-updating-docc-documentation/)