### PR TITLE
actor shell slimmed down a bit, adjust test

### DIFF
--- a/Tests/DistributedClusterTests/Metrics/ActorMemoryTests.swift
+++ b/Tests/DistributedClusterTests/Metrics/ActorMemoryTests.swift
@@ -24,8 +24,8 @@ final class ActorMemoryTests: XCTestCase {
 
     func test_osx_actorShell_instanceSize() {
         #if os(OSX)
-        class_getInstanceSize(_ActorShell<Int>.self).shouldEqual(664)
-        class_getInstanceSize(_ActorShell<String>.self).shouldEqual(664)
+        class_getInstanceSize(_ActorShell<Int>.self).shouldEqual(632)
+        class_getInstanceSize(_ActorShell<String>.self).shouldEqual(632)
         #else
         print("Skipping test_osx_actorShell_instanceSize as requires Objective-C runtime")
         #endif


### PR DESCRIPTION

### Motivation:

Test fails on macos; Test should be adjusted to reflect smaller shell size

### Modifications:

Adjust shell instance size (down)

### Result:

passing tests on macos