### PR TITLE
ClusterControl.joined should cause joining; fix waiting issues

### DIFF
--- a/Sources/DistributedActorsTestKit/ShouldMatchers.swift
+++ b/Sources/DistributedActorsTestKit/ShouldMatchers.swift
@@ -15,9 +15,6 @@
 import Foundation
 import XCTest
 
-// bear with me; we need testing facilities for the async things.
-// Yeah, I know about https://github.com/Quick/Nimble
-
 /// Used to determine if "pretty printing" errors should be done or not.
 /// Pretty errors help tremendously to quickly spot exact errors and track them back to source locations,
 /// e.g. on CI or when testing in command line and developing in a separate IDE or editor.

--- a/Sources/DistributedCluster/Cluster/ClusterControl.swift
+++ b/Sources/DistributedCluster/Cluster/ClusterControl.swift
@@ -194,8 +194,9 @@ public struct ClusterControl {
     public func joined(node: Cluster.Node, within: Duration) async throws -> Cluster.Member {
         // waiting to be "joined" means having passed the "joining" member status
         if let member = await self.membershipSnapshot.member(node),
-           member.status > .joining {
-                return member
+           member.status > .joining
+        {
+            return member
         }
 
         self.join(node: node) // kick off the joining process in case we're not trying to already
@@ -213,10 +214,11 @@ public struct ClusterControl {
     public func joined(endpoint: Cluster.Endpoint, within: Duration) async throws -> Cluster.Member? {
         // waiting to be "joined" means having passed the "joining" member status
         if let member = await self.membershipSnapshot.anyMember(forEndpoint: endpoint),
-           member.status > .joining {
+           member.status > .joining
+        {
             return member
         }
-        
+
         self.join(endpoint: endpoint) // kick off the joining process in case we're not trying to already
         return try await self.waitFor(endpoint, .up, within: within)
     }

--- a/Sources/DistributedCluster/Cluster/ClusterControl.swift
+++ b/Sources/DistributedCluster/Cluster/ClusterControl.swift
@@ -345,7 +345,7 @@ public struct ClusterControl {
                 throw Cluster.MembershipError(.notFound(node, in: membership))
             }
 
-            if atLeastStatus <= foundMember.status {
+            if atLeastStatus < foundMember.status {
                 throw Cluster.MembershipError(.atLeastStatusRequirementNotMet(expectedAtLeast: atLeastStatus, found: foundMember))
             }
             return foundMember

--- a/Tests/DistributedClusterTests/Cluster/AssociationClusteredTests.swift
+++ b/Tests/DistributedClusterTests/Cluster/AssociationClusteredTests.swift
@@ -86,6 +86,16 @@ final class ClusterAssociationTests: ClusteredActorSystemsXCTestCase {
         try assertAssociated(second, withExactly: first.cluster.node)
     }
 
+    func test_clusterControl_joined_shouldCauseJoiningAttempt() async throws {
+        let (first, second) = await setUpPair()
+
+        try await first.cluster.joined(endpoint: second.cluster.endpoint, within: .seconds(3))
+        try await second.cluster.joined(endpoint: first.cluster.endpoint, within: .seconds(3))
+
+        try assertAssociated(first, withExactly: second.cluster.node)
+        try assertAssociated(second, withExactly: first.cluster.node)
+    }
+
     // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: Joining into existing cluster
 

--- a/Tests/DistributedClusterTests/Cluster/AssociationClusteredTests.swift
+++ b/Tests/DistributedClusterTests/Cluster/AssociationClusteredTests.swift
@@ -93,7 +93,10 @@ final class ClusterAssociationTests: ClusteredActorSystemsXCTestCase {
         try await second.cluster.joined(endpoint: first.cluster.endpoint, within: .seconds(3))
 
         try assertAssociated(first, withExactly: second.cluster.node)
+        try await assertMemberStatus(on: first, node: second.cluster.node, atLeast: .up, within: .seconds(3))
+
         try assertAssociated(second, withExactly: first.cluster.node)
+        try await assertMemberStatus(on: second, node: first.cluster.node, atLeast: .up, within: .seconds(3))
     }
 
     // ==== ------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
bug: We wrongly waited on the `self.node` to become up but should wait for the other node in `joined(node:)`

improvement: We should initiate joining when not already trying to and someone asks `try await joined(node:)` since the equivalent `join()` makes it seem like joined would do this as well