### PR TITLE
ClusterControl.joined should cause joining for simpler usage

### DIFF
--- a/Sources/DistributedActorsTestKit/ShouldMatchers.swift
+++ b/Sources/DistributedActorsTestKit/ShouldMatchers.swift
@@ -15,9 +15,6 @@
 import Foundation
 import XCTest
 
-// bear with me; we need testing facilities for the async things.
-// Yeah, I know about https://github.com/Quick/Nimble
-
 /// Used to determine if "pretty printing" errors should be done or not.
 /// Pretty errors help tremendously to quickly spot exact errors and track them back to source locations,
 /// e.g. on CI or when testing in command line and developing in a separate IDE or editor.

--- a/Sources/DistributedCluster/Cluster/ClusterControl.swift
+++ b/Sources/DistributedCluster/Cluster/ClusterControl.swift
@@ -194,8 +194,9 @@ public struct ClusterControl {
     public func joined(node: Cluster.Node, within: Duration) async throws -> Cluster.Member {
         // waiting to be "joined" means having passed the "joining" member status
         if let member = await self.membershipSnapshot.member(node),
-           member.status > .joining {
-                return member
+           member.status > .joining
+        {
+            return member
         }
 
         self.join(node: node) // kick off the joining process in case we're not trying to already
@@ -213,10 +214,11 @@ public struct ClusterControl {
     public func joined(endpoint: Cluster.Endpoint, within: Duration) async throws -> Cluster.Member? {
         // waiting to be "joined" means having passed the "joining" member status
         if let member = await self.membershipSnapshot.anyMember(forEndpoint: endpoint),
-           member.status > .joining {
+           member.status > .joining
+        {
             return member
         }
-        
+
         self.join(endpoint: endpoint) // kick off the joining process in case we're not trying to already
         return try await self.waitFor(endpoint, .up, within: within)
     }

--- a/Sources/DistributedCluster/Cluster/ClusterControl.swift
+++ b/Sources/DistributedCluster/Cluster/ClusterControl.swift
@@ -345,7 +345,7 @@ public struct ClusterControl {
                 throw Cluster.MembershipError(.notFound(node, in: membership))
             }
 
-            if atLeastStatus <= foundMember.status {
+            if atLeastStatus < foundMember.status {
                 throw Cluster.MembershipError(.atLeastStatusRequirementNotMet(expectedAtLeast: atLeastStatus, found: foundMember))
             }
             return foundMember

--- a/Sources/DistributedCluster/DeadLetters.swift
+++ b/Sources/DistributedCluster/DeadLetters.swift
@@ -220,6 +220,10 @@ public final class DeadLetterOffice {
                 return metadata
             }()
         )
+
+        pinfo("ALL ACTORS: \(self.system?.cluster.node)")
+        self.system?._printTree()
+        print("\n\n======")
     }
 
     private func specialHandled(_ message: _SystemMessage, recipient: ActorID?) -> Bool {

--- a/Sources/DistributedCluster/Plugins/ClusterSingleton/ClusterSingleton.swift
+++ b/Sources/DistributedCluster/Plugins/ClusterSingleton/ClusterSingleton.swift
@@ -30,7 +30,7 @@ import Logging
 ///
 /// To host a distributed cluster singleton, use the ``ClusterSingletonPlugin/host(_:name:settings:makeInstance:)`` method.
 ///
-public protocol ClusterSingleton: DistributedActor where ActorSystem == ClusterSystem {
+public protocol ClusterSingleton: Codable, DistributedActor where ActorSystem == ClusterSystem {
     /// The singleton is now active, and should perform its duties.
     ///
     /// Invoked by the cluster singleton boss when after it has created this instance of the singleton

--- a/Sources/DistributedCluster/Plugins/ClusterSingleton/ClusterSingletonSettings.swift
+++ b/Sources/DistributedCluster/Plugins/ClusterSingleton/ClusterSingletonSettings.swift
@@ -35,6 +35,16 @@ public struct ClusterSingletonSettings {
     /// we stop stashing calls and throw error.
     public var allocationTimeout: Duration = .seconds(30)
 
+    // Backoff configuration when trying to obtain an active singleton reference on a new node.
+    public var locateActiveSingletonBackoff: LocateActiveSingletonBackoffSettings = .init()
+    public struct LocateActiveSingletonBackoffSettings {
+        var initialInterval: Duration = .milliseconds(300)
+        var multiplier: Double = ExponentialBackoffStrategy.Defaults.multiplier
+        var capInterval: Duration = ExponentialBackoffStrategy.Defaults.capInterval
+        var randomFactor: Double = ExponentialBackoffStrategy.Defaults.randomFactor
+        var maxAttempts: Int = 5
+    }
+
     public init() {}
 }
 

--- a/Tests/DistributedClusterTests/Cluster/AssociationClusteredTests.swift
+++ b/Tests/DistributedClusterTests/Cluster/AssociationClusteredTests.swift
@@ -86,6 +86,16 @@ final class ClusterAssociationTests: ClusteredActorSystemsXCTestCase {
         try assertAssociated(second, withExactly: first.cluster.node)
     }
 
+    func test_clusterControl_joined_shouldCauseJoiningAttempt() async throws {
+        let (first, second) = await setUpPair()
+
+        try await first.cluster.joined(endpoint: second.cluster.endpoint, within: .seconds(3))
+        try await second.cluster.joined(endpoint: first.cluster.endpoint, within: .seconds(3))
+
+        try assertAssociated(first, withExactly: second.cluster.node)
+        try assertAssociated(second, withExactly: first.cluster.node)
+    }
+
     // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: Joining into existing cluster
 

--- a/Tests/DistributedClusterTests/Cluster/AssociationClusteredTests.swift
+++ b/Tests/DistributedClusterTests/Cluster/AssociationClusteredTests.swift
@@ -93,7 +93,10 @@ final class ClusterAssociationTests: ClusteredActorSystemsXCTestCase {
         try await second.cluster.joined(endpoint: first.cluster.endpoint, within: .seconds(3))
 
         try assertAssociated(first, withExactly: second.cluster.node)
+        try await assertMemberStatus(on: first, node: second.cluster.node, atLeast: .up, within: .seconds(3))
+
         try assertAssociated(second, withExactly: first.cluster.node)
+        try await assertMemberStatus(on: second, node: first.cluster.node, atLeast: .up, within: .seconds(3))
     }
 
     // ==== ------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This hardens singleton handover, sadly it also hits a bug in IRGen which made the impl uglier than I would have wanted to.

This is not to be reviewed yet, I want to give it some runs on CI