### PR TITLE
Prevent distributed singletons created during other's init from duping IDs

### DIFF
--- a/Sources/DistributedCluster/ActorID.swift
+++ b/Sources/DistributedCluster/ActorID.swift
@@ -429,7 +429,7 @@ extension ActorID: _PathRelationships {
         self.path.segments
     }
 
-    func makeChildAddress(name: String, incarnation: ActorIncarnation) throws -> ActorID {
+    func makeChildID(name: String, incarnation: ActorIncarnation) throws -> ActorID {
         switch self._location {
         case .local(let node):
             return try .init(local: node, path: self.makeChildPath(name: name), incarnation: incarnation)
@@ -765,7 +765,6 @@ public struct ActorIncarnation: Equatable, Hashable, ExpressibleByIntegerLiteral
 extension ActorIncarnation {
     /// To be used ONLY by special actors whose existence is wellKnown and identity never-changing.
     /// Examples: `/system/deadLetters` or `/system/cluster`.
-    @available(*, deprecated, message: "Useful only with behavior actors, will be removed entirely")
     internal static let wellKnown: ActorIncarnation = .init(0)
 
     public static func random() -> ActorIncarnation {

--- a/Sources/DistributedCluster/Cluster/ClusterEventStream.swift
+++ b/Sources/DistributedCluster/Cluster/ClusterEventStream.swift
@@ -26,10 +26,10 @@ public struct ClusterEventStream: AsyncSequence {
     private let actor: ClusterEventStreamActor?
 
     internal init(_ system: ClusterSystem, customName: String? = nil) {
-        var props = ClusterEventStreamActor.props
-        if let customName = customName {
-            props._knownActorName = customName
-        }
+        var props = ClusterEventStreamActor.props(customName: customName)
+//        if let customName = customName {
+//            props._knownActorName =
+//        }
 
         self.actor = _Props.$forSpawn.withValue(props) {
             ClusterEventStreamActor(actorSystem: system)
@@ -126,9 +126,9 @@ public struct ClusterEventStream: AsyncSequence {
 internal distributed actor ClusterEventStreamActor: LifecycleWatch {
     typealias ActorSystem = ClusterSystem
 
-    static var props: _Props {
+    static func props(customName: String?) -> _Props {
         var ps = _Props()
-        ps._knownActorName = "clusterEventStream"
+        ps._knownActorName = customName ?? "clusterEventStream"
         ps._systemActor = true
         ps._wellKnown = true
         return ps

--- a/Sources/DistributedCluster/Cluster/Reception/OperationLogDistributedReceptionist.swift
+++ b/Sources/DistributedCluster/Cluster/Reception/OperationLogDistributedReceptionist.swift
@@ -254,8 +254,10 @@ public distributed actor OpLogDistributedReceptionist: DistributedReceptionist, 
 
         // === listen to cluster events ------------------
         self.wellKnownName = ActorPath.distributedActorReceptionist.name
-        assert(self.id.path.description == "/system/receptionist",
-            "\(Self.self) expects to be on well known path: /system/receptionist, but was: \(self.id.fullDescription)") // TODO(distributed): remove when we remove paths entirely
+        assert(
+            self.id.path.description == "/system/receptionist",
+            "\(Self.self) expects to be on well known path: /system/receptionist, but was: \(self.id.fullDescription)"
+        ) // TODO(distributed): remove when we remove paths entirely
 
         self.eventsListeningTask = Task { [weak self, system] in
             for try await event in system.cluster.events {

--- a/Sources/DistributedCluster/Cluster/Reception/OperationLogDistributedReceptionist.swift
+++ b/Sources/DistributedCluster/Cluster/Reception/OperationLogDistributedReceptionist.swift
@@ -254,7 +254,8 @@ public distributed actor OpLogDistributedReceptionist: DistributedReceptionist, 
 
         // === listen to cluster events ------------------
         self.wellKnownName = ActorPath.distributedActorReceptionist.name
-        assert(self.id.path.description == "/system/receptionist") // TODO(distributed): remove when we remove paths entirely
+        assert(self.id.path.description == "/system/receptionist",
+            "\(Self.self) expects to be on well known path: /system/receptionist, but was: \(self.id.fullDescription)") // TODO(distributed): remove when we remove paths entirely
 
         self.eventsListeningTask = Task { [weak self, system] in
             for try await event in system.cluster.events {

--- a/Sources/DistributedCluster/Cluster/SWIM/ClusterMembership+Converters.swift
+++ b/Sources/DistributedCluster/Cluster/SWIM/ClusterMembership+Converters.swift
@@ -29,7 +29,11 @@ extension ClusterMembership.Node {
     }
 
     func swimShell(_ system: ClusterSystem) -> SWIMActor {
-        try! SWIMActor.resolve(id: ._swim(on: self.asClusterNode!), using: system) // TODO: the ! is not so nice
+        do {
+            return try SWIMActor.resolve(id: ._swim(on: self.asClusterNode!), using: system)
+        } catch {
+            fatalError("Failed to resolve \(ActorID._swim(on: self.asClusterNode!).detailedDescription): \(error), tree: \n\(system._treeString())")
+        }
     }
 
     var asClusterNode: Cluster.Node? {

--- a/Sources/DistributedCluster/ClusterSystem.swift
+++ b/Sources/DistributedCluster/ClusterSystem.swift
@@ -1013,9 +1013,9 @@ extension ClusterSystem {
             id.metadata.wellKnown = wellKnownName
             id.metadata._props = _PropsShuttle(props: props)
         }
-        if let wellKnownName = props.metadata.remove(forKey: ActorMetadataKeys.__instance.wellKnown) {
-            id.metadata.wellKnown = wellKnownName
-        }
+//        if let wellKnownName = props.metadata.remove(forKey: ActorMetadataKeys.__instance.wellKnown) {
+//            id.metadata.wellKnown = wellKnownName
+//        }
 
         self.log.trace("Assign identity", metadata: [
             "actor/type": "\(actorType)",

--- a/Sources/DistributedCluster/ClusterSystem.swift
+++ b/Sources/DistributedCluster/ClusterSystem.swift
@@ -763,7 +763,7 @@ extension ClusterSystem: _ActorRefFactory {
             return try self._spawn(using: provider, behavior, id: id, props: props)
             // try!-safe, since the naming must have been correct
         } catch {
-            fatalError("THE ID: \(id.fullDescription)\n THE PROPS: \(id.metadata._props?.props)")
+            fatalError("Failed to _spawn DistributedActor, id: \(id.fullDescription); props: \(id.metadata._props?.props), error: \(error)")
         }
     }
 }

--- a/Sources/DistributedCluster/ClusterSystem.swift
+++ b/Sources/DistributedCluster/ClusterSystem.swift
@@ -646,13 +646,12 @@ extension ClusterSystem: _ActorRefFactory {
         try behavior.validateAsInitial()
 
         let incarnation: ActorIncarnation = props._wellKnown ? .wellKnown : .random()
-
         // TODO: lock inside provider, not here
         // FIXME: protect the naming context access and name reservation; add a test
         let id: ActorID = try self.withNamingContext { namingContext in
             let name = naming.makeName(&namingContext)
 
-            return try provider.rootAddress.makeChildAddress(name: name, incarnation: incarnation)
+            return try provider.rootAddress.makeChildID(name: name, incarnation: incarnation)
             // FIXME: reserve the name, atomically
             // provider.reserveName(name) -> ActorID
         }
@@ -682,7 +681,7 @@ extension ClusterSystem: _ActorRefFactory {
     // Actual spawn implementation, minus the leading "$" check on names;
     internal func _spawn<Message>(
         using provider: _ActorRefProvider,
-        _ behavior: _Behavior<Message>, id: ActorID, props: _Props = _Props(),
+        _ behavior: _Behavior<Message>, id: ActorID, props: _Props,
         startImmediately: Bool = true
     ) throws -> _ActorRef<Message>
         where Message: Codable
@@ -705,14 +704,17 @@ extension ClusterSystem: _ActorRefFactory {
 
         return try provider._spawn(
             system: self,
-            behavior: behavior, id: id,
-            dispatcher: dispatcher, props: props,
+            behavior: behavior,
+            id: id,
+            dispatcher: dispatcher,
+            props: props,
             startImmediately: startImmediately
         )
     }
 
     // Reserve an actor address.
-    internal func _reserveName<Act>(type: Act.Type, props: _Props) throws -> ActorID where Act: DistributedActor {
+    internal func _reserveName<Act>(type: Act.Type, props: _Props,
+                                    file: String = #fileID, line: UInt = #line) throws -> ActorID where Act: DistributedActor {
         let incarnation: ActorIncarnation = props._wellKnown ? .wellKnown : .random()
         guard let provider = (props._systemActor ? self.systemProvider : self.userProvider) else {
             fatalError("Unable to obtain system/user actor provider") // TODO(distributed): just throw here instead
@@ -731,22 +733,22 @@ extension ClusterSystem: _ActorRefFactory {
                 name = naming.makeName(&namingContext)
             }
 
-            let address = try provider.rootAddress.makeChildAddress(name: name, incarnation: incarnation)
-            guard self._reservedNames.insert(address).inserted else {
+            let id = try provider.rootAddress.makeChildID(name: name, incarnation: incarnation)
+            guard self._reservedNames.insert(id).inserted else {
                 fatalError("""
-                Attempted to reserve duplicate actor address: \(address.detailedDescription), 
+                Attempted to reserve duplicate actor address: \(id.detailedDescription), 
                 reserved: \(self._reservedNames.map(\.detailedDescription))
                 """)
             }
 
-            return address
+            return id
         }
     }
 
     public func _spawnDistributedActor<Message>(
         _ behavior: _Behavior<Message>, identifiedBy id: ClusterSystem.ActorID
     ) -> _ActorRef<Message> where Message: Codable {
-        var props = _Props.forSpawn
+        var props = id.metadata._props?.props ?? _Props()  // ?? _Props.forSpawn
         props._distributedActor = true
 
         let provider: _ActorRefProvider
@@ -756,7 +758,12 @@ extension ClusterSystem: _ActorRefFactory {
             provider = self.userProvider
         }
 
-        return try! self._spawn(using: provider, behavior, id: id, props: props) // try!-safe, since the naming must have been correct
+        do {
+            return try self._spawn(using: provider, behavior, id: id, props: props)
+            // try!-safe, since the naming must have been correct
+        } catch {
+            fatalError("THE ID: \(id.fullDescription)\n THE PROPS: \(id.metadata._props?.props)")
+        }
     }
 }
 
@@ -770,9 +777,18 @@ extension ClusterSystem: _ActorTreeTraversable {
     /// the print completes already have terminated, or may not print actors which started just after a visit at certain parent.
     internal func _printTree() {
         self._traverseAllVoid { context, ref in
-            print("\(String(repeating: "  ", count: context.depth))- /\(ref.id.name) - \(ref) @ incarnation:\(ref.id.incarnation)")
+            print("\(_hackyPThreadThreadId()): \(String(repeating: "  ", count: context.depth))- /\(ref.id.name) - \(ref) @ incarnation:\(ref.id.incarnation)")
             return .continue
         }
+    }
+
+    internal func _treeString() -> String {
+        var ids = [String]()
+        self._traverseAllVoid { context, ref in
+            ids.append("\(ref.id.detailedDescription)")
+            return .continue
+        }
+        return ids.joined(separator: "\n")
     }
 
     func _traverse<T>(context: _TraversalContext<T>, _ visit: (_TraversalContext<T>, _AddressableActorRef) -> _TraversalDirective<T>) -> _TraversalResult<T> {
@@ -958,10 +974,11 @@ extension ClusterSystem {
         return self._assignID(actorType, baseContext: nil)
     }
 
-    internal func _assignID<Act>(_ actorType: Act.Type, baseContext: DistributedActorContext?) -> ClusterSystem.ActorID
+    internal func _assignID<Act>(_ actorType: Act.Type, baseContext: DistributedActorContext?,
+                                 file: String = #fileID, line: UInt = #line) -> ClusterSystem.ActorID
         where Act: DistributedActor
     {
-        let props = _Props.forSpawn // task-local read for any properties this actor should have
+        let props = _Props.forSpawn.consume() // task-local read for any properties this actor should have
 
         if let designatedActorID = props._designatedActorID {
             return designatedActorID
@@ -970,7 +987,7 @@ extension ClusterSystem {
         var id = try! self._reserveName(type: Act.self, props: props)
 
         let lifecycleContainer: LifecycleWatchContainer?
-        if Act.self is (any(LifecycleWatch).Type) {
+        if Act.self is (any (LifecycleWatch).Type) {
             lifecycleContainer = LifecycleWatchContainer(watcherID: id.withoutLifecycle, actorSystem: self)
         } else {
             lifecycleContainer = nil
@@ -993,17 +1010,18 @@ extension ClusterSystem {
 
         if let wellKnownName = props._wellKnownName {
             id.metadata.wellKnown = wellKnownName
+            id.metadata._props = _PropsShuttle(props: props)
+        }
+        if let wellKnownName = props.metadata.remove(forKey: ActorMetadataKeys.__instance.wellKnown) {
+            id.metadata.wellKnown = wellKnownName
         }
 
         self.log.trace("Assign identity", metadata: [
             "actor/type": "\(actorType)",
             "actor/id": "\(id)",
+            "id": "\(id.fullDescription)",
         ])
 
-//        return self.namingLock.withLock {
-//            self._reservedNames.insert(id)
-//            return id
-//        }
         return id
     }
 
@@ -1101,9 +1119,9 @@ extension ClusterSystem {
     {
         /// Prepare a distributed actor context base, such that the reserved ID will contain the interceptor in the context.
         let baseContext = DistributedActorContext(lifecycle: nil, remoteCallInterceptor: interceptor)
-        var id = self._assignID(Act.self, baseContext: baseContext)
+         var id = self._assignID(Act.self, baseContext: baseContext)
         assert(id.context.remoteCallInterceptor != nil)
-        id = id._asRemote // FIXME(distributed): not strictly necessary ???
+        id = id._asRemote // Not strictly necessary?
 
         var props = _Props()
         props._designatedActorID = id
@@ -1700,7 +1718,7 @@ public struct GenericRemoteCallError: Error, Codable {
 
 public struct ClusterSystemError: DistributedActorSystemError, CustomStringConvertible {
     internal enum _ClusterSystemError {
-        case duplicateActorPath(path: ActorPath)
+        case duplicateActorPath(path: ActorPath, existing: ActorID)
         case shuttingDown(String)
     }
 

--- a/Sources/DistributedCluster/ClusterSystem.swift
+++ b/Sources/DistributedCluster/ClusterSystem.swift
@@ -714,7 +714,8 @@ extension ClusterSystem: _ActorRefFactory {
 
     // Reserve an actor address.
     internal func _reserveName<Act>(type: Act.Type, props: _Props,
-                                    file: String = #fileID, line: UInt = #line) throws -> ActorID where Act: DistributedActor {
+                                    file: String = #fileID, line: UInt = #line) throws -> ActorID where Act: DistributedActor
+    {
         let incarnation: ActorIncarnation = props._wellKnown ? .wellKnown : .random()
         guard let provider = (props._systemActor ? self.systemProvider : self.userProvider) else {
             fatalError("Unable to obtain system/user actor provider") // TODO(distributed): just throw here instead
@@ -748,7 +749,7 @@ extension ClusterSystem: _ActorRefFactory {
     public func _spawnDistributedActor<Message>(
         _ behavior: _Behavior<Message>, identifiedBy id: ClusterSystem.ActorID
     ) -> _ActorRef<Message> where Message: Codable {
-        var props = id.metadata._props?.props ?? _Props()  // ?? _Props.forSpawn
+        var props = id.metadata._props?.props ?? _Props() // ?? _Props.forSpawn
         props._distributedActor = true
 
         let provider: _ActorRefProvider
@@ -784,7 +785,7 @@ extension ClusterSystem: _ActorTreeTraversable {
 
     internal func _treeString() -> String {
         var ids = [String]()
-        self._traverseAllVoid { context, ref in
+        self._traverseAllVoid { _, ref in
             ids.append("\(ref.id.detailedDescription)")
             return .continue
         }
@@ -987,7 +988,7 @@ extension ClusterSystem {
         var id = try! self._reserveName(type: Act.self, props: props)
 
         let lifecycleContainer: LifecycleWatchContainer?
-        if Act.self is (any (LifecycleWatch).Type) {
+        if Act.self is (any(LifecycleWatch).Type) {
             lifecycleContainer = LifecycleWatchContainer(watcherID: id.withoutLifecycle, actorSystem: self)
         } else {
             lifecycleContainer = nil
@@ -1119,7 +1120,7 @@ extension ClusterSystem {
     {
         /// Prepare a distributed actor context base, such that the reserved ID will contain the interceptor in the context.
         let baseContext = DistributedActorContext(lifecycle: nil, remoteCallInterceptor: interceptor)
-         var id = self._assignID(Act.self, baseContext: baseContext)
+        var id = self._assignID(Act.self, baseContext: baseContext)
         assert(id.context.remoteCallInterceptor != nil)
         id = id._asRemote // Not strictly necessary?
 

--- a/Sources/DistributedCluster/Props.swift
+++ b/Sources/DistributedCluster/Props.swift
@@ -48,8 +48,12 @@ public struct _Props: @unchecked Sendable {
 
     /// Sets the ``ActorMetadataKeys/wellKnown`` key to this name during spawning.
     internal var _wellKnownName: String? {
-        willSet {
+        get {
+            self.metadata.wellKnown
+        }
+        set {
             self._wellKnown = newValue != nil
+            self.metadata.wellKnown = newValue
         }
     }
 
@@ -60,7 +64,14 @@ public struct _Props: @unchecked Sendable {
     /// INTERNAL API: Allows to request the actor system to spawn this actor under a specific name
     /// Used only with 'distributed actor' as a way to pass path to the `assignIdentity` call.
     /// // TODO(distributed): We should instead allow for an explicit way to pass params to the transport.
-    internal var _knownActorName: String?
+    internal var _knownActorName: String? {
+        get {
+            self.metadata.knownActorName
+        }
+        set {
+            self.metadata.knownActorName = newValue
+        }
+    }
 
     /// Makes `DistributedActor.resolve` use the designated ID, rather than assigning one.
     internal var _designatedActorID: ActorID?
@@ -79,9 +90,49 @@ public struct _Props: @unchecked Sendable {
         self.metrics = metrics
     }
 
+    func consume() -> _Props {
+        let c = deepCopy()
+        self.metadata.clear()
+        return c
+    }
+
+    /// Since metadata is mutable storage, we sometimes may need to perform a deep copy of Props if we want to have
+    /// separate metadata storage from the original copy.
+    func deepCopy() -> _Props {
+        var p = _Props(metadata: self.metadata.copy(), metrics: self.metrics)
+        p.supervision = self.supervision
+        p.dispatcher = self.dispatcher
+        p._systemActor = self._systemActor
+        p._designatedActorID = self._designatedActorID
+        if p._knownActorName == nil {
+            p._knownActorName = self._knownActorName
+        }
+        p._wellKnownName = self._wellKnownName
+        p._wellKnown = self._wellKnown
+        return p
+    }
+
     /// Allows for passing properties to creating a distributed actor.
     @TaskLocal
     internal static var forSpawn: _Props = .init()
+}
+
+/// INTERNAL: Used for shuttling the Props into the ID while performing assignID.
+/// These props must be used during `_spawn` which happens on `actorReady`.
+///
+/// This is somewhat of a relict of ActorRef infrastructure and should eventually be removed.
+struct _PropsShuttle: @unchecked Sendable, Codable {
+    let props: _Props
+    init(props: _Props) {
+        self.props = props.deepCopy()
+    }
+
+    init(from decoder: Decoder) throws {
+        fatalError()
+    }
+    public func encode(to encoder: Encoder) throws {
+        fatalError()
+    }
 }
 
 // ==== ----------------------------------------------------------------------------------------------------------------

--- a/Sources/DistributedCluster/Props.swift
+++ b/Sources/DistributedCluster/Props.swift
@@ -91,7 +91,7 @@ public struct _Props: @unchecked Sendable {
     }
 
     func consume() -> _Props {
-        let c = deepCopy()
+        let c = self.deepCopy()
         self.metadata.clear()
         return c
     }
@@ -130,6 +130,7 @@ struct _PropsShuttle: @unchecked Sendable, Codable {
     init(from decoder: Decoder) throws {
         fatalError()
     }
+
     public func encode(to encoder: Encoder) throws {
         fatalError()
     }

--- a/Sources/DistributedCluster/Props.swift
+++ b/Sources/DistributedCluster/Props.swift
@@ -99,7 +99,7 @@ public struct _Props: @unchecked Sendable {
     /// Since metadata is mutable storage, we sometimes may need to perform a deep copy of Props if we want to have
     /// separate metadata storage from the original copy.
     func deepCopy() -> _Props {
-        var p = _Props(metadata: self.metadata.copy(), metrics: self.metrics)
+        var p = _Props(metadata: ActorMetadata(), metrics: self.metrics)
         p.supervision = self.supervision
         p.dispatcher = self.dispatcher
         p._systemActor = self._systemActor

--- a/Sources/DistributedCluster/Refs.swift
+++ b/Sources/DistributedCluster/Refs.swift
@@ -638,8 +638,8 @@ public class _Guardian {
                 throw _ActorContextError(.alreadyStopping("system: \(self.system?.name ?? "<nil>")"))
             }
 
-            if self._children.contains(name: path.name) {
-                throw ClusterSystemError(.duplicateActorPath(path: path))
+            if let existing = self._children.findID(named: path.name) {
+                throw ClusterSystemError(.duplicateActorPath(path: path, existing: existing))
             }
 
             let cell = try spawn()

--- a/Sources/DistributedCluster/_ActorShell.swift
+++ b/Sources/DistributedCluster/_ActorShell.swift
@@ -699,7 +699,7 @@ public final class _ActorShell<Message: Codable>: _ActorContext<Message>, Abstra
 
             let naming = _ActorNaming(unchecked: .prefixed(prefix: "$sub-\(id.id)", suffixScheme: .letters))
             let name = naming.makeName(&self.namingContext)
-            let adaptedAddress = try self.id.makeChildAddress(name: name, incarnation: .random()) // TODO: actor name to BE the identity
+            let adaptedAddress = try self.id.makeChildID(name: name, incarnation: .random()) // TODO: actor name to BE the identity
             let ref = SubReceiveAdapter(SubMessage.self, owner: self.myself, id: adaptedAddress, identifier: identifier)
 
             self._children.insert(ref) // TODO: separate adapters collection?
@@ -749,7 +749,7 @@ public final class _ActorShell<Message: Codable>: _ActorContext<Message>, Abstra
             if let adapter: _ActorRefAdapter<Message> = self.messageAdapter {
                 return .init(.adapter(adapter))
             } else {
-                let adaptedAddress = try self.id.makeChildAddress(name: _ActorNaming.adapter.makeName(&self.namingContext), incarnation: .wellKnown)
+                let adaptedAddress = try self.id.makeChildID(name: _ActorNaming.adapter.makeName(&self.namingContext), incarnation: .wellKnown)
                 let adapter = _ActorRefAdapter(fromType: fromType, to: self.myself, id: adaptedAddress)
 
                 self.messageAdapter = adapter

--- a/Sources/DistributedCluster/utils.swift
+++ b/Sources/DistributedCluster/utils.swift
@@ -79,12 +79,12 @@ private func _createTimeFormatter() -> DateFormatter {
 }
 
 /// Short for "pretty print", useful for debug tracing
-func pprint(_ message: String, file: String = #fileID, line: UInt = #line) {
+func pprint(_ message: String, function: String = #function, file: String = #fileID, line: UInt = #line) {
     print("""
     [pprint]\
     [\(_createTimeFormatter().string(from: Date()))] \
-    [\(file):\(line)]\
-    [\(_hackyPThreadThreadId())]: \
+    [\(file):\(line)] \
+    (\(function)) \
     \(message)
     """)
 }

--- a/Tests/DistributedClusterTests/ClusterSystemTests.swift
+++ b/Tests/DistributedClusterTests/ClusterSystemTests.swift
@@ -27,7 +27,7 @@ final class ClusterSystemTests: SingleClusterSystemXCTestCase {
             let _: _ActorRef<String> = try system._spawn("test", .ignore)
         }
 
-        guard let systemError = error as? ClusterSystemError, case .duplicateActorPath(let path) = systemError.underlying.error else {
+        guard let systemError = error as? ClusterSystemError, case .duplicateActorPath(let path, let existing) = systemError.underlying.error else {
             XCTFail("Expected ClusterSystemError.duplicateActorPath, but was: \(error)")
             return
         }

--- a/Tests/DistributedClusterTests/Metrics/ActorMemoryTests.swift
+++ b/Tests/DistributedClusterTests/Metrics/ActorMemoryTests.swift
@@ -24,8 +24,8 @@ final class ActorMemoryTests: XCTestCase {
 
     func test_osx_actorShell_instanceSize() {
         #if os(OSX)
-        class_getInstanceSize(_ActorShell<Int>.self).shouldEqual(634)
-        class_getInstanceSize(_ActorShell<String>.self).shouldEqual(634)
+        class_getInstanceSize(_ActorShell<Int>.self).shouldEqual(624)
+        class_getInstanceSize(_ActorShell<String>.self).shouldEqual(624)
         #else
         print("Skipping test_osx_actorShell_instanceSize as requires Objective-C runtime")
         #endif

--- a/Tests/DistributedClusterTests/ParentChildActorTests.swift
+++ b/Tests/DistributedClusterTests/ParentChildActorTests.swift
@@ -63,7 +63,7 @@ final class ParentChildActorTests: SingleClusterSystemXCTestCase {
                     }
                     probe.tell(.spawned(child: kid))
                 } catch let error as _ActorContextError {
-                    if case .duplicateActorPath(let path) = error.underlying.error {
+                    if case .duplicateActorPath(let path, let existing) = error.underlying.error {
                         probe.tell(.spawnFailed(path: path))
                     } else {
                         throw error
@@ -77,7 +77,7 @@ final class ParentChildActorTests: SingleClusterSystemXCTestCase {
                     }
                     probe.tell(.spawned(child: kid))
                 } catch let error as _ActorContextError {
-                    if case .duplicateActorPath(let path) = error.underlying.error {
+                    if case .duplicateActorPath(let path, let existing) = error.underlying.error {
                         probe.tell(.spawnFailed(path: path))
                     } else {
                         throw error
@@ -134,7 +134,7 @@ final class ParentChildActorTests: SingleClusterSystemXCTestCase {
                         }
                         probe.tell(.spawned(child: kid))
                     } catch let error as _ActorContextError {
-                        if case .duplicateActorPath(let path) = error.underlying.error {
+                        if case .duplicateActorPath(let path, let existing) = error.underlying.error {
                             probe.tell(.spawnFailed(path: path))
                         } else {
                             throw error

--- a/Tests/DistributedClusterTests/Plugins/ClusterSingleton/ClusterSingletonPluginTests.swift
+++ b/Tests/DistributedClusterTests/Plugins/ClusterSingleton/ClusterSingletonPluginTests.swift
@@ -17,7 +17,6 @@ import DistributedActorsTestKit
 import XCTest
 
 final class ClusterSingletonPluginTests: SingleClusterSystemXCTestCase {
-
     func test_singletonPlugin_clusterDisabled() async throws {
         // Singleton should work just fine without clustering
         let test = await setUpNode("test") { settings in
@@ -86,7 +85,6 @@ final class ClusterSingletonPluginTests: SingleClusterSystemXCTestCase {
         init(actorSystem: ActorSystem) {
             self.actorSystem = actorSystem
         }
-
 
         distributed func greet() {
             print("Hello!")

--- a/Tests/DistributedClusterTests/Plugins/ClusterSingleton/ClusterSingletonPluginTests.swift
+++ b/Tests/DistributedClusterTests/Plugins/ClusterSingleton/ClusterSingletonPluginTests.swift
@@ -55,7 +55,6 @@ final class ClusterSingletonPluginTests: SingleClusterSystemXCTestCase {
         pinfo("singleton actual   id: \(try await singleton.actualID())")
         pinfo("singleton(greeter) id: \(greeterID)")
 
-//        singletonID.detailedDescription.shouldContain("test-singleton")
         try await singleton.actualID().detailedDescription.shouldContain("test-singleton")
         // if this were true we would have crashed by a duplicate name already, but let's make sure:
         singletonID.shouldNotEqual(greeterID)

--- a/Tests/DistributedClusterTests/_ActorRefReceptionistTests.swift
+++ b/Tests/DistributedClusterTests/_ActorRefReceptionistTests.swift
@@ -22,7 +22,7 @@ final class _ActorRefReceptionistTests: SingleClusterSystemXCTestCase {
     let receptionistBehavior = _OperationLogClusterReceptionist(settings: .default).behavior
 
     func test_receptionist_shouldRespondWithRegisteredRefsForKey() throws {
-        let receptionist = SystemReceptionist(ref: try system._spawn("receptionist", self.receptionistBehavior))
+        let receptionist = SystemReceptionist(ref: try system._spawn("test-receptionist", self.receptionistBehavior))
         let probe: ActorTestProbe<String> = self.testKit.makeTestProbe()
         let lookupProbe: ActorTestProbe<_Reception.Listing<_ActorRef<String>>> = self.testKit.makeTestProbe()
 
@@ -59,7 +59,7 @@ final class _ActorRefReceptionistTests: SingleClusterSystemXCTestCase {
     }
 
     func test_receptionist_shouldRespondWithEmptyRefForUnknownKey() throws {
-        let receptionist = SystemReceptionist(ref: try system._spawn("receptionist", self.receptionistBehavior))
+        let receptionist = SystemReceptionist(ref: try system._spawn("test-receptionist", self.receptionistBehavior))
         let lookupProbe: ActorTestProbe<_Reception.Listing<_ActorRef<String>>> = self.testKit.makeTestProbe()
 
         let ref: _ActorRef<String> = try system._spawn(
@@ -82,7 +82,7 @@ final class _ActorRefReceptionistTests: SingleClusterSystemXCTestCase {
     }
 
     func test_receptionist_shouldNotRegisterTheSameRefTwice() throws {
-        let receptionist = SystemReceptionist(ref: try system._spawn("receptionist", self.receptionistBehavior))
+        let receptionist = SystemReceptionist(ref: try system._spawn("test-receptionist", self.receptionistBehavior))
         let lookupProbe: ActorTestProbe<_Reception.Listing<_ActorRef<String>>> = self.testKit.makeTestProbe()
 
         let ref: _ActorRef<String> = try system._spawn(.anonymous, .receiveMessage { _ in .same })
@@ -100,7 +100,7 @@ final class _ActorRefReceptionistTests: SingleClusterSystemXCTestCase {
     }
 
     func test_receptionist_shouldRemoveAndAddNewSingletonRef() throws {
-        let receptionist = SystemReceptionist(ref: try system._spawn("receptionist", self.receptionistBehavior))
+        let receptionist = SystemReceptionist(ref: try system._spawn("test-receptionist", self.receptionistBehavior))
         let lookupProbe: ActorTestProbe<_Reception.Listing<_ActorRef<String>>> = self.testKit.makeTestProbe()
 
         let old: _ActorRef<String> = try system._spawn(
@@ -134,7 +134,7 @@ final class _ActorRefReceptionistTests: SingleClusterSystemXCTestCase {
     }
 
     func test_receptionist_shouldReplyWithRegistered() throws {
-        let receptionist = SystemReceptionist(ref: try system._spawn("receptionist", self.receptionistBehavior))
+        let receptionist = SystemReceptionist(ref: try system._spawn("test-receptionist", self.receptionistBehavior))
         let probe: ActorTestProbe<_Reception.Registered<_ActorRef<String>>> = self.testKit.makeTestProbe()
 
         let ref: _ActorRef<String> = try system._spawn(
@@ -155,7 +155,7 @@ final class _ActorRefReceptionistTests: SingleClusterSystemXCTestCase {
     }
 
     func test_receptionist_shouldUnregisterTerminatedRefs() throws {
-        let receptionist = SystemReceptionist(ref: try system._spawn("receptionist", self.receptionistBehavior))
+        let receptionist = SystemReceptionist(ref: try system._spawn("test-receptionist", self.receptionistBehavior))
         let lookupProbe: ActorTestProbe<_Reception.Listing<_ActorRef<String>>> = self.testKit.makeTestProbe()
 
         let ref: _ActorRef<String> = try system._spawn(
@@ -183,7 +183,7 @@ final class _ActorRefReceptionistTests: SingleClusterSystemXCTestCase {
     }
 
     func test_receptionist_shouldContinuouslySendUpdatesForSubscriptions() throws {
-        let receptionist = SystemReceptionist(ref: try system._spawn("receptionist", self.receptionistBehavior))
+        let receptionist = SystemReceptionist(ref: try system._spawn("test-receptionist", self.receptionistBehavior))
         let lookupProbe: ActorTestProbe<_Reception.Listing<_ActorRef<String>>> = self.testKit.makeTestProbe()
 
         let refA: _ActorRef<String> = try system._spawn(
@@ -219,7 +219,7 @@ final class _ActorRefReceptionistTests: SingleClusterSystemXCTestCase {
     // MARK: Delayed flush
 
     func test_delayedFlush_shouldEmitEvenWhenAllPeersRemoved() throws {
-        let receptionist = SystemReceptionist(ref: try system._spawn("receptionist", self.receptionistBehavior))
+        let receptionist = SystemReceptionist(ref: try system._spawn("test-receptionist", self.receptionistBehavior))
         let lookupProbe: ActorTestProbe<_Reception.Listing<_ActorRef<String>>> = self.testKit.makeTestProbe()
 
         let key = _Reception.Key(_ActorRef<String>.self, id: "test")


### PR DESCRIPTION
### Motivation:

We need to "consume" the sneaky way we sneak in the "use this ID" into `assignID`. Without this we'd assign the same ID if someone were to create a singleton DURING the init() of another singleton.

I need to work around a few aggressive assertions that are trying to prevent users doing bad stuff that we actually do want to do here, but this'll work ok.


### Modifications:

We "consume" the "props for spawn" during assignID as it should be. This works because that's code generated as first thing in every distributed actor init.


### Result:


resolves #1131
rdar://112434926

relates to rdar://112433423 which is about a language feature to enable control over this properly.

