### PR TITLE
=lifecycle missing synchronization; those methods may be invoked from outside actor

### DIFF
--- a/Sources/DistributedCluster/LifecycleMonitoring/LifecycleWatch.swift
+++ b/Sources/DistributedCluster/LifecycleMonitoring/LifecycleWatch.swift
@@ -135,10 +135,6 @@ extension LifecycleWatch {
 extension LifecycleWatch {
     /// Function invoked by the actor transport when a distributed termination is detected.
     public func _receiveActorTerminated(id: ID) async {
-        guard let watch = self.context.lifecycle else {
-            return
-        }
-
-        watch.receiveTerminated(id)
+        self.context.lifecycle?.receiveTerminated(id)
     }
 }

--- a/Sources/DistributedCluster/LifecycleMonitoring/LifecycleWatch.swift
+++ b/Sources/DistributedCluster/LifecycleMonitoring/LifecycleWatch.swift
@@ -71,7 +71,7 @@ extension LifecycleWatch {
         }
 
         watch.termination(of: watchee.id, whenTerminated: { id in
-            try? await self.terminated(actor: id)
+            await self.terminated(actor: id)
         }, file: file, line: line)
 
         return watchee

--- a/Sources/DistributedCluster/LifecycleMonitoring/LifecycleWatchContainer.swift
+++ b/Sources/DistributedCluster/LifecycleMonitoring/LifecycleWatchContainer.swift
@@ -50,7 +50,7 @@ final class LifecycleWatchContainer {
     }
 
     func clear() {
-        _lock.wait()
+        self._lock.wait()
         defer {
             _lock.signal()
         }
@@ -79,7 +79,7 @@ extension LifecycleWatchContainer {
         defer {
             self._lock.signal()
         }
-        
+
         traceLog_DeathWatch("issue watch: \(watcheeID) (from \(self.watcherID))")
 
         let watcherID: ActorID = self.watcherID


### PR DESCRIPTION
These methods may be invoked from outside the actor, so synchronize them properly as the rest of the container.

I need to review some more code for safety and we should get a tsan build going here, we missed this for quite a while huh.

rdar://112815057