### PR TITLE
Lowest address ordering fix

### DIFF
--- a/Sources/DistributedCluster/ClusterEndpoint.swift
+++ b/Sources/DistributedCluster/ClusterEndpoint.swift
@@ -73,7 +73,7 @@ extension Cluster.Endpoint: Comparable {
     // Silly but good enough comparison for deciding "who is lower node"
     // as we only use those for "tie-breakers" any ordering is fine to be honest here.
     public static func < (lhs: Cluster.Endpoint, rhs: Cluster.Endpoint) -> Bool {
-        "\(lhs)" < "\(rhs)"
+        "\(lhs.protocol)\(lhs.host)\(lhs.port)" < "\(rhs.protocol)\(rhs.host)\(rhs.port)"
     }
 
     public func hash(into hasher: inout Hasher) {

--- a/Tests/DistributedClusterTests/Cluster/LeadershipTests.swift
+++ b/Tests/DistributedClusterTests/Cluster/LeadershipTests.swift
@@ -19,9 +19,9 @@ import NIO
 import XCTest
 
 final class LeadershipTests: XCTestCase {
-    let memberA = Cluster.Member(node: Cluster.Node(endpoint: Cluster.Endpoint(systemName: "System", host: "1.1.1.1", port: 7337), nid: .random()), status: .up)
-    let memberB = Cluster.Member(node: Cluster.Node(endpoint: Cluster.Endpoint(systemName: "System", host: "2.2.2.2", port: 8228), nid: .random()), status: .up)
-    let memberC = Cluster.Member(node: Cluster.Node(endpoint: Cluster.Endpoint(systemName: "System", host: "3.3.3.3", port: 9119), nid: .random()), status: .up)
+    let memberA = Cluster.Member(node: Cluster.Node(endpoint: Cluster.Endpoint(systemName: "C", host: "1.1.1.1", port: 7337), nid: .random()), status: .up)
+    let memberB = Cluster.Member(node: Cluster.Node(endpoint: Cluster.Endpoint(systemName: "B", host: "2.2.2.2", port: 8228), nid: .random()), status: .up)
+    let memberC = Cluster.Member(node: Cluster.Node(endpoint: Cluster.Endpoint(systemName: "A", host: "3.3.3.3", port: 9119), nid: .random()), status: .up)
     let newMember = Cluster.Member(node: Cluster.Node(endpoint: Cluster.Endpoint(systemName: "System", host: "4.4.4.4", port: 1001), nid: .random()), status: .up)
 
     let fakeContext = LeaderElectionContext(log: NoopLogger.make(), eventLoop: EmbeddedEventLoop())


### PR DESCRIPTION
### Motivation:

Currently there is a bug in lowest address ordering where it will sort nodes and choose lowest not by address, but by alphabetical order (or guess unicode order) of systemName node's variables.

### Modifications:

Changed implementation of Comparable for ClusterEndpoint and tweaked tests a bit.

### Result:

- Resolves #1141 
