### PR TITLE
Remove __secretlyKnownToBeLocal, adopt whenLocal

### DIFF
--- a/Sources/DistributedCluster/Cluster/Downing/DowningStrategy.swift
+++ b/Sources/DistributedCluster/Cluster/Downing/DowningStrategy.swift
@@ -93,9 +93,9 @@ internal distributed actor DowningStrategyShell {
         self.strategy = strategy
         self.actorSystem = system
         self.eventsListeningTask = Task { [weak self] in
-            try await self?.whenLocal { __secretlyKnownToBeLocal in
+            try await self?.whenLocal { myself in
                 for await event in system.cluster.events {
-                    try __secretlyKnownToBeLocal.receiveClusterEvent(event)
+                    try myself.receiveClusterEvent(event)
                 }
             }
         }
@@ -120,13 +120,13 @@ internal distributed actor DowningStrategyShell {
         case .startTimer(let member, let delay):
             self.log.trace("Start timer for member: \(member), delay: \(delay)")
             self.memberTimerTasks[member] = Task { [weak self] in
-                try await self?.whenLocal { __secretlyKnownToBeLocal in
-                    defer { __secretlyKnownToBeLocal.memberTimerTasks.removeValue(forKey: member) }
+                try await self?.whenLocal { myself in
+                    defer { myself.memberTimerTasks.removeValue(forKey: member) }
                     
                     try await Task.sleep(until: .now + delay, clock: .continuous)
                     
                     guard !Task.isCancelled else { return }
-                    __secretlyKnownToBeLocal.onTimeout(member: member)
+                    myself.onTimeout(member: member)
                 }
             }
         case .cancelTimer(let member):

--- a/Sources/DistributedCluster/Cluster/Downing/DowningStrategy.swift
+++ b/Sources/DistributedCluster/Cluster/Downing/DowningStrategy.swift
@@ -122,9 +122,9 @@ internal distributed actor DowningStrategyShell {
             self.memberTimerTasks[member] = Task { [weak self] in
                 try await self?.whenLocal { myself in
                     defer { myself.memberTimerTasks.removeValue(forKey: member) }
-                    
+
                     try await Task.sleep(until: .now + delay, clock: .continuous)
-                    
+
                     guard !Task.isCancelled else { return }
                     myself.onTimeout(member: member)
                 }

--- a/Sources/DistributedCluster/Cluster/Reception/OperationLogDistributedReceptionist.swift
+++ b/Sources/DistributedCluster/Cluster/Reception/OperationLogDistributedReceptionist.swift
@@ -485,12 +485,12 @@ extension OpLogDistributedReceptionist {
         let flushDelay = actorSystem.settings.receptionist.listingFlushDelay
         self.log.debug("schedule delayed flush")
         self.flushTimerTasks[timerTaskKey] = Task { [weak self] in
-          try await self?.whenLocal { myself in
-            defer { myself.flushTimerTasks.removeValue(forKey: timerTaskKey) }
-              
-            try await Task.sleep(until: .now + flushDelay, clock: .continuous)
-            myself.onDelayedListingFlushTick(key: key)
-          }
+            try await self?.whenLocal { myself in
+                defer { myself.flushTimerTasks.removeValue(forKey: timerTaskKey) }
+
+                try await Task.sleep(until: .now + flushDelay, clock: .continuous)
+                myself.onDelayedListingFlushTick(key: key)
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation:

Calling `__secretlyKnownToBeLocal` somehow doesn't guarantee isolation and crashes sometimes (e.g. #1140). Not sure what exact issue though, but anyway it's better to call `whenLocal`.

### Modifications:

Moved from calling `__secretlyKnownToBeLocal` to `whenLocal` where possible.

### Result:

- Resolves #1140
