### PR TITLE
Added hook to lifecycle events

### DIFF
--- a/Sources/DistributedCluster/ClusterSystem.swift
+++ b/Sources/DistributedCluster/ClusterSystem.swift
@@ -1049,6 +1049,10 @@ extension ClusterSystem {
         if let wellKnownName = actor.id.metadata.wellKnown {
             self._managedWellKnownDistributedActors[wellKnownName] = actor
         }
+      
+        for hook in self.settings.plugins.actorLifecycleHooks {
+            hook.actorReady(actor)
+        }
     }
 
     /// Advertise to the cluster system that a "well known" distributed actor has become ready.
@@ -1090,6 +1094,10 @@ extension ClusterSystem {
             _ = self._managedDistributedActors.removeActor(identifiedBy: id)
 
             // Well-known actors are held strongly and should be released using `releaseWellKnownActorID`
+        }
+        
+        for hook in self.settings.plugins.actorLifecycleHooks {
+            hook.resignID(id)
         }
     }
 

--- a/Sources/DistributedCluster/Plugins/ClusterSystem+Plugins.swift
+++ b/Sources/DistributedCluster/Plugins/ClusterSystem+Plugins.swift
@@ -114,3 +114,9 @@ internal struct AnyPluginKey: Hashable, CustomStringConvertible {
         }
     }
 }
+
+/// Way to hook into ClusterSystem's actor lifecycle events, specifically to `ready` and `resign`.
+public protocol PluginActorLifecycleHook {
+    func actorReady<Act: DistributedActor>(_ actor: Act) where Act: DistributedActor, Act.ID == ClusterSystem.ActorID
+    func resignID(_ id: ClusterSystem.ActorID)
+}

--- a/Sources/DistributedCluster/Plugins/ClusterSystemSettings+Plugins.swift
+++ b/Sources/DistributedCluster/Plugins/ClusterSystemSettings+Plugins.swift
@@ -21,6 +21,7 @@ public struct PluginsSettings {
     }
 
     internal var plugins: [BoxedPlugin] = []
+    internal var actorLifecycleHooks: [PluginActorLifecycleHook] = []
 
     public init() {}
 
@@ -72,7 +73,9 @@ extension PluginsSettings {
             !self.isInstalled(plugin: plugin),
             "Attempted to add plugin \(plugin.key) but key already used! Plugin [\(plugin)], installed plugins: \(self.plugins)."
         )
-
+        if let plugin = plugin as? PluginActorLifecycleHook {
+            self.actorLifecycleHooks.append(plugin)
+        }
         return self.plugins.append(BoxedPlugin(plugin))
     }
 

--- a/Tests/DistributedClusterTests/Plugins/ClusterSingleton/ClusterSingletonPluginTests.swift
+++ b/Tests/DistributedClusterTests/Plugins/ClusterSingleton/ClusterSingletonPluginTests.swift
@@ -59,6 +59,48 @@ final class ClusterSingletonPluginTests: SingleClusterSystemXCTestCase {
         // if this were true we would have crashed by a duplicate name already, but let's make sure:
         singletonID.shouldNotEqual(greeterID)
     }
+    
+    func test_plugin_hooks() async throws {
+        let actorId = "actorHookId"
+        let hookFulfillment = self.expectation(description: "actor-hook")
+        let plugin = TestClusterHookPlugin { actor in
+            /// There are multiple internal actors fired, we only checking for `ActorWithId`
+            guard let actor = actor as? ActorWithId else { return }
+            let id = try? await actor.getId()
+            XCTAssertEqual(id, actorId, "Expected \(actorId) as an id")
+            hookFulfillment.fulfill()
+        }
+        let testNode = await setUpNode("test-hook") { settings in
+            settings.enabled = false
+            settings += plugin
+        }
+
+        let _ = ActorWithId(actorSystem: testNode, id: actorId)
+        await fulfillment(of: [hookFulfillment])
+    }
+    
+    actor TestClusterHookPlugin: _Plugin, PluginActorLifecycleHook {
+        nonisolated var key: Key { "$testClusterHook" }
+        
+        let onActorReady: (any DistributedActor) async throws -> ()
+        
+        init(
+            onActorReady: @escaping (any DistributedActor) async throws -> Void
+        ) {
+            self.onActorReady = onActorReady
+        }
+        
+        nonisolated func actorReady<Act>(_ actor: Act) where Act: DistributedActor, Act.ID == DistributedCluster.ClusterSystem.ActorID {
+            Task { try await self.onActorReady(actor) }
+        }
+        
+        nonisolated func resignID(_ id: DistributedCluster.ClusterSystem.ActorID) {
+            
+        }
+        
+        func start(_ system: ClusterSystem) async throws {}
+        func stop(_ system: ClusterSystem) async {}
+    }
 
     distributed actor SingletonWhichCreatesDistributedActorDuringInit: ClusterSingleton {
         typealias ActorSystem = ClusterSystem
@@ -87,6 +129,22 @@ final class ClusterSingletonPluginTests: SingleClusterSystemXCTestCase {
 
         distributed func greet() {
             print("Hello!")
+        }
+    }
+    
+    distributed actor ActorWithId {
+        let customId: String
+        
+        init(
+            actorSystem: ActorSystem,
+            id: String
+        ) {
+            self.actorSystem = actorSystem
+            self.customId = id
+        }
+        
+        distributed func getId() -> String { 
+            self.customId
         }
     }
 }


### PR DESCRIPTION
Ability to listen to actors lifecycles in a plugin.

### Motivation:

Plugins give an option to extend system with some logic. Problem is sometimes you need to hook into actor's creation/deletion, which currently is impossible. As an example—for actor recovery we need to restore state when it's created and ready for cluster system, which can be done by some potential `EventSourcingJournal`.

By adding simple hook protocol we can enable this.

### Modifications:

- `PluginActorLifecycleHook` protocol
- additional `actorLifecycleHooks` in plugins settings
- inside ClusterSystem's `actorReady` and `resignID` are called for each _hookable_ plugin added to the system.