### PR TITLE
Fixed a crash on Swift 6.0+ where Integer deserialization was assuming aligned memory

### DIFF
--- a/Sources/DistributedCluster/Serialization/Serialization+PrimitiveSerializers.swift
+++ b/Sources/DistributedCluster/Serialization/Serialization+PrimitiveSerializers.swift
@@ -73,7 +73,7 @@ internal class IntegerSerializer<Number: FixedWidthInteger>: Serializer<Number> 
     override func deserialize(from buffer: Serialization.Buffer) throws -> Number {
         switch buffer {
         case .data(let data):
-            return Number(bigEndian: data.withUnsafeBytes { $0.load(as: Number.self) })
+            return Number(bigEndian: data.withUnsafeBytes { $0.loadUnaligned(as: Number.self) })
         case .nioByteBuffer(let buffer):
             guard let i = buffer.getInteger(at: 0, endianness: .big, as: Number.self) else {
                 throw SerializationError(.notAbleToDeserialize(hint: "\(buffer) as \(Number.self)"))


### PR DESCRIPTION
### Motivation:

The integer deserializer was assuming that the input raw memory was correctly aligned for the integer type to be deserialized. In the test that was true on some platforms, but not others.

This caused a crash in the unit test.

### Modifications:

Use `loadUnaligned` instead of `load` when loading integers.

### Result:

Fixes https://github.com/apple/swift-distributed-actors/issues/1179.
