### PR TITLE
Enable macOS CI on pull requests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -42,3 +42,7 @@ jobs:
     uses: apple/swift-nio/.github/workflows/cxx_interop.yml@main
     with:
       linux_5_9_enabled: false
+
+  macos-tests:
+    with:
+      runner_pool: general


### PR DESCRIPTION
Motivation:

* Improve test coverage

Modifications:

Enable macOS CI to be run on pull request commits and make the use of the nightly runner pool for main.yml jobs explicit.

Result:

Improved test coverage.
