### PR TITLE
Switch integration tests to newer Swift test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,21 +17,54 @@ jobs:
       linux_nightly_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 
+  construct-integration-tests-matrix:
+    name: Construct integration matrix
+    runs-on: ubuntu-latest
+    outputs:
+      integration-tests-matrix: '${{ steps.generate-matrix.outputs.integration-tests-matrix }}'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - id: generate-matrix
+        run: echo "integration-tests-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        env:
+          MATRIX_LINUX_COMMAND: swift package --disable-sandbox multi-node test
+          MATRIX_LINUX_5_9_ENABLED: false
+
   integration-tests:
     name: Integration tests
-    uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+    needs: construct-integration-tests-matrix
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
     with:
       name: "Integration tests"
-      matrix_linux_5_9_enabled: false
-      matrix_linux_command: "swift package --disable-sandbox multi-node test"
+      matrix_string: '${{ needs.construct-integration-tests-matrix.outputs.integration-tests-matrix }}'
 
-  sample-philosophers:
+  construct-dining-philosophers-matrix:
+    name: Construct dining philosophers matrix
+    runs-on: ubuntu-latest
+    outputs:
+      dining-philosophers-matrix: '${{ steps.generate-matrix.outputs.dining-philosophers-matrix }}'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - id: generate-matrix
+        run: echo "dining-philosophers-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        env:
+          MATRIX_LINUX_SETUP_COMMAND: apt-get update -y && apt-get install -yq jq && git config --global --add safe.directory /swift-openapi-runtime
+          MATRIX_LINUX_COMMAND: swift run --package-path Samples SampleDiningPhilosophers
+          MATRIX_LINUX_5_9_ENABLED: false
+
+  dining-philosophers:
     name: Sample dining philosophers
-    uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+    needs: construct-dining-philosophers-matrix
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
     with:
       name: "Sample dining philosophers"
-      matrix_linux_5_9_enabled: false
-      matrix_linux_command: "swift run --package-path Samples SampleDiningPhilosophers"
+      matrix_string: '${{ needs.construct-dining-philosophers-matrix.outputs.dining-philosophers-matrix }}'
 
   cxx-interop:
     name: Cxx interop

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,21 +21,54 @@ jobs:
       linux_nightly_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 
+  construct-integration-tests-matrix:
+    name: Construct integration matrix
+    runs-on: ubuntu-latest
+    outputs:
+      integration-tests-matrix: '${{ steps.generate-matrix.outputs.integration-tests-matrix }}'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - id: generate-matrix
+        run: echo "integration-tests-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        env:
+          MATRIX_LINUX_COMMAND: swift package --disable-sandbox multi-node test
+          MATRIX_LINUX_5_9_ENABLED: false
+
   integration-tests:
     name: Integration tests
-    uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+    needs: construct-integration-tests-matrix
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
     with:
       name: "Integration tests"
-      matrix_linux_5_9_enabled: false
-      matrix_linux_command: "swift package --disable-sandbox multi-node test"
+      matrix_string: '${{ needs.construct-integration-tests-matrix.outputs.integration-tests-matrix }}'
 
-  sample-philosophers:
+  construct-dining-philosophers-matrix:
+    name: Construct dining philosophers matrix
+    runs-on: ubuntu-latest
+    outputs:
+      dining-philosophers-matrix: '${{ steps.generate-matrix.outputs.dining-philosophers-matrix }}'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - id: generate-matrix
+        run: echo "dining-philosophers-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        env:
+          MATRIX_LINUX_SETUP_COMMAND: apt-get update -y && apt-get install -yq jq && git config --global --add safe.directory /swift-openapi-runtime
+          MATRIX_LINUX_COMMAND: swift run --package-path Samples SampleDiningPhilosophers
+          MATRIX_LINUX_5_9_ENABLED: false
+
+  dining-philosophers:
     name: Sample dining philosophers
-    uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+    needs: construct-dining-philosophers-matrix
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
     with:
       name: "Sample dining philosophers"
-      matrix_linux_5_9_enabled: false
-      matrix_linux_command: "swift run --package-path Samples SampleDiningPhilosophers"
+      matrix_string: '${{ needs.construct-dining-philosophers-matrix.outputs.dining-philosophers-matrix }}'
 
   cxx-interop:
     name: Cxx interop


### PR DESCRIPTION
### Motivation:

To remove all uses of the older workflow so it can be removed to simplify the workflows.

### Modifications:

* Switch integration tests an the dining philosophers example to use the newer Swift test matrix workflow, `swift_test_matrix.yml`

### Result:

This should make no difference to the running of integration tests.