### PR TITLE
Fix the Samples project so that it compiles and runs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can refer to the `Samples/` directory to view a number of more realistic sam
 
 The most "classical" example of distributed actors is the [`SampleDiningPhilosophers`](Samples/Sources/SampleDiningPhilosophers/DistributedDiningPhilosophers.swift).
 
-You can run it all in a single node (`run --package-path Samples/ SampleDiningPhilosophers`), or in 3 cluster nodes hosted on the same physical machine: `run --package-path Samples/ SampleDiningPhilosophers distributed`. Notice how one does not need to change implementation of the distributed actors to run them in either "local" or "distributed" mode.
+You can run it all in a single node (`swift run --package-path Samples/ SampleDiningPhilosophers`), or in 3 cluster nodes hosted on the same physical machine: `swift run --package-path Samples/ SampleDiningPhilosophers distributed`. Notice how one does not need to change implementation of the distributed actors to run them in either "local" or "distributed" mode.
 
 ## Documentation
 

--- a/Samples/Package.swift
+++ b/Samples/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -51,7 +51,7 @@ let package = Package(
     platforms: [
         // we require the 'distributed actor' language and runtime feature:
         .iOS(.v16),
-        .macOS(.v13),
+        .macOS(.v14),
         .tvOS(.v16),
         .watchOS(.v9),
     ],


### PR DESCRIPTION
### Motivation:

Currently, the sample project doesn't compile because `swift-cluster-membership` requires macos 14.0.

```console
error: the executable 'SampleDiningPhilosophers' requires macos 13.0, but depends on the product 'DistributedCluster' which requires macos 14.0; consider changing the executable 'SampleDiningPhilosophers' to require macos 14.0 or later, or the product 'DistributedCluster' to require macos 13.0 or earlier.
```

### Modifications:

Update the `Package.swift` file in `/Samples` to require macos 14 and bump to Swift 5.9 to support running in distributed mode.

Updated README to include `swift` in the run commands.

### Result:

`Samples` project now compiles and runs.
