### PR TITLE
Update expected memory size in actor memory tests

### DIFF
--- a/Tests/DistributedClusterTests/Metrics/ActorMemoryTests.swift
+++ b/Tests/DistributedClusterTests/Metrics/ActorMemoryTests.swift
@@ -24,9 +24,9 @@ final class ActorMemoryTests: XCTestCase {
     // TODO: we could use malloc hooking to get an idea about this in allocation tests; more interesting since over time as well based on ops
 
     func test_osx_actorShell_instanceSize() {
-        #if os(OSX)
-        class_getInstanceSize(_ActorShell<Int>.self).shouldEqual(624)
-        class_getInstanceSize(_ActorShell<String>.self).shouldEqual(624)
+        #if os(macOS)
+        class_getInstanceSize(_ActorShell<Int>.self).shouldEqual(576)
+        class_getInstanceSize(_ActorShell<String>.self).shouldEqual(576)
         #else
         print("Skipping test_osx_actorShell_instanceSize as requires Objective-C runtime")
         #endif


### PR DESCRIPTION
### Motivation:

There's an open PR to add macOS CI and one of the tests is failing because there's a hardcoded expected size of a class instance, which isn't using the correct value. It seems that, since this test was written, the class instance uses less memory. This is reproducible locally. Since this isn't a regression, we should just use the newer (better) value as the expected.

### Modifications:

Update value used in test.

### Result:

Tests now pass on macOS.
