### PR TITLE
Fix hang using multi-node package plugin on Swift 6+

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -93,7 +93,7 @@ var targets: [PackageDescription.Target] = [
             // permissions: needs full network access
         ),
         dependencies: [
-            "MultiNodeTestKitRunner",
+            "MultiNodeTestKitRunner"
         ]
     ),
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -92,7 +92,9 @@ var targets: [PackageDescription.Target] = [
             intent: .custom(verb: "multi-node", description: "Run MultiNodeTestKit based tests across multiple processes or physical compute nodes")
             // permissions: needs full network access
         ),
-        dependencies: []
+        dependencies: [
+            "MultiNodeTestKitRunner",
+        ]
     ),
     .target(
         name: "MultiNodeTestKit",

--- a/Plugins/MultiNodeTestPlugin/plugin.swift
+++ b/Plugins/MultiNodeTestPlugin/plugin.swift
@@ -39,8 +39,11 @@ final class MultiNodeTestPlugin: CommandPlugin {
             }
         }
 
+        // Find the executable dependency frome the plugin context.
+        let tool = try context.tool(named: "MultiNodeTestKitRunner")
+
         // Terminate all previous runners
-        Process.killall(name: "MultiNodeTestKitRunner")
+        Process.killall(name: tool.name)
 
         switch self.buildConfiguration {
         case .debug:
@@ -71,14 +74,14 @@ final class MultiNodeTestPlugin: CommandPlugin {
         log("Detected multi-node test runner: \(multiNodeRunner.path.lastComponent)")
 
         let process = Process()
-        process.binaryPath = "/usr/bin/swift"
-        process.arguments = ["run", "MultiNodeTestKitRunner"]
+        process.binaryPath = tool.path.string
+        process.arguments = []
         for arg in arguments {
             process.arguments?.append(arg)
         }
 
         do {
-            log("> swift \(process.arguments?.joined(separator: " ") ?? "")")
+            log("> \(tool.name) \(process.arguments?.joined(separator: " ") ?? "")")
             try process.runProcess()
             process.waitUntilExit()
         } catch {
@@ -144,7 +147,7 @@ extension Process {
     static func killall(name: String) {
         let killAllRunners = Process()
         killAllRunners.binaryPath = "/usr/bin/killall"
-        killAllRunners.arguments = ["-9", "MultiNodeTestKitRunner"]
+        killAllRunners.arguments = ["-9", name]
         try? killAllRunners.runProcess()
         killAllRunners.waitUntilExit()
     }


### PR DESCRIPTION
### Motivation:

The integration tests for Swift 6.0 and 6.1 are hanging. They are passing on Swift 5.10. This is because SwiftPM started taking a lock over the package and cannot be run concurrently on the same package.

This is causing hangs in the integration test because it calls the `multi-node` package plugin which is running the `MultiNodeTestKitRunner` using `swift run MultiNodeTestKitRunner`.

This isn't the supported way for Swift package plugins to use executables from the package, which should instead be looked up from the context passed into the plugin.

### Modifications:

Use the package plugin context to find the executable dependency used by the multi-node plugin.

### Result:

Integration tests no longer hang on Swift 6.0 and 6.1.
