### PR TITLE
Fix compilation on platforms without Foundation.Process

### DIFF
--- a/Sources/MultiNodeTestKitRunner/Process+Extensions.swift
+++ b/Sources/MultiNodeTestKitRunner/Process+Extensions.swift
@@ -18,9 +18,12 @@ import NIOCore
 import NIOPosix
 
 import class Foundation.FileHandle
+#if canImport(Foundation.Process)
 import class Foundation.Process
+#endif
 import struct Foundation.URL
 
+#if canImport(Foundation.Process)
 // Compatible with Swift on all macOS versions as well as Linux
 extension Process {
     var binaryPath: String? {
@@ -48,3 +51,4 @@ extension Process {
         }
     }
 }
+#endif

--- a/Sources/MultiNodeTestKitRunner/Terminal+Rainbow.swift
+++ b/Sources/MultiNodeTestKitRunner/Terminal+Rainbow.swift
@@ -21,7 +21,6 @@ import OrderedCollections
 
 import struct Foundation.Date
 import class Foundation.FileHandle
-import class Foundation.Process
 import struct Foundation.URL
 
 enum Rainbow: String {

--- a/Sources/MultiNodeTestKitRunner/boot+MultiNodeTestKitRunner.swift
+++ b/Sources/MultiNodeTestKitRunner/boot+MultiNodeTestKitRunner.swift
@@ -21,13 +21,20 @@ import OrderedCollections
 
 import struct Foundation.Date
 import class Foundation.FileHandle
+#if canImport(Foundation.Process)
 import class Foundation.Process
+#endif
 import struct Foundation.URL
 
 @main
 struct MultiNodeTestKitRunnerBoot {
     static func main() async throws {
+        #if !canImport(Foundation.Process)
+        print("Platform does not support multi-node tests")
+        throw ExitCode.failure
+        #else
         try await Self().run()
+        #endif
     }
 
     struct TestFilter {


### PR DESCRIPTION
### Motivation:

There's an open PR to add CI for Apple platforms. This is currently failing since it tries to build for all Apple platforms, not just macOS. This is because there are targets that provide support for testing that rely on `Foundation.process`, which is unavailable on non-macOS Apple platforms.  

### Modifications:

Guard the use of `Foundation.Process` with an `#if canImport`. 

### Result:

Package builds for non-macOS Apple platforms: iOS, tvOS, watchOS, etc.