### PR TITLE
Disable api breakage check

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,6 +10,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
     with:
       license_header_check_project_name: "Swift Distributed Actors"
+      api_breakage_check_enabled: false
 
   unit-tests:
     name: Unit tests


### PR DESCRIPTION
https://github.com/apple/swift-distributed-actors/pull/1165#issuecomment-2844558188
We can disable API breakage check for now as we're pre-1.0