### PR TITLE
Make CDistributedActorsMailbox compatible with C++ interop

### DIFF
--- a/Sources/CDistributedActorsMailbox/include/backtrace_support.h
+++ b/Sources/CDistributedActorsMailbox/include/backtrace_support.h
@@ -15,6 +15,10 @@
 #ifndef SACT_BACKTRACE_SUPPORT_H
 #define SACT_BACKTRACE_SUPPORT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Prints a stack backtrace directly to `stderr`.
  * Use only internally, mostly for 
@@ -25,5 +29,9 @@
 void sact_dump_backtrace(void);
 
 int sact_get_backtrace(char*** strs);
+
+#if defined(__cplusplus)
+}  // extern "C"
+#endif
 
 #endif

--- a/Sources/CDistributedActorsMailbox/include/c_mpsc_linked_queue.h
+++ b/Sources/CDistributedActorsMailbox/include/c_mpsc_linked_queue.h
@@ -18,6 +18,10 @@
 #include <stdatomic.h>
 #include <stdlib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct Node {
     void* item;
     _Atomic (struct Node*) next;
@@ -38,5 +42,9 @@ void c_sact_mpsc_linked_queue_destroy(CSActMPSCLinkedQueue* q);
 void c_sact_mpsc_linked_queue_enqueue(CSActMPSCLinkedQueue* q, void* item);
 
 void* c_sact_mpsc_linked_queue_dequeue(CSActMPSCLinkedQueue* q);
+
+#if defined(__cplusplus)
+}  // extern "C"
+#endif
 
 #endif /* CMPSCLinkedQueue_h */


### PR DESCRIPTION
### Motivation:

This fixes linker errors such as
```
"c_sact_mpsc_linked_queue_create()", referenced from:
      DistributedCluster.MPSCLinkedQueue.init() -> DistributedCluster.MPSCLinkedQueue<A> in MPSCLinkedQueue.swift.o
   NOTE: found '_c_sact_mpsc_linked_queue_create' in c_mpsc_linked_queue.c.o, declaration possibly missing 'extern "C"'
```
when building with Swift/C++ interoperability enabled.

### Modifications:

This wraps the C/C++ declarations in a couple headers in `extern "C" { ... }` blocks.

### Result:

The project builds with Swift/C++ interoperability enabled.