### PR TITLE
Mark configuration setting closure as sending

### DIFF
--- a/Samples/Package.swift
+++ b/Samples/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -26,6 +26,9 @@ var targets: [PackageDescription.Target] = [
         exclude: [
             "dining-philosopher-fsm.graffle",
             "dining-philosopher-fsm.svg",
+        ],
+        swiftSettings: [
+            .swiftLanguageMode(.v5)
         ]
     ),
 
@@ -50,10 +53,10 @@ let package = Package(
     name: "swift-distributed-actors-samples",
     platforms: [
         // we require the 'distributed actor' language and runtime feature:
-        .iOS(.v16),
-        .macOS(.v14),
-        .tvOS(.v16),
-        .watchOS(.v9),
+        .iOS(.v17),
+        .macOS(.v15),
+        .tvOS(.v17),
+        .watchOS(.v10),
     ],
     products: [
         // ---  samples ---

--- a/Samples/Sources/SampleDiningPhilosophers/SamplePrettyLogHandler.swift
+++ b/Samples/Sources/SampleDiningPhilosophers/SamplePrettyLogHandler.swift
@@ -15,6 +15,8 @@
 import Distributed
 import Logging
 
+import struct Foundation.Date
+
 @testable import DistributedCluster
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
@@ -129,18 +131,7 @@ struct SamplePrettyLogHandler: LogHandler {
     }
 
     private func timestamp() -> String {
-        var buffer = [Int8](repeating: 0, count: 255)
-        var timestamp = time(nil)
-        let localTime = localtime(&timestamp)
-        // This format is pleasant to read in local sample apps:
-        strftime(&buffer, buffer.count, "%H:%M:%S", localTime)
-        // The usual full format is:
-        // strftime(&buffer, buffer.count, "%Y-%m-%dT%H:%M:%S%z", localTime)
-        return buffer.withUnsafeBufferPointer {
-            $0.withMemoryRebound(to: CChar.self) {
-                String(cString: $0.baseAddress!)
-            }
-        }
+        Date.now.formatted(date: .omitted, time: .standard)
     }
 }
 

--- a/Sources/DistributedCluster/Behaviors.swift
+++ b/Sources/DistributedCluster/Behaviors.swift
@@ -131,10 +131,11 @@ extension _Behavior {
     func receiveSignalAsync(
         context: _ActorContext<Message>,
         signal: _Signal,
-        handleSignal: @escaping @Sendable (
-            _ActorContext<Message>,
-            _Signal
-        ) async throws -> _Behavior<Message>
+        handleSignal:
+            @escaping @Sendable (
+                _ActorContext<Message>,
+                _Signal
+            ) async throws -> _Behavior<Message>
     ) -> _Behavior<Message> {
         .setup { context in
             receiveSignalAsync0(handleSignal, context: context, signal: signal)

--- a/Sources/DistributedCluster/ClusterSystem+Clusterd.swift
+++ b/Sources/DistributedCluster/ClusterSystem+Clusterd.swift
@@ -23,7 +23,7 @@ import Logging
 import NIO
 
 extension ClusterSystem {
-    public static func startClusterDaemon(configuredWith configureSettings: (inout ClusterSystemSettings) -> Void = { _ in () }) async -> ClusterDaemon {
+    public static func startClusterDaemon(configuredWith configureSettings: sending (inout ClusterSystemSettings) -> Void = { _ in () }) async -> ClusterDaemon {
         let system = await ClusterSystem("clusterd") { settings in
             settings.endpoint = ClusterDaemon.defaultEndpoint
             configureSettings(&settings)

--- a/Sources/DistributedCluster/ClusterSystem.swift
+++ b/Sources/DistributedCluster/ClusterSystem.swift
@@ -209,7 +209,7 @@ public class ClusterSystem: DistributedActorSystem, @unchecked Sendable {
     /// The name is useful for debugging cross system communication.
     ///
     /// - Faults: when configuration closure performs very illegal action, e.g. reusing a serializer identifier
-    public convenience init(_ name: String, configuredWith configureSettings: (inout ClusterSystemSettings) -> Void = { _ in () }) async {
+    public convenience init(_ name: String, configuredWith configureSettings: sending (inout ClusterSystemSettings) -> Void = { _ in () }) async {
         var settings = ClusterSystemSettings(name: name)
         configureSettings(&settings)
 


### PR DESCRIPTION
### Motivation:

Configuring cluster system on main actor (whoever needs this) using configuration closure init leads to compiler error `Sending value of non-Sendable type '(inout ClusterSystemSettings) -> Void' risks causing data races`.

### Modifications:

As library already been updated to Swift 6 and ClusterSystemSettings is not used outside configuration closure — feels like marking closure as **sending** is more suitable than using **Sendable** conformance.

### Result:

- Resolves [#1223](https://github.com/apple/swift-distributed-actors/issues/1223)

### Additional information

There are other same type closures in the system, but as they're not exposed to outside world — will be fixed [during refactoring](https://github.com/apple/swift-distributed-actors/issues/1215).


